### PR TITLE
GTPS-64 platforms are not retrived from Wikidata when platforms are independent of the publication date

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,8 +6,6 @@ from game_manager import resolve_game_entry, _add_new_game_to_db
 import os
 
 
-
-
 async def main():
     # Initialize `game_db`
     await create_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)


### PR DESCRIPTION
Resolution Details:

it’s modified to abort when IntegrityError occurs due to the fact that a game was searched for in Wikidata while it’s already present in the gameDB.

Updated the order of getting platform data(first from publication date node then platform node)

BIND and COALESCE were used to prioritize the platform data from publication date node.

Updated the gameDB