### PR TITLE
GTPS-65 correct combinations of platforms and release dates are displ…

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ async def main():
     # Initialize `game_db`
     await create_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
     db_connection_pool = await init_pool(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db')
-    await resolve_game_entry('doom the dark ages', db_connection_pool)
+    await resolve_game_entry('Spider-Man Miles Morale', db_connection_pool)
 
     # The last to step before closing the app
     db_connection_pool.close()


### PR DESCRIPTION
Update:

It’s turned out that providing the fastest date is the good solution for this. The real issue is that wrong combinations of platforms and release dates are displayed due to technical issues. So the AC has been modified to show correct combinations. However, still there is an issue left. In some cases, there are multiple release dates with various reasons. For example, Spider-Man: Miles Morales has 4 dates, 2 of which are for PS5. This is because in North America, PS5 was released earlier than other the other regions. I have not decided how to deal with this. The moment that these different dates are to be shown is the game is not present in gameDB. If the game is already present, there will be only one value(maybe users would request correction). Let’s leave it this way and deal with it later

Resolution Details:

the query to Wikidata has been updated to filter out cases whose publication region is not worldwide or North America