### PR TITLE
Gtps 46 implement searching for parent games for dlc

### DIFF
--- a/DB/game_db_schema.sql
+++ b/DB/game_db_schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS game_table (
     aliases VARCHAR(1024),
 	wikidata_code VARCHAR(100) UNIQUE,
     is_DLC BOOLEAN,
-    parent VARCHAR(255) NOT NULL,
+    parent_id VARCHAR(255),
     genres VARCHAR(1024),
     developers VARCHAR(255),
     publishers VARCHAR(255),
@@ -12,7 +12,8 @@ CREATE TABLE IF NOT EXISTS game_table (
     meta_critic_score INT UNSIGNED,
     meta_user_score FLOAT UNSIGNED,
 	open_critic_score INT UNSIGNED,
-    open_user_score FLOAT UNSIGNED
+    open_user_score FLOAT UNSIGNED,
+    FULLTEXT(title, aliases)
 );
 
 CREATE TABLE IF NOT EXISTS date_platform_table (

--- a/DB/game_db_schema.sql
+++ b/DB/game_db_schema.sql
@@ -1,14 +1,11 @@
 CREATE TABLE IF NOT EXISTS game_table (
-	id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+	game_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(255) NOT NULL,
-    alias VARCHAR(1024),
+    aliases VARCHAR(1024),
 	wikidata_code VARCHAR(100) UNIQUE,
     genres VARCHAR(1024),
     developers VARCHAR(255),
     publishers VARCHAR(255),
-    release_date DATE,
-    released BOOLEAN,
-    platforms VARCHAR(255),
     pro_enhanced BOOLEAN,
     meta_critic_score INT UNSIGNED,
     meta_user_score FLOAT UNSIGNED,
@@ -16,4 +13,14 @@ CREATE TABLE IF NOT EXISTS game_table (
     open_user_score FLOAT UNSIGNED,
     my_score INT UNSIGNED,
     manually_created BOOLEAN
+);
+
+CREATE TABLE IF NOT EXISTS date_platform_table (
+	release_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    game_id INT NOT NULL,
+	release_date DATE,
+    released BOOLEAN,
+    platforms VARCHAR(255),
+    regions VARCHAR(255),
+    FOREIGN KEY (game_id) REFERENCES game_table(game_id)
 );

--- a/DB/game_db_schema.sql
+++ b/DB/game_db_schema.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS game_table (
 	id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(255) NOT NULL,
+    alias VARCHAR(1024),
 	wikidata_code VARCHAR(100) UNIQUE,
     genres VARCHAR(1024),
     developers VARCHAR(255),

--- a/DB/game_db_schema.sql
+++ b/DB/game_db_schema.sql
@@ -11,8 +11,7 @@ CREATE TABLE IF NOT EXISTS game_table (
     meta_user_score FLOAT UNSIGNED,
 	open_critic_score INT UNSIGNED,
     open_user_score FLOAT UNSIGNED,
-    my_score INT UNSIGNED,
-    manually_created BOOLEAN
+    my_score INT UNSIGNED
 );
 
 CREATE TABLE IF NOT EXISTS date_platform_table (

--- a/DB/game_db_schema.sql
+++ b/DB/game_db_schema.sql
@@ -3,6 +3,8 @@ CREATE TABLE IF NOT EXISTS game_table (
     title VARCHAR(255) NOT NULL,
     aliases VARCHAR(1024),
 	wikidata_code VARCHAR(100) UNIQUE,
+    is_DLC BOOLEAN,
+    parent VARCHAR(255) NOT NULL,
     genres VARCHAR(1024),
     developers VARCHAR(255),
     publishers VARCHAR(255),
@@ -10,8 +12,7 @@ CREATE TABLE IF NOT EXISTS game_table (
     meta_critic_score INT UNSIGNED,
     meta_user_score FLOAT UNSIGNED,
 	open_critic_score INT UNSIGNED,
-    open_user_score FLOAT UNSIGNED,
-    my_score INT UNSIGNED
+    open_user_score FLOAT UNSIGNED
 );
 
 CREATE TABLE IF NOT EXISTS date_platform_table (

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 import asyncio
 import argparse
 from db_manager import create_db, init_pool, local_db_host, local_db_passwd, local_db_port, local_db_user, game_db_schema_path
-from game_manager import resolve_game_entry, _add_new_game_to_db
+from game_manager import resolve_game_entry
 import os
 
 
@@ -10,7 +10,7 @@ async def main():
     # Initialize `game_db`
     await create_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
     db_connection_pool = await init_pool(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db')
-    await resolve_game_entry('god of war', db_connection_pool)
+    await resolve_game_entry('cyberpunk 2077', db_connection_pool)
 
     # The last to step before closing the app
     db_connection_pool.close()

--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ async def main():
     # Initialize `game_db`
     await create_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
     db_connection_pool = await init_pool(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db')
-    await resolve_game_entry('god of war ragnarok', db_connection_pool)
+    await resolve_game_entry('The Witcher 3: Wild Hunt – Hearts of stone', db_connection_pool)
 
     # The last to step before closing the app
     db_connection_pool.close()

--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ async def main():
     # Initialize `game_db`
     await create_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
     db_connection_pool = await init_pool(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db')
-    await resolve_game_entry('Dynasty Warriors: Origins', db_connection_pool)
+    await resolve_game_entry('god of war ragnarok', db_connection_pool)
 
     # The last to step before closing the app
     db_connection_pool.close()

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 """ Entry point of the app """
 import asyncio
 import argparse
-from db_manager import create_db, init_pool, local_db_host, local_db_passwd, local_db_port, local_db_user, game_db_schema_path
+from db_manager import create_db, init_pool, local_db_host, local_db_passwd, local_db_port, local_db_user, game_db_schema_path, query_db_with_pool
 from game_manager import resolve_game_entry
 import os
 
@@ -10,7 +10,7 @@ async def main():
     # Initialize `game_db`
     await create_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
     db_connection_pool = await init_pool(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db')
-    await resolve_game_entry('cyberpunk 2077', db_connection_pool)
+    await resolve_game_entry('Dynasty Warriors: Origins', db_connection_pool)
 
     # The last to step before closing the app
     db_connection_pool.close()

--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ async def main():
     # Initialize `game_db`
     await create_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
     db_connection_pool = await init_pool(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db')
-    await resolve_game_entry('crimson desert', db_connection_pool)
+    await resolve_game_entry('The Witcher 4', db_connection_pool)
 
     # The last to step before closing the app
     db_connection_pool.close()

--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ async def main():
     # Initialize `game_db`
     await create_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
     db_connection_pool = await init_pool(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db')
-    await resolve_game_entry('The Witcher 4', db_connection_pool)
+    await resolve_game_entry('god of war', db_connection_pool)
 
     # The last to step before closing the app
     db_connection_pool.close()

--- a/db_manager.py
+++ b/db_manager.py
@@ -50,7 +50,7 @@ async def init_pool(host: str, port: int, user: str, passwd: str, db_name: str):
     return pool
 
 
-async def query_db_with_pool(pool, query: str, values: Optional[Tuple], query_type: str) -> Optional[Any]:
+async def query_db_with_pool(pool, query_type: str, query: str, values: Optional[Tuple] = None) -> Optional[Any]:
     """Sends a query to DB using Connection pool."""
     try:
         async with pool.acquire() as db_connection:
@@ -68,9 +68,10 @@ async def query_db_with_pool(pool, query: str, values: Optional[Tuple], query_ty
         raise IntegrityError() from e
     except Exception as e:
         print(f'Error occurred while querying : {type(e)} | {e}')
+        raise e from e
 
 
-async def query_wikidata(query_template: str, values: Dict, search_page_num: int = 10, search_offset: int = 0) -> Any:
+async def query_wikidata(query_template: str, values: Dict) -> Any:
     """Sends SPARQL query to `Wikidata`.
     
     Args:
@@ -87,8 +88,6 @@ async def query_wikidata(query_template: str, values: Dict, search_page_num: int
     Raises:
         RuntimeError: if the response code is either 429 or 500.
     """
-    values['search_page_num'] = search_page_num
-    values['search_offset'] = search_offset
     query = query_template.format(**values)
 
     sparql_wikidata = AsyncSparqlWrapper(WIKIDATA_SPARQL_URL)

--- a/db_manager.py
+++ b/db_manager.py
@@ -42,6 +42,8 @@ async def create_db(host: str, port: int, user: str, passwd: str, db_name: str, 
             await create_db(local_db_host, local_db_port, local_db_user, local_db_passwd, 'game_db', game_db_schema_path)
     except ProgrammingError as e:
         print(f'Error occurred while creating DB: {e}')
+    except Exception as e:
+        raise Exception(f'Error occurred in `create_db()`: {e}') from e
 
 
 async def init_pool(host: str, port: int, user: str, passwd: str, db_name: str):

--- a/db_manager.py
+++ b/db_manager.py
@@ -62,7 +62,7 @@ async def query_db_with_pool(pool, query_type: str, query: str, values: Optional
                 if query_type == 'SELECT':
                     result = await db_cursor.fetchall()
                     return result
-                elif query_type in ('INSERT', 'UPDATE'):
+                elif query_type in ('INSERT', 'UPDATE', 'USE'):
                     await db_connection.commit()
     except IntegrityError as e:
         raise IntegrityError() from e

--- a/db_manager.py
+++ b/db_manager.py
@@ -67,8 +67,7 @@ async def query_db_with_pool(pool, query_type: str, query: str, values: Optional
     except IntegrityError as e:
         raise IntegrityError() from e
     except Exception as e:
-        print(f'Error occurred while querying : {type(e)} | {e}')
-        raise e from e
+        raise RuntimeError(f'Error occurred while querying | {type(e)} : {e}') from e
 
 
 async def query_wikidata(query_template: str, values: Dict) -> Any:

--- a/game.py
+++ b/game.py
@@ -41,10 +41,9 @@ class Goals(Enum):
 
 class Game:
     """A class to hold metadata on a game"""
-    def __init__(self, title:str, manually_created:bool, wikidata =Dict[str, str]):
+    def __init__(self, title:str, wikidata =Dict[str, str]):
         # Necessary data on the game
         self.title = title
-        self.manually_created = manually_created
 
         # Data from the user
         self.purchase_date = None # this is not stored in game_db
@@ -79,9 +78,6 @@ class Game:
         self.playing = None
         self.played = None
         self.status: Status = None
-
-        if not manually_created:
-            self._fill_metadata_from_wikidata(wikidata) #TODO GTPS-59 prioritize the gameDB
 
 
     def update_status(self) -> None:

--- a/game.py
+++ b/game.py
@@ -115,54 +115,6 @@ class Game:
     
 
 
-    def set_purchase(self) -> None:
-        """Sets the purchase date and purchase related status."""
-        # TODO maybe this should be called by the client
-        # TODO this can be called when the game is purchased before or after released.
-        while True:
-            purchase_date = input('Please put the date of purchase in the following format, yyyy-mm-dd.\nPlease enter 0, if you haven\'t purchased the game yet.\n')
-            if purchase_date == '0':
-                self.purchased = False
-                break
-            elif _validate_date_format(purchase_date):
-                self.purchase_date = datetime.strptime(purchase_date, '%Y-%m-%d')
-                self.purchased = True
-                break
-            else:
-                print(f'Wrong date format: {purchase_date}')
-                continue
-        self.update_status()
-
-        
-    def set_play_platform(self) -> None:
-        """Sets the play platform."""
-        # TODO maybe this should be called by the client
-        # TODO this can be called each time the user wants to change the value.
-        while True:
-            play_platform = input('Please put the device you play this game on between PS4 and PS5.\n')
-            if play_platform not in Platform:
-                print(f'Wrong platform: {play_platform}')
-                continue
-            break
-        self.play_platform = Platform(play_platform)
-
-    
-    def set_expectation(self) -> None:
-        """Sets the user expectation on the game."""
-        # TODO maybe this should be called by the client
-        # TODO this can be called each time the user wants to change the value.
-        while True:
-            try:
-                expectation = int(input('Please put your expectation on this game from 0 to 3, the higher, the more hyped.\n'))
-                if (expectation > 3) or (expectation < 0):
-                    print(f'Invalid value for the expectation: {expectation}')
-                    continue
-                break
-            except ValueError:
-                print(f'Please enter a valid integer.')
-                continue
-        self.expectaion = Expectation(int(expectation)).value
-
 
     def set_game_active(self) ->  None:
         """Set the game currently playing."""
@@ -222,6 +174,57 @@ class Game:
             return (self.release_date - current_date).days
         
 
+
+    def set_purchase(self) -> None:
+        """Sets the purchase date and purchase related status."""
+        # TODO this should be called by the client
+        # TODO this can be called when the game is purchased before or after released.
+        while True:
+            purchase_date = input('Please put the date of purchase in the following format, yyyy-mm-dd.\nPlease enter 0, if you haven\'t purchased the game yet.\n')
+            if purchase_date == '0':
+                self.purchased = False
+                break
+            elif _validate_date_format(purchase_date):
+                self.purchase_date = datetime.strptime(purchase_date, '%Y-%m-%d')
+                self.purchased = True
+                break
+            else:
+                print(f'Wrong date format: {purchase_date}')
+                continue
+        self.update_status()
+
+
+
+    # TODO this should be called by the client
+    def set_play_platform(self) -> None:
+        """Sets the play platform."""
+        # TODO this can be called each time the user wants to change the value.
+        while True:
+            play_platform = input('Please put the device you play this game on between PS4 and PS5.\n')
+            if play_platform not in Platform:
+                print(f'Wrong platform: {play_platform}')
+                continue
+            break
+        self.play_platform = Platform(play_platform)
+
+    # TODO this should be called by the client
+    def set_expectation(self) -> None:
+        """Sets the user expectation on the game."""
+        # TODO this can be called each time the user wants to change the value.
+        while True:
+            try:
+                expectation = int(input('Please put your expectation on this game from 0 to 3, the higher, the more hyped.\n'))
+                if (expectation > 3) or (expectation < 0):
+                    print(f'Invalid value for the expectation: {expectation}')
+                    continue
+                break
+            except ValueError:
+                print(f'Please enter a valid integer.')
+                continue
+        self.expectaion = Expectation(int(expectation)).value
+
+
+    # TODO this should be called by the client
     def fill_post_playing_data(self):
         """Fills up certain data after playing"""
         pass
@@ -230,6 +233,7 @@ class Game:
         # self.my_score = 0
 
 
+    # TODO this should be called by the client
     def fill_meta_score(self):
         """Retrieve critics score and user score from `Metacritic`"""
         pass
@@ -238,6 +242,7 @@ class Game:
         # self.meta_user_score = 0
 
 
+    # TODO this should be called by the client
     def fill_open_score(self):
         """Retrieve critics score and user score from `Opencritic`"""
         pass

--- a/game.py
+++ b/game.py
@@ -117,6 +117,7 @@ class Game:
 
     def set_purchase(self) -> None:
         """Sets the purchase date and purchase related status."""
+        # TODO maybe this should be called by the client
         # TODO this can be called when the game is purchased before or after released.
         while True:
             purchase_date = input('Please put the date of purchase in the following format, yyyy-mm-dd.\nPlease enter 0, if you haven\'t purchased the game yet.\n')
@@ -135,6 +136,7 @@ class Game:
         
     def set_play_platform(self) -> None:
         """Sets the play platform."""
+        # TODO maybe this should be called by the client
         # TODO this can be called each time the user wants to change the value.
         while True:
             play_platform = input('Please put the device you play this game on between PS4 and PS5.\n')
@@ -147,6 +149,7 @@ class Game:
     
     def set_expectation(self) -> None:
         """Sets the user expectation on the game."""
+        # TODO maybe this should be called by the client
         # TODO this can be called each time the user wants to change the value.
         while True:
             try:


### PR DESCRIPTION
# Description

Currently, there is a column named `is_DLC` in `game_db`. Due to the nature of DLC in `Wikidata`, some data are missing in `Wikidata`. Let’s have DLCs linked with their parents and their missing data filled from them as well.

# Acceptance Criteria

- [x]  When an entry, which is DLC is added into `game_db`, its parent game’s ID should be registered to the row together
- [x]  Have missing data on the DLC entry filled with data from its parent entry.

# Resolution Details

- Removed filtering for `PlayStation` in `_make_candiate_list_wikidata()`
- `wikidata_link` is retrieved instead of `wikidata_code`
- the user is asked if the game is a DLC or expansion pack, to choose the parent games.
- Tested with `The Witcher 3: Wild Hunt` and its expansion packs