### PR TITLE
GTPS-45 enhanced the game_db search

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ async def main():
     # Initialize `game_db`
     await create_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
     db_connection_pool = await init_pool(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db')
-    await resolve_game_entry('The Witcher 3: Wild Hunt – Hearts of stone', db_connection_pool)
+    await resolve_game_entry('dynasty warriors: origins', db_connection_pool)
 
     # The last to step before closing the app
     db_connection_pool.close()


### PR DESCRIPTION
# Resolution Details

- `_find_parents()` has been removed but the usages of `FULLTEXT INDEX` inside has been moved into `_search_game()`
- `_search_game()` is now used to find the parent games.
- When the parent game is not found in `game_db` , the process gets terminated, instead of leading to another attempt to search `Wikidata`  for the parent game again.
- Tested with `Cyberpunk 2077, Witcher 3 and God of War Ragnarök`