### PR TITLE
Gtps 51

### DIFF
--- a/DB/game_db_practice.sql
+++ b/DB/game_db_practice.sql
@@ -1,0 +1,12 @@
+USE game_db;
+SELECT * FROM game_table;
+SELECT * FROM date_platform_table;
+
+DELETE FROM game_table WHERE game_id = 1;
+DELETE FROM date_platform_table WHERE game_id = 1;
+
+DROP TABLE game_table;
+
+USE game_db;
+SELECT * FROM game_table WHERE LCASE(title) = LCASE('Dynasty Warriors: Origins') OR LCASE(aliases) LIKE CONCAT('%', LCASE('Dynasty Warriors: Origins'), '%');
+

--- a/DB/game_db_practice.sql
+++ b/DB/game_db_practice.sql
@@ -2,11 +2,14 @@ USE game_db;
 SELECT * FROM game_table;
 SELECT * FROM date_platform_table;
 
-DELETE FROM game_table WHERE game_id = 1;
-DELETE FROM date_platform_table WHERE game_id = 1;
+DELETE FROM game_table WHERE game_id = 34;
+DELETE FROM date_platform_table WHERE game_id = 9;
 
 DROP TABLE game_table;
-
+DROP TABLE date_platform_table;
 USE game_db;
 SELECT * FROM game_table WHERE LCASE(title) = LCASE('Dynasty Warriors: Origins') OR LCASE(aliases) LIKE CONCAT('%', LCASE('Dynasty Warriors: Origins'), '%');
 
+CREATE FULLTEXT INDEX titles ON game_table (title, aliases);
+
+SELECT * FROM game_table WHERE MATCH(title, aliases) AGAINST('god of war ragnarok valhalla' IN NATURAL LANGUAGE MODE);

--- a/DB/game_db_schema.sql
+++ b/DB/game_db_schema.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS game_table (
     genres VARCHAR(1024),
     developers VARCHAR(255),
     publishers VARCHAR(255),
+    platforms VARCHAR(255),
     pro_enhanced BOOLEAN,
     meta_critic_score INT UNSIGNED,
     meta_user_score FLOAT UNSIGNED,

--- a/DB/wikidata_properties.json
+++ b/DB/wikidata_properties.json
@@ -1,0 +1,32552 @@
+{
+    "genres": [
+        {
+          "code": "Q23916",
+          "label": "adventure video game"
+        },
+        {
+          "code": "Q54767",
+          "label": "puzzle video game"
+        },
+        {
+          "code": "Q208189",
+          "label": "real-time strategy"
+        },
+        {
+          "code": "Q132311",
+          "label": "fantasy"
+        },
+        {
+          "code": "Q175173",
+          "label": "massively multiplayer online role-playing game"
+        },
+        {
+          "code": "Q270948",
+          "label": "action game"
+        },
+        {
+          "code": "Q185029",
+          "label": "first-person shooter"
+        },
+        {
+          "code": "Q343568",
+          "label": "action-adventure game"
+        },
+        {
+          "code": "Q333967",
+          "label": "survival horror"
+        },
+        {
+          "code": "Q172067",
+          "label": "hentai"
+        },
+        {
+          "code": "Q380266",
+          "label": "third-person shooter"
+        },
+        {
+          "code": "Q197949",
+          "label": "post-apocalyptic fiction"
+        },
+        {
+          "code": "Q229371",
+          "label": "3D computer graphics software"
+        },
+        {
+          "code": "Q254183",
+          "label": "augmented reality"
+        },
+        {
+          "code": "Q689445",
+          "label": "visual novel"
+        },
+        {
+          "code": "Q472055",
+          "label": "strategy video game"
+        },
+        {
+          "code": "Q744038",
+          "label": "role-playing video game"
+        },
+        {
+          "code": "Q828322",
+          "label": "platform game"
+        },
+        {
+          "code": "Q584105",
+          "label": "music video game"
+        },
+        {
+          "code": "Q819122",
+          "label": "location-based game"
+        },
+        {
+          "code": "Q1037904",
+          "label": "scrolling shooter"
+        },
+        {
+          "code": "Q690342",
+          "label": "harem"
+        },
+        {
+          "code": "Q860750",
+          "label": "racing video game"
+        },
+        {
+          "code": "Q858523",
+          "label": "stealth game"
+        },
+        {
+          "code": "Q868217",
+          "label": "sports video game"
+        },
+        {
+          "code": "Q1036289",
+          "label": "construction and management simulation"
+        },
+        {
+          "code": "Q846224",
+          "label": "fighting game"
+        },
+        {
+          "code": "Q1044478",
+          "label": "shoot 'em up"
+        },
+        {
+          "code": "Q1080071",
+          "label": "submarine simulator"
+        },
+        {
+          "code": "Q1143132",
+          "label": "roguelike"
+        },
+        {
+          "code": "Q862490",
+          "label": "massively multiplayer online game"
+        },
+        {
+          "code": "Q1163960",
+          "label": "hack and slash"
+        },
+        {
+          "code": "Q904447",
+          "label": "military science fiction"
+        },
+        {
+          "code": "Q1046788",
+          "label": "eroge"
+        },
+        {
+          "code": "Q1260861",
+          "label": "tactical shooter"
+        },
+        {
+          "code": "Q1199309",
+          "label": "life simulation game"
+        },
+        {
+          "code": "Q1198141",
+          "label": "business simulation game"
+        },
+        {
+          "code": "Q1189206",
+          "label": "multiplayer online battle arena"
+        },
+        {
+          "code": "Q1143087",
+          "label": "massively multiplayer online real-time strategy game"
+        },
+        {
+          "code": "Q1223895",
+          "label": "side-scrolling video game"
+        },
+        {
+          "code": "Q1143118",
+          "label": "interactive fiction"
+        },
+        {
+          "code": "Q1049203",
+          "label": "otome game"
+        },
+        {
+          "code": "Q603481",
+          "label": "combat flight simulator game"
+        },
+        {
+          "code": "Q604725",
+          "label": "psychological horror"
+        },
+        {
+          "code": "Q2070892",
+          "label": "vehicular combat game"
+        },
+        {
+          "code": "Q2351849",
+          "label": "military education and training"
+        },
+        {
+          "code": "Q401831",
+          "label": "beat 'em up"
+        },
+        {
+          "code": "Q868410",
+          "label": "graphics software"
+        },
+        {
+          "code": "Q1610017",
+          "label": "simulation video game"
+        },
+        {
+          "code": "Q1892535",
+          "label": "space flight simulation game"
+        },
+        {
+          "code": "Q1464369",
+          "label": "behind-the-scenes film"
+        },
+        {
+          "code": "Q3177953",
+          "label": "boxing video game"
+        },
+        {
+          "code": "Q3775539",
+          "label": "government simulation game"
+        },
+        {
+          "code": "Q4282636",
+          "label": "shooter game"
+        },
+        {
+          "code": "Q1422746",
+          "label": "action role-playing game"
+        },
+        {
+          "code": "Q1339223",
+          "label": "dating sim"
+        },
+        {
+          "code": "Q21030988",
+          "label": "survival game"
+        },
+        {
+          "code": "Q2313710",
+          "label": "real-time tactics"
+        },
+        {
+          "code": "Q27670585",
+          "label": "science fiction video game"
+        },
+        {
+          "code": "Q21192427",
+          "label": "crossover fiction"
+        },
+        {
+          "code": "Q25397095",
+          "label": "sandbox game"
+        },
+        {
+          "code": "Q1417032",
+          "label": "sim racing"
+        },
+        {
+          "code": "Q1265717",
+          "label": "dungeon crawl"
+        },
+        {
+          "code": "Q444835",
+          "label": "virtual world"
+        },
+        {
+          "code": "Q21154509",
+          "label": "space combat simulation game"
+        },
+        {
+          "code": "Q588289",
+          "label": "city-building game"
+        },
+        {
+          "code": "Q61507686",
+          "label": "space trading and combat game"
+        },
+        {
+          "code": "Q96195505",
+          "label": "cinematic platformer"
+        },
+        {
+          "code": "Q85422949",
+          "label": "video game with LGBT character"
+        },
+        {
+          "code": "Q56298645",
+          "label": "association football management game"
+        },
+        {
+          "code": "Q5519929",
+          "label": "game creation system"
+        },
+        {
+          "code": "Q19643088",
+          "label": "Metroidvania"
+        },
+        {
+          "code": "Q15613992",
+          "label": "arcade"
+        },
+        {
+          "code": "Q13717398",
+          "label": "maze video game"
+        },
+        {
+          "code": "Q16935625",
+          "label": "fishing video game"
+        },
+        {
+          "code": "Q30680823",
+          "label": "immersive sim"
+        },
+        {
+          "code": "Q54323360",
+          "label": "cyberpunk video game"
+        },
+        {
+          "code": "Q8018891",
+          "label": "romance adventure game"
+        },
+        {
+          "code": "Q1501543",
+          "label": "wargame"
+        },
+        {
+          "code": "Q1478420",
+          "label": "association football video game"
+        },
+        {
+          "code": "Q1823737",
+          "label": "text-based video game"
+        },
+        {
+          "code": "Q115101598",
+          "label": "post-apocalyptic video game"
+        },
+        {
+          "code": "Q1529437",
+          "label": "tactical role-playing game"
+        },
+        {
+          "code": "Q1323555",
+          "label": "bishōjo game"
+        },
+        {
+          "code": "Q1635956",
+          "label": "interactive film"
+        },
+        {
+          "code": "Q116790461",
+          "label": "3D platform game"
+        },
+        {
+          "code": "Q131317489",
+          "label": "mascot racer"
+        },
+        {
+          "code": "Q2176159",
+          "label": "turn-based strategy video game"
+        },
+        {
+          "code": "Q63914800",
+          "label": "darts video game"
+        },
+        {
+          "code": "Q61719251",
+          "label": "bowling video game"
+        },
+        {
+          "code": "Q130270628",
+          "label": "3D fighting game"
+        },
+        {
+          "code": "Q11298493",
+          "label": "quiz video game"
+        },
+        {
+          "code": "Q4451239",
+          "label": "tank simulation game"
+        },
+        {
+          "code": "Q7551387",
+          "label": "social simulation game"
+        },
+        {
+          "code": "Q2941225",
+          "label": "Breakout clone"
+        },
+        {
+          "code": "Q11590806",
+          "label": "point-and-click adventure"
+        },
+        {
+          "code": "Q7802107",
+          "label": "tile-matching video game"
+        },
+        {
+          "code": "Q3139142",
+          "label": "grand strategy wargame"
+        },
+        {
+          "code": "Q3177937",
+          "label": "historical game"
+        },
+        {
+          "code": "Q19272838",
+          "label": "board video game"
+        },
+        {
+          "code": "Q60617825",
+          "label": "mystery video game"
+        },
+        {
+          "code": "Q105702790",
+          "label": "Christmas video game"
+        },
+        {
+          "code": "Q113259205",
+          "label": "zombie video game"
+        },
+        {
+          "code": "Q104819482",
+          "label": "collect-a-thon platformer"
+        },
+        {
+          "code": "Q1050023",
+          "label": "casual game"
+        },
+        {
+          "code": "Q71468194",
+          "label": "skateboarding video game"
+        },
+        {
+          "code": "Q42409239",
+          "label": "fantasy video game"
+        },
+        {
+          "code": "Q603555",
+          "label": "4X"
+        },
+        {
+          "code": "Q116278254",
+          "label": "tilesweeper"
+        },
+        {
+          "code": "Q124986412",
+          "label": "massively multiplayer online social game"
+        },
+        {
+          "code": "Q105702814",
+          "label": "halloween video game"
+        },
+        {
+          "code": "Q107542373",
+          "label": "space opera video game"
+        },
+        {
+          "code": "Q181283",
+          "label": "adult comics"
+        },
+        {
+          "code": "Q221181",
+          "label": "train simulator"
+        },
+        {
+          "code": "Q2632782",
+          "label": "rhythm game"
+        },
+        {
+          "code": "Q1041225",
+          "label": "social network game"
+        },
+        {
+          "code": "Q242488",
+          "label": "yaoi"
+        },
+        {
+          "code": "Q467880",
+          "label": "programming game"
+        },
+        {
+          "code": "Q1077883",
+          "label": "biopunk"
+        },
+        {
+          "code": "Q1150710",
+          "label": "strategy game"
+        },
+        {
+          "code": "Q1194763",
+          "label": "2D computer graphics"
+        },
+        {
+          "code": "Q1137896",
+          "label": "tower defense"
+        },
+        {
+          "code": "Q11338014",
+          "label": "horror video game"
+        },
+        {
+          "code": "Q121023939",
+          "label": "squash video game"
+        },
+        {
+          "code": "Q1137176",
+          "label": "simulation game"
+        },
+        {
+          "code": "Q104735362",
+          "label": "turn-based Japanese role-playing game"
+        },
+        {
+          "code": "Q113645065",
+          "label": "character-action video game"
+        },
+        {
+          "code": "Q107542272",
+          "label": "science fantasy video game"
+        },
+        {
+          "code": "Q129695809",
+          "label": "horde shooter"
+        },
+        {
+          "code": "Q85341917",
+          "label": "LGBT-themed video game"
+        },
+        {
+          "code": "Q33183362",
+          "label": "walking simulator"
+        },
+        {
+          "code": "Q71474253",
+          "label": "hunting video game"
+        },
+        {
+          "code": "Q60480500",
+          "label": "run and gun"
+        },
+        {
+          "code": "Q2421031",
+          "label": "neo-noir"
+        },
+        {
+          "code": "Q122207",
+          "label": "artillery game"
+        },
+        {
+          "code": "Q4096094",
+          "label": "massively multiplayer browser role-playing game"
+        },
+        {
+          "code": "Q5366020",
+          "label": "science fiction anime and manga"
+        },
+        {
+          "code": "Q4375640",
+          "label": "turn-based tactics"
+        },
+        {
+          "code": "Q3965952",
+          "label": "light-gun shooter"
+        },
+        {
+          "code": "Q4292083",
+          "label": "mecha"
+        },
+        {
+          "code": "Q1224999",
+          "label": "educational video game"
+        },
+        {
+          "code": "Q11064557",
+          "label": "advergame"
+        },
+        {
+          "code": "Q1153173",
+          "label": "educational entertainment"
+        },
+        {
+          "code": "Q1999690",
+          "label": "sword and sorcery"
+        },
+        {
+          "code": "Q1436734",
+          "label": "adventure"
+        },
+        {
+          "code": "Q279060",
+          "label": "robinsonade"
+        },
+        {
+          "code": "Q536420",
+          "label": "god game"
+        },
+        {
+          "code": "Q821157",
+          "label": "bullet hell"
+        },
+        {
+          "code": "Q67016067",
+          "label": "card battle video game"
+        },
+        {
+          "code": "Q62591185",
+          "label": "puzzle-platformer"
+        },
+        {
+          "code": "Q29471320",
+          "label": "card video game"
+        },
+        {
+          "code": "Q15637310",
+          "label": "romance anime and manga"
+        },
+        {
+          "code": "Q15637299",
+          "label": "drama anime and manga"
+        },
+        {
+          "code": "Q5366097",
+          "label": "school anime and manga"
+        },
+        {
+          "code": "Q79798",
+          "label": "machine translation"
+        },
+        {
+          "code": "Q15637301",
+          "label": "fantasy anime and manga"
+        },
+        {
+          "code": "Q116790414",
+          "label": "2D platform game"
+        },
+        {
+          "code": "Q113019268",
+          "label": "multiple perspectives role-playing"
+        },
+        {
+          "code": "Q53094",
+          "label": "black comedy"
+        },
+        {
+          "code": "Q111184276",
+          "label": "dark fantasy video game"
+        },
+        {
+          "code": "Q108934731",
+          "label": "ice hockey management game"
+        },
+        {
+          "code": "Q62019045",
+          "label": "baseball video game"
+        },
+        {
+          "code": "Q650711",
+          "label": "combat"
+        },
+        {
+          "code": "Q320568",
+          "label": "yuri"
+        },
+        {
+          "code": "Q1035213",
+          "label": "capture the flag"
+        },
+        {
+          "code": "Q2016457",
+          "label": "fitness video game"
+        },
+        {
+          "code": "Q123198231",
+          "label": "zombie apocalyptic video game"
+        },
+        {
+          "code": "Q326439",
+          "label": "high fantasy"
+        },
+        {
+          "code": "Q1192658",
+          "label": "minigame"
+        },
+        {
+          "code": "Q71679871",
+          "label": "chess video game"
+        },
+        {
+          "code": "Q63465202",
+          "label": "handball video game"
+        },
+        {
+          "code": "Q61793886",
+          "label": "tennis video game"
+        },
+        {
+          "code": "Q2187138",
+          "label": "dance video game"
+        },
+        {
+          "code": "Q2628513",
+          "label": "graphic adventure game"
+        },
+        {
+          "code": "Q214932",
+          "label": "flight simulator"
+        },
+        {
+          "code": "Q7888616",
+          "label": "party video game"
+        },
+        {
+          "code": "Q96475230",
+          "label": "Tron-like"
+        },
+        {
+          "code": "Q71467408",
+          "label": "winter sports video game"
+        },
+        {
+          "code": "Q4740553",
+          "label": "flight simulation video game"
+        },
+        {
+          "code": "Q5383567",
+          "label": "episodic video game"
+        },
+        {
+          "code": "Q19683436",
+          "label": "truck simulation video game"
+        },
+        {
+          "code": "Q3362070",
+          "label": "erotic video game"
+        },
+        {
+          "code": "Q113940299",
+          "label": "satirical video game"
+        },
+        {
+          "code": "Q63915391",
+          "label": "American football video game"
+        },
+        {
+          "code": "Q71474750",
+          "label": "ice hockey video game"
+        },
+        {
+          "code": "Q105221690",
+          "label": "professional wrestling video game"
+        },
+        {
+          "code": "Q839864",
+          "label": "party game"
+        },
+        {
+          "code": "Q112284013",
+          "label": "bus simulation video game"
+        },
+        {
+          "code": "Q116703284",
+          "label": "trade simulation game"
+        },
+        {
+          "code": "Q129722891",
+          "label": "science fiction horror"
+        },
+        {
+          "code": "Q5188177",
+          "label": "hybrid literary genre"
+        },
+        {
+          "code": "Q219559",
+          "label": "ecchi"
+        },
+        {
+          "code": "Q40831",
+          "label": "comedy"
+        },
+        {
+          "code": "Q25861761",
+          "label": "virtual pet video game"
+        },
+        {
+          "code": "Q975060",
+          "label": "massively multiplayer online first-person shooter"
+        },
+        {
+          "code": "Q111019582",
+          "label": "vampire anime and manga"
+        },
+        {
+          "code": "Q114444644",
+          "label": "hard science fiction video game"
+        },
+        {
+          "code": "Q734698",
+          "label": "collectible card game"
+        },
+        {
+          "code": "Q15286013",
+          "label": "comedy anime and manga"
+        },
+        {
+          "code": "Q19683335",
+          "label": "ship simulation game"
+        },
+        {
+          "code": "Q60256879",
+          "label": "golf video game"
+        },
+        {
+          "code": "Q845159",
+          "label": "yaoi game"
+        },
+        {
+          "code": "Q751424",
+          "label": "MUD"
+        },
+        {
+          "code": "Q1187635",
+          "label": "digital pet"
+        },
+        {
+          "code": "Q9326077",
+          "label": "speculative fiction"
+        },
+        {
+          "code": "Q124331614",
+          "label": "rocks-and-diamonds video game"
+        },
+        {
+          "code": "Q105098453",
+          "label": "roguelite"
+        },
+        {
+          "code": "Q110505373",
+          "label": "nonogram video game"
+        },
+        {
+          "code": "Q2920921",
+          "label": "management"
+        },
+        {
+          "code": "Q63915027",
+          "label": "basketball video game"
+        },
+        {
+          "code": "Q4304915",
+          "label": "motorcycle simulation game"
+        },
+        {
+          "code": "Q752321",
+          "label": "magical girl"
+        },
+        {
+          "code": "Q103842351",
+          "label": "poker video game"
+        },
+        {
+          "code": "Q15637293",
+          "label": "action anime and manga"
+        },
+        {
+          "code": "Q15712918",
+          "label": "adventure anime and manga"
+        },
+        {
+          "code": "Q3739535",
+          "label": "art game"
+        },
+        {
+          "code": "Q6290007",
+          "label": "space simulator"
+        },
+        {
+          "code": "Q1506693",
+          "label": "serious game"
+        },
+        {
+          "code": "Q1122588",
+          "label": "computer chess"
+        },
+        {
+          "code": "Q63645120",
+          "label": "athletics video game"
+        },
+        {
+          "code": "Q653928",
+          "label": "pinball machine game"
+        },
+        {
+          "code": "Q860626",
+          "label": "romantic comedy"
+        },
+        {
+          "code": "Q2044250",
+          "label": "nonlinear gameplay"
+        },
+        {
+          "code": "Q131436",
+          "label": "board game"
+        },
+        {
+          "code": "Q71475833",
+          "label": "roller skating video game"
+        },
+        {
+          "code": "Q16681627",
+          "label": "alternate history video game"
+        },
+        {
+          "code": "Q18759108",
+          "label": "kart racing game"
+        },
+        {
+          "code": "Q4419886",
+          "label": "mech simulation game"
+        },
+        {
+          "code": "Q1631467",
+          "label": "strategy guide"
+        },
+        {
+          "code": "Q2454898",
+          "label": "computer wargame"
+        },
+        {
+          "code": "Q5110393",
+          "label": "Christian video game"
+        },
+        {
+          "code": "Q1643932",
+          "label": "tabletop role-playing game"
+        },
+        {
+          "code": "Q1637212",
+          "label": "fantasy comedy"
+        },
+        {
+          "code": "Q7548531",
+          "label": "snowboarding video game"
+        },
+        {
+          "code": "Q4421045",
+          "label": "timekeeping in games"
+        },
+        {
+          "code": "Q2127647",
+          "label": "rail shooter"
+        },
+        {
+          "code": "Q112616215",
+          "label": "magical girl video game"
+        },
+        {
+          "code": "Q54251760",
+          "label": "yuri game"
+        },
+        {
+          "code": "Q63645039",
+          "label": "mixed martial arts video game"
+        },
+        {
+          "code": "Q48997688",
+          "label": "collectible card video game"
+        },
+        {
+          "code": "Q3177954",
+          "label": "pinball video game"
+        },
+        {
+          "code": "Q130232",
+          "label": "drama film"
+        },
+        {
+          "code": "Q468478",
+          "label": "space opera"
+        },
+        {
+          "code": "Q1473699",
+          "label": "full motion video"
+        },
+        {
+          "code": "Q110701702",
+          "label": "urban crawl"
+        },
+        {
+          "code": "Q794912",
+          "label": "dark fantasy"
+        },
+        {
+          "code": "Q15712145",
+          "label": "romantic comedy anime and manga"
+        },
+        {
+          "code": "Q30607131",
+          "label": "battle royale game"
+        },
+        {
+          "code": "Q1366112",
+          "label": "drama television series"
+        },
+        {
+          "code": "Q7708377",
+          "label": "text-based"
+        },
+        {
+          "code": "Q2056928",
+          "label": "patience"
+        },
+        {
+          "code": "Q127602751",
+          "label": "2D fighting game"
+        },
+        {
+          "code": "Q5386",
+          "label": "auto racing"
+        },
+        {
+          "code": "Q858330",
+          "label": "romance novel"
+        },
+        {
+          "code": "Q24925",
+          "label": "science fiction"
+        },
+        {
+          "code": "Q66230650",
+          "label": "tube shooter"
+        },
+        {
+          "code": "Q96146237",
+          "label": "vertically scrolling shooter"
+        },
+        {
+          "code": "Q18822231",
+          "label": "time management video game"
+        },
+        {
+          "code": "Q62019097",
+          "label": "beach volleyball video game"
+        },
+        {
+          "code": "Q3742351",
+          "label": "casino game"
+        },
+        {
+          "code": "Q193606",
+          "label": "horror literature"
+        },
+        {
+          "code": "Q7089173",
+          "label": "olympic video game"
+        },
+        {
+          "code": "Q263847",
+          "label": "artificial life"
+        },
+        {
+          "code": "Q104760508",
+          "label": "sudoku video game"
+        },
+        {
+          "code": "Q56324412",
+          "label": "arena shooter"
+        },
+        {
+          "code": "Q71477837",
+          "label": "personal watercraft racing video game"
+        },
+        {
+          "code": "Q7281",
+          "label": "propaganda"
+        },
+        {
+          "code": "Q185867",
+          "label": "film noir"
+        },
+        {
+          "code": "Q113940368",
+          "label": "psychological horror video game"
+        },
+        {
+          "code": "Q116634",
+          "label": "online game"
+        },
+        {
+          "code": "Q128758",
+          "label": "satire"
+        },
+        {
+          "code": "Q564910",
+          "label": "gallows humor"
+        },
+        {
+          "code": "Q32554",
+          "label": "cracker"
+        },
+        {
+          "code": "Q10308060",
+          "label": "falling block puzzle game"
+        },
+        {
+          "code": "Q578868",
+          "label": "vehicle simulation game"
+        },
+        {
+          "code": "Q63645079",
+          "label": "karate video game"
+        },
+        {
+          "code": "Q10336582",
+          "label": "newsgame"
+        },
+        {
+          "code": "Q15062348",
+          "label": "dystopian fiction"
+        },
+        {
+          "code": "Q78145485",
+          "label": "multidirectional shooter"
+        },
+        {
+          "code": "Q1093434",
+          "label": "citizen science"
+        },
+        {
+          "code": "Q71471444",
+          "label": "cheerleading video game"
+        },
+        {
+          "code": "Q60617948",
+          "label": "trivia video game"
+        },
+        {
+          "code": "Q11756212",
+          "label": "physics game"
+        },
+        {
+          "code": "Q7643432",
+          "label": "superhero fiction"
+        },
+        {
+          "code": "Q590103",
+          "label": "psychological thriller"
+        },
+        {
+          "code": "Q4503635",
+          "label": "isometric view"
+        },
+        {
+          "code": "Q1493064",
+          "label": "human-based computation game"
+        },
+        {
+          "code": "Q61715376",
+          "label": "match-three video game"
+        },
+        {
+          "code": "Q12767035",
+          "label": "horror anime and manga"
+        },
+        {
+          "code": "Q11020",
+          "label": "pool"
+        },
+        {
+          "code": "Q120373252",
+          "label": "sokoban video game"
+        },
+        {
+          "code": "Q108380937",
+          "label": "traffic simulation game"
+        },
+        {
+          "code": "Q116236809",
+          "label": "rhythm platformer"
+        },
+        {
+          "code": "Q130287890",
+          "label": "fumblecore"
+        },
+        {
+          "code": "Q38848",
+          "label": "heavy metal"
+        },
+        {
+          "code": "Q747381",
+          "label": "light novel"
+        },
+        {
+          "code": "Q57775833",
+          "label": "endless runner game"
+        },
+        {
+          "code": "Q6368",
+          "label": "web browser"
+        },
+        {
+          "code": "Q846662",
+          "label": "game show"
+        },
+        {
+          "code": "Q110547060",
+          "label": "backgammon video game"
+        },
+        {
+          "code": "Q121769643",
+          "label": "rolling platformer"
+        },
+        {
+          "code": "Q63645108",
+          "label": "martial arts video game"
+        },
+        {
+          "code": "Q71471935",
+          "label": "extreme sports video game"
+        },
+        {
+          "code": "Q105475134",
+          "label": "soulslike"
+        },
+        {
+          "code": "Q63106609",
+          "label": "cabal shooter"
+        },
+        {
+          "code": "Q1196408",
+          "label": "historical fiction"
+        },
+        {
+          "code": "Q1368898",
+          "label": "game of skill"
+        },
+        {
+          "code": "Q129212292",
+          "label": "word video game"
+        },
+        {
+          "code": "Q106764019",
+          "label": "photography game"
+        },
+        {
+          "code": "Q116680021",
+          "label": "driving video game"
+        },
+        {
+          "code": "Q95124454",
+          "label": "arcade racing game"
+        },
+        {
+          "code": "Q7832342",
+          "label": "traditional video game"
+        },
+        {
+          "code": "Q71468383",
+          "label": "table tennis video game"
+        },
+        {
+          "code": "Q749749",
+          "label": "non-game"
+        },
+        {
+          "code": "Q1004",
+          "label": "comics"
+        },
+        {
+          "code": "Q11322721",
+          "label": "maze chase"
+        },
+        {
+          "code": "Q1493029",
+          "label": "video game art"
+        },
+        {
+          "code": "Q1299049",
+          "label": "first-person view"
+        },
+        {
+          "code": "Q735",
+          "label": "art"
+        },
+        {
+          "code": "Q61793874",
+          "label": "surfing video game"
+        },
+        {
+          "code": "Q96146284",
+          "label": "fixed shooter"
+        },
+        {
+          "code": "Q111519486",
+          "label": "shooting gallery game"
+        },
+        {
+          "code": "Q21010853",
+          "label": "drama fiction"
+        },
+        {
+          "code": "Q9318902",
+          "label": "mahjong video game"
+        },
+        {
+          "code": "Q216293",
+          "label": "Pong"
+        },
+        {
+          "code": "Q5923834",
+          "label": "Japanese role-playing video game"
+        },
+        {
+          "code": "Q108882014",
+          "label": "looter shooter"
+        },
+        {
+          "code": "Q110639931",
+          "label": "platform fighter"
+        },
+        {
+          "code": "Q71472303",
+          "label": "fantasy sports video game"
+        },
+        {
+          "code": "Q1188977",
+          "label": "urban fantasy"
+        },
+        {
+          "code": "Q848991",
+          "label": "browser game"
+        },
+        {
+          "code": "Q73476571",
+          "label": "off-road racing video game"
+        },
+        {
+          "code": "Q273383",
+          "label": "memento mori"
+        },
+        {
+          "code": "Q54314590",
+          "label": "time travel video game"
+        },
+        {
+          "code": "Q71726635",
+          "label": "kinetic novel"
+        },
+        {
+          "code": "Q181319",
+          "label": "scrolling"
+        },
+        {
+          "code": "Q223770",
+          "label": "B movie"
+        },
+        {
+          "code": "Q61721552",
+          "label": "cricket video game"
+        },
+        {
+          "code": "Q1272194",
+          "label": "tile-based game"
+        },
+        {
+          "code": "Q7835145",
+          "label": "transport puzzle"
+        },
+        {
+          "code": "Q113939436",
+          "label": "parody video game"
+        },
+        {
+          "code": "Q1054574",
+          "label": "romance film"
+        },
+        {
+          "code": "Q122766396",
+          "label": "augmented reality video game"
+        },
+        {
+          "code": "Q92608103",
+          "label": "karaoke video game"
+        },
+        {
+          "code": "Q113259250",
+          "label": "vampire video game"
+        },
+        {
+          "code": "Q6606171",
+          "label": "list of artificial pet games"
+        },
+        {
+          "code": "Q11015",
+          "label": "snooker"
+        },
+        {
+          "code": "Q60617897",
+          "label": "gambling video game"
+        },
+        {
+          "code": "Q130278840",
+          "label": "reversi video game"
+        },
+        {
+          "code": "Q6585139",
+          "label": "mystery fiction"
+        },
+        {
+          "code": "Q71467370",
+          "label": "skiing video game"
+        },
+        {
+          "code": "Q108611897",
+          "label": "horse racing video game"
+        },
+        {
+          "code": "Q170539",
+          "label": "parody"
+        },
+        {
+          "code": "Q3177952",
+          "label": "equestrian video game"
+        },
+        {
+          "code": "Q125177944",
+          "label": "snake video game"
+        },
+        {
+          "code": "Q96146141",
+          "label": "horizontally scrolling shooter"
+        },
+        {
+          "code": "Q62022558",
+          "label": "cue sports video game"
+        },
+        {
+          "code": "Q18351283",
+          "label": "incremental game"
+        },
+        {
+          "code": "Q7674123",
+          "label": "tactical wargame"
+        },
+        {
+          "code": "Q274079",
+          "label": "quiz"
+        },
+        {
+          "code": "Q876274",
+          "label": "naval warfare"
+        },
+        {
+          "code": "Q25377002",
+          "label": "hidden object game"
+        },
+        {
+          "code": "Q3297989",
+          "label": "multiplayer online game"
+        },
+        {
+          "code": "Q32112",
+          "label": "boxing"
+        },
+        {
+          "code": "Q116280691",
+          "label": "superhero video game"
+        },
+        {
+          "code": "Q21570197",
+          "label": "typing tutor"
+        },
+        {
+          "code": "Q189177",
+          "label": "3D computer graphics"
+        },
+        {
+          "code": "Q5923736",
+          "label": "first-person adventure"
+        },
+        {
+          "code": "Q11328978",
+          "label": "pachinko video game"
+        },
+        {
+          "code": "Q186424",
+          "label": "detective fiction"
+        },
+        {
+          "code": "Q60617905",
+          "label": "game show video game"
+        },
+        {
+          "code": "Q63644993",
+          "label": "cycling video game"
+        },
+        {
+          "code": "Q3332709",
+          "label": "medieval fantasy"
+        },
+        {
+          "code": "Q160738",
+          "label": "role-playing game"
+        },
+        {
+          "code": "Q28026639",
+          "label": "Christmas film"
+        },
+        {
+          "code": "Q29621749",
+          "label": "family drama"
+        },
+        {
+          "code": "Q96102031",
+          "label": "shogi video game"
+        },
+        {
+          "code": "Q109470190",
+          "label": "NASCAR video game"
+        },
+        {
+          "code": "Q93876174",
+          "label": "archery video game"
+        },
+        {
+          "code": "Q109529923",
+          "label": "espionage video game"
+        },
+        {
+          "code": "Q1055974",
+          "label": "light gun"
+        },
+        {
+          "code": "Q2328286",
+          "label": "skeet shooting"
+        },
+        {
+          "code": "Q1181095",
+          "label": "Dancing"
+        },
+        {
+          "code": "Q107",
+          "label": "space"
+        },
+        {
+          "code": "Q754796",
+          "label": "miniature golf"
+        },
+        {
+          "code": "Q41595400",
+          "label": "mind game"
+        },
+        {
+          "code": "Q181001",
+          "label": "erotica"
+        },
+        {
+          "code": "Q112129971",
+          "label": "checkers video game"
+        },
+        {
+          "code": "Q63645033",
+          "label": "sumo wrestling video game"
+        },
+        {
+          "code": "Q96678034",
+          "label": "BMX video game"
+        },
+        {
+          "code": "Q130270654",
+          "label": "arena fighter"
+        },
+        {
+          "code": "Q181008",
+          "label": "jigsaw puzzle"
+        },
+        {
+          "code": "Q62019077",
+          "label": "volleyball video game"
+        },
+        {
+          "code": "Q126598654",
+          "label": "minigame collection"
+        },
+        {
+          "code": "Q6786274",
+          "label": "Matching game"
+        },
+        {
+          "code": "Q63645022",
+          "label": "judo video game"
+        },
+        {
+          "code": "Q62019104",
+          "label": "lacrosse video game"
+        },
+        {
+          "code": "Q4464730",
+          "label": "3D video game"
+        },
+        {
+          "code": "Q9086092",
+          "label": "third-person view"
+        },
+        {
+          "code": "Q781048",
+          "label": "audio game"
+        },
+        {
+          "code": "Q5433331",
+          "label": "Family game"
+        },
+        {
+          "code": "Q3606845",
+          "label": "agricultural science"
+        },
+        {
+          "code": "Q5434359",
+          "label": "fantasy sport"
+        },
+        {
+          "code": "Q3414877",
+          "label": "quest / mission"
+        },
+        {
+          "code": "Q878160",
+          "label": "bingo"
+        },
+        {
+          "code": "Q1074158",
+          "label": "educational software"
+        },
+        {
+          "code": "Q16070115",
+          "label": "video game compilation"
+        },
+        {
+          "code": "Q5570915",
+          "label": "climate change video game"
+        },
+        {
+          "code": "Q215641",
+          "label": "aerobics"
+        },
+        {
+          "code": "Q107527031",
+          "label": "top-down shooter"
+        },
+        {
+          "code": "Q8434",
+          "label": "education"
+        },
+        {
+          "code": "Q10928179",
+          "label": "online and offline"
+        },
+        {
+          "code": "Q1358545",
+          "label": "arena football"
+        },
+        {
+          "code": "Q3249257",
+          "label": "adult animation"
+        },
+        {
+          "code": "Q2081815",
+          "label": "driving simulator"
+        },
+        {
+          "code": "Q71683262",
+          "label": "massively multiplayer browser game"
+        },
+        {
+          "code": "Q2394336",
+          "label": "interactive art"
+        },
+        {
+          "code": "Q116811570",
+          "label": "2.5D platform game"
+        },
+        {
+          "code": "Q336059",
+          "label": "science fiction television program"
+        },
+        {
+          "code": "Q10728648",
+          "label": "occult detective fiction"
+        },
+        {
+          "code": "Q85133165",
+          "label": "LGBT-related television series"
+        },
+        {
+          "code": "Q11248529",
+          "label": "sound novel"
+        },
+        {
+          "code": "Q6719091",
+          "label": "MUSH"
+        },
+        {
+          "code": "Q104093099",
+          "label": "massively multiplayer online third-person shooter"
+        },
+        {
+          "code": "Q97097760",
+          "label": "floorball video game"
+        },
+        {
+          "code": "Q11630302",
+          "label": "memory video game"
+        },
+        {
+          "code": "Q63915650",
+          "label": "Australian football video game"
+        },
+        {
+          "code": "Q61791393",
+          "label": "miniature golf video game"
+        },
+        {
+          "code": "Q71472862",
+          "label": "gaelic games video game"
+        },
+        {
+          "code": "Q1521451",
+          "label": "trivia"
+        },
+        {
+          "code": "Q124539804",
+          "label": "alchemy game"
+        },
+        {
+          "code": "Q4184",
+          "label": "autobiography"
+        },
+        {
+          "code": "Q312466",
+          "label": "utility software"
+        },
+        {
+          "code": "Q229345",
+          "label": "karaoke"
+        },
+        {
+          "code": "Q1140722",
+          "label": "drinking game"
+        },
+        {
+          "code": "Q14947863",
+          "label": "parlour game"
+        },
+        {
+          "code": "Q413",
+          "label": "physics"
+        },
+        {
+          "code": "Q11416",
+          "label": "gambling"
+        },
+        {
+          "code": "Q7257249",
+          "label": "pub game"
+        },
+        {
+          "code": "Q71443011",
+          "label": "paintball video game"
+        },
+        {
+          "code": "Q60616268",
+          "label": "language learning video game"
+        },
+        {
+          "code": "Q719798",
+          "label": "player versus player"
+        },
+        {
+          "code": "Q37073",
+          "label": "pop music"
+        },
+        {
+          "code": "Q309",
+          "label": "history"
+        },
+        {
+          "code": "Q63914927",
+          "label": "stunt racing video game"
+        },
+        {
+          "code": "Q11633",
+          "label": "photography"
+        },
+        {
+          "code": "Q1191212",
+          "label": "low fantasy"
+        },
+        {
+          "code": "Q1413053",
+          "label": "jousting"
+        },
+        {
+          "code": "Q116236834",
+          "label": "cooking simulation video game"
+        },
+        {
+          "code": "Q62019057",
+          "label": "rugby union video game"
+        },
+        {
+          "code": "Q103821052",
+          "label": "strip poker video game"
+        },
+        {
+          "code": "Q746106",
+          "label": "speed reading"
+        },
+        {
+          "code": "Q6486703",
+          "label": "language arts"
+        },
+        {
+          "code": "Q2088390",
+          "label": "spelling"
+        },
+        {
+          "code": "Q500834",
+          "label": "tournament"
+        },
+        {
+          "code": "Q276709",
+          "label": "Southern Gothic"
+        },
+        {
+          "code": "Q2238071",
+          "label": "bat-and-ball game"
+        },
+        {
+          "code": "Q211773",
+          "label": "show jumping"
+        },
+        {
+          "code": "Q111411020",
+          "label": "motorcycle video game"
+        },
+        {
+          "code": "Q126366922",
+          "label": "snowmobile racing video game"
+        },
+        {
+          "code": "Q2057931",
+          "label": "simulator"
+        },
+        {
+          "code": "Q1348645",
+          "label": "learning material"
+        },
+        {
+          "code": "Q38926",
+          "label": "news"
+        },
+        {
+          "code": "Q4011394",
+          "label": "sports manager video game"
+        },
+        {
+          "code": "Q8134",
+          "label": "economics"
+        },
+        {
+          "code": "Q92602121",
+          "label": "figure skating video game"
+        },
+        {
+          "code": "Q58199",
+          "label": "instant messaging"
+        },
+        {
+          "code": "Q133500",
+          "label": "learning"
+        },
+        {
+          "code": "Q63243980",
+          "label": "pool video game"
+        },
+        {
+          "code": "Q63915162",
+          "label": "dodgeball video game"
+        },
+        {
+          "code": "Q19",
+          "label": "cheating"
+        },
+        {
+          "code": "Q102259548",
+          "label": "steampunk video game"
+        },
+        {
+          "code": "Q71476528",
+          "label": "water sports video game"
+        },
+        {
+          "code": "Q61745129",
+          "label": "air hockey video game"
+        },
+        {
+          "code": "Q71441946",
+          "label": "snooker video game"
+        },
+        {
+          "code": "Q2940678",
+          "label": "multicart"
+        },
+        {
+          "code": "Q3023661",
+          "label": "demolition derby"
+        },
+        {
+          "code": "Q438419",
+          "label": "alternate reality game"
+        },
+        {
+          "code": "Q1099522",
+          "label": "race game"
+        },
+        {
+          "code": "Q7696995",
+          "label": "comedy television program"
+        },
+        {
+          "code": "Q599853",
+          "label": "furry fandom"
+        },
+        {
+          "code": "Q725377",
+          "label": "graphic novel"
+        },
+        {
+          "code": "Q63466098",
+          "label": "hockey video game"
+        },
+        {
+          "code": "Q6719017",
+          "label": "MU*"
+        },
+        {
+          "code": "Q5432283",
+          "label": "falling-sand game"
+        },
+        {
+          "code": "Q131578",
+          "label": "J-pop"
+        },
+        {
+          "code": "Q6895044",
+          "label": "multiplayer video game"
+        },
+        {
+          "code": "Q126393551",
+          "label": "text adventure"
+        },
+        {
+          "code": "Q113939522",
+          "label": "comedy video game"
+        },
+        {
+          "code": "Q82604",
+          "label": "design"
+        },
+        {
+          "code": "Q25450968",
+          "label": "cave flyer"
+        },
+        {
+          "code": "Q123198290",
+          "label": "zombie apocalyptic television program"
+        },
+        {
+          "code": "Q111391909",
+          "label": "raising sim video game"
+        },
+        {
+          "code": "Q14411698",
+          "label": "romance video game"
+        },
+        {
+          "code": "Q23622",
+          "label": "dictionary"
+        },
+        {
+          "code": "Q107631040",
+          "label": "side-scrolling role-playing video game"
+        },
+        {
+          "code": "Q5319044",
+          "label": "Dynamical simulation"
+        },
+        {
+          "code": "Q38695",
+          "label": "cooking"
+        },
+        {
+          "code": "Q3220391",
+          "label": "social networking service"
+        },
+        {
+          "code": "Q355217",
+          "label": "time management"
+        },
+        {
+          "code": "Q87741364",
+          "label": "virtual reality video game"
+        },
+        {
+          "code": "Q131918199",
+          "label": "video game about pirates"
+        },
+        {
+          "code": "Q228395",
+          "label": "mating"
+        },
+        {
+          "code": "Q173799",
+          "label": "entertainment"
+        },
+        {
+          "code": "Q738473",
+          "label": "romance"
+        },
+        {
+          "code": "Q59536813",
+          "label": "supernatural horror game"
+        },
+        {
+          "code": "Q3341285",
+          "label": "cue sports"
+        },
+        {
+          "code": "Q3590573",
+          "label": "game of chance"
+        },
+        {
+          "code": "Q111149309",
+          "label": "farming simulation game"
+        },
+        {
+          "code": "Q3053964",
+          "label": "spot the difference"
+        },
+        {
+          "code": "Q11282930",
+          "label": "action puzzle video game"
+        },
+        {
+          "code": "Q16575965",
+          "label": "horror fiction"
+        },
+        {
+          "code": "Q7927914",
+          "label": "video game graphics"
+        },
+        {
+          "code": "Q309227",
+          "label": "lolicon"
+        },
+        {
+          "code": "Q2111958",
+          "label": "productivity"
+        },
+        {
+          "code": "Q603291",
+          "label": "historical fantasy"
+        },
+        {
+          "code": "Q7856",
+          "label": "rallying"
+        },
+        {
+          "code": "Q836661",
+          "label": "pachinko"
+        },
+        {
+          "code": "Q21590660",
+          "label": "Western"
+        },
+        {
+          "code": "Q101240878",
+          "label": "suspense anime and manga"
+        },
+        {
+          "code": "Q206021",
+          "label": "flight"
+        },
+        {
+          "code": "Q643873",
+          "label": "legal drama"
+        },
+        {
+          "code": "Q122766381",
+          "label": "deck-building video game"
+        },
+        {
+          "code": "Q788553",
+          "label": "German-style board game"
+        },
+        {
+          "code": "Q344",
+          "label": "future"
+        },
+        {
+          "code": "Q11084095",
+          "label": "historical video game"
+        },
+        {
+          "code": "Q15079592",
+          "label": "strategic game"
+        },
+        {
+          "code": "Q109520717",
+          "label": "biathlon video game"
+        },
+        {
+          "code": "Q208850",
+          "label": "single-player video game"
+        },
+        {
+          "code": "Q8473",
+          "label": "military"
+        },
+        {
+          "code": "Q5292",
+          "label": "encyclopedia"
+        },
+        {
+          "code": "Q1509934",
+          "label": "children's game"
+        },
+        {
+          "code": "Q48835388",
+          "label": "gacha game"
+        },
+        {
+          "code": "Q1738531",
+          "label": "Kemonā"
+        },
+        {
+          "code": "Q112278052",
+          "label": "one-move game"
+        },
+        {
+          "code": "Q99015944",
+          "label": "parkour video game"
+        },
+        {
+          "code": "Q1244298",
+          "label": "RPG"
+        },
+        {
+          "code": "Q124041478",
+          "label": "solitaire video game"
+        },
+        {
+          "code": "Q125693245",
+          "label": "action roguelike"
+        },
+        {
+          "code": "Q2705092",
+          "label": "Formula One racing"
+        },
+        {
+          "code": "Q210339",
+          "label": "tic-tac-toe"
+        },
+        {
+          "code": "Q725757",
+          "label": "hard science fiction"
+        },
+        {
+          "code": "Q130374784",
+          "label": "mahjong solitaire video game"
+        },
+        {
+          "code": "Q7644030",
+          "label": "supernatural fiction"
+        },
+        {
+          "code": "Q128188835",
+          "label": ".io game"
+        },
+        {
+          "code": "Q71477585",
+          "label": "scuba diving video game"
+        },
+        {
+          "code": "Q60617863",
+          "label": "fashion and beauty video game"
+        },
+        {
+          "code": "Q104767049",
+          "label": "time-travel television program"
+        },
+        {
+          "code": "Q85801811",
+          "label": "social deduction game"
+        },
+        {
+          "code": "Q1758804",
+          "label": "co-op mode"
+        },
+        {
+          "code": "Q128790044",
+          "label": "extraction video game"
+        },
+        {
+          "code": "Q104830011",
+          "label": "hero shooter"
+        },
+        {
+          "code": "Q109942850",
+          "label": "motocross racing video game"
+        },
+        {
+          "code": "Q128115",
+          "label": "abstract art"
+        },
+        {
+          "code": "Q26692802",
+          "label": "endless video game"
+        },
+        {
+          "code": "Q1894374",
+          "label": "tech noir"
+        },
+        {
+          "code": "Q109599573",
+          "label": "online crane game"
+        },
+        {
+          "code": "Q699",
+          "label": "fairy tale"
+        },
+        {
+          "code": "Q142714",
+          "label": "card game"
+        },
+        {
+          "code": "Q7094075",
+          "label": "online creation"
+        },
+        {
+          "code": "Q5370763",
+          "label": "emergent gameplay"
+        },
+        {
+          "code": "Q2249149",
+          "label": "electronic game"
+        },
+        {
+          "code": "Q1519335",
+          "label": "ghost story"
+        },
+        {
+          "code": "Q182015",
+          "label": "thriller"
+        },
+        {
+          "code": "Q2975633",
+          "label": "coming-of-age fiction"
+        },
+        {
+          "code": "Q3244175",
+          "label": "tabletop game"
+        },
+        {
+          "code": "Q573573",
+          "label": "abstract strategy game"
+        },
+        {
+          "code": "Q110738513",
+          "label": "boss game"
+        },
+        {
+          "code": "Q60982656",
+          "label": "auto-runner video game"
+        },
+        {
+          "code": "Q52670593",
+          "label": "solitaire"
+        },
+        {
+          "code": "Q48758400",
+          "label": "ship personification"
+        },
+        {
+          "code": "Q135637",
+          "label": "chiptune"
+        },
+        {
+          "code": "Q6045390",
+          "label": "interactive novel"
+        },
+        {
+          "code": "Q122808398",
+          "label": "live action video game"
+        },
+        {
+          "code": "Q17049225",
+          "label": "vertically scrolling video game"
+        },
+        {
+          "code": "Q105906396",
+          "label": "turn-based role-playing game"
+        },
+        {
+          "code": "Q2903135",
+          "label": "interactive storytelling"
+        },
+        {
+          "code": "Q319226",
+          "label": "adventure novel"
+        },
+        {
+          "code": "Q1121542",
+          "label": "mobile game"
+        },
+        {
+          "code": "Q1414510",
+          "label": "free-to-play"
+        },
+        {
+          "code": "Q53911753",
+          "label": "isekai"
+        },
+        {
+          "code": "Q75276527",
+          "label": "factory simulation game"
+        },
+        {
+          "code": "Q912009",
+          "label": "modularity"
+        },
+        {
+          "code": "Q63915290",
+          "label": "Canadian football video game"
+        },
+        {
+          "code": "Q113940337",
+          "label": "cosmic horror video game"
+        },
+        {
+          "code": "Q1201679",
+          "label": "escape room video game"
+        },
+        {
+          "code": "Q2594402",
+          "label": "guessing game"
+        },
+        {
+          "code": "Q754803",
+          "label": "wuxia"
+        },
+        {
+          "code": "Q115105241",
+          "label": "boomer shooter"
+        },
+        {
+          "code": "Q121432229",
+          "label": "historical educational game"
+        },
+        {
+          "code": "Q7230210",
+          "label": "pornographic video game"
+        },
+        {
+          "code": "Q124695018",
+          "label": "management simulation game"
+        },
+        {
+          "code": "Q628165",
+          "label": "road movie"
+        },
+        {
+          "code": "Q3328821",
+          "label": "narration"
+        },
+        {
+          "code": "Q109598322",
+          "label": "roguevania"
+        },
+        {
+          "code": "Q1107",
+          "label": "anime"
+        },
+        {
+          "code": "Q108924240",
+          "label": "racing management video game"
+        },
+        {
+          "code": "Q1311927",
+          "label": "railway game"
+        },
+        {
+          "code": "Q531067",
+          "label": "metafiction"
+        },
+        {
+          "code": "Q55335263",
+          "label": "crossword video game"
+        },
+        {
+          "code": "Q291",
+          "label": "pornography"
+        },
+        {
+          "code": "Q30347815",
+          "label": "twin-stick shooter"
+        },
+        {
+          "code": "Q1762165",
+          "label": "action fiction"
+        },
+        {
+          "code": "Q55058128",
+          "label": "sailing simulator"
+        },
+        {
+          "code": "Q1092460",
+          "label": "surreal humour"
+        },
+        {
+          "code": "Q3093436",
+          "label": "Grand Theft Auto clone"
+        },
+        {
+          "code": "Q104880795",
+          "label": "non-binary characters in fiction"
+        },
+        {
+          "code": "Q109594644",
+          "label": "social VR"
+        },
+        {
+          "code": "Q85797695",
+          "label": "roguelike deck-building game"
+        },
+        {
+          "code": "Q11322147",
+          "label": "DATA CARDDASS"
+        },
+        {
+          "code": "Q5937792",
+          "label": "crime fiction"
+        },
+        {
+          "code": "Q1395452",
+          "label": "fan adventure"
+        },
+        {
+          "code": "Q2561438",
+          "label": "slice of life"
+        },
+        {
+          "code": "Q112224709",
+          "label": "gender bender"
+        },
+        {
+          "code": "Q27291",
+          "label": "crying game"
+        },
+        {
+          "code": "Q110068411",
+          "label": "blackjack video game"
+        },
+        {
+          "code": "Q96381517",
+          "label": "hypercasual game"
+        },
+        {
+          "code": "Q7168625",
+          "label": "historical drama"
+        },
+        {
+          "code": "Q84322932",
+          "label": "horror eroge"
+        },
+        {
+          "code": "Q67650958",
+          "label": "auto battler"
+        },
+        {
+          "code": "Q6630681",
+          "label": "list of ninja video games"
+        },
+        {
+          "code": "Q174526",
+          "label": "cyberpunk"
+        },
+        {
+          "code": "Q185529",
+          "label": "pornographic film"
+        },
+        {
+          "code": "Q102128235",
+          "label": "interactive DVD game"
+        },
+        {
+          "code": "Q17232662",
+          "label": "brain video game"
+        },
+        {
+          "code": "Q126394863",
+          "label": "clicker game"
+        },
+        {
+          "code": "Q1062702",
+          "label": "video game music"
+        },
+        {
+          "code": "Q17015069",
+          "label": "escape room"
+        },
+        {
+          "code": "Q2915546",
+          "label": "virtual tour"
+        },
+        {
+          "code": "Q905770",
+          "label": "soft science fiction"
+        },
+        {
+          "code": "Q109603400",
+          "label": "soulsvania"
+        },
+        {
+          "code": "Q2281709",
+          "label": "side-scrolling beat 'em up"
+        },
+        {
+          "code": "Q117474613",
+          "label": "monster-taming game"
+        },
+        {
+          "code": "Q60617834",
+          "label": "empire-building video game"
+        },
+        {
+          "code": "Q11327529",
+          "label": "silly game"
+        },
+        {
+          "code": "Q63914602",
+          "label": "curling video game"
+        },
+        {
+          "code": "Q86607071",
+          "label": "retro video game"
+        },
+        {
+          "code": "Q2215841",
+          "label": "cycle sport"
+        },
+        {
+          "code": "Q7225114",
+          "label": "political satire"
+        },
+        {
+          "code": "Q1065444",
+          "label": "kaiju"
+        },
+        {
+          "code": "Q93184",
+          "label": "drawing"
+        },
+        {
+          "code": "Q111306718",
+          "label": "supercross racing video game"
+        },
+        {
+          "code": "Q111411588",
+          "label": "superbike racing video game"
+        },
+        {
+          "code": "Q104861501",
+          "label": "typing game"
+        },
+        {
+          "code": "Q1370621",
+          "label": "yandere"
+        },
+        {
+          "code": "Q110887639",
+          "label": "crowd-combat video game"
+        },
+        {
+          "code": "Q124490",
+          "label": "violence"
+        },
+        {
+          "code": "Q110763412",
+          "label": "gomoku video game"
+        },
+        {
+          "code": "Q110746103",
+          "label": "coloring book game"
+        },
+        {
+          "code": "Q20124979",
+          "label": "Plataforma"
+        },
+        {
+          "code": "Q110546562",
+          "label": "Texas hold 'em video game"
+        },
+        {
+          "code": "Q61719571",
+          "label": "detective video game"
+        },
+        {
+          "code": "Q668312",
+          "label": "tentacle erotica"
+        },
+        {
+          "code": "Q105809369",
+          "label": "cosmic horror"
+        },
+        {
+          "code": "Q117428071",
+          "label": "milsim video game"
+        },
+        {
+          "code": "Q3257925",
+          "label": "Go software"
+        },
+        {
+          "code": "Q104860440",
+          "label": "digital tabletop game"
+        },
+        {
+          "code": "Q108099476",
+          "label": "jigsaw puzzle video game"
+        },
+        {
+          "code": "Q13698",
+          "label": "puzzle"
+        },
+        {
+          "code": "Q122791012",
+          "label": "bullet heaven"
+        },
+        {
+          "code": "Q874342",
+          "label": "interactive television"
+        },
+        {
+          "code": "Q118444867",
+          "label": "mascot horror video game"
+        },
+        {
+          "code": "Q1054122",
+          "label": "futanari"
+        },
+        {
+          "code": "Q112074728",
+          "label": "rally racing video game"
+        },
+        {
+          "code": "Q109628205",
+          "label": "found footage horror"
+        },
+        {
+          "code": "Q36649",
+          "label": "visual arts"
+        },
+        {
+          "code": "Q124757184",
+          "label": "automobile simulation game"
+        },
+        {
+          "code": "Q7620492",
+          "label": "storytelling game"
+        },
+        {
+          "code": "Q130728111",
+          "label": "existentialist video game"
+        },
+        {
+          "code": "Q113940304",
+          "label": "body horror video game"
+        },
+        {
+          "code": "Q123198217",
+          "label": "apocalyptic video game"
+        },
+        {
+          "code": "Q210980",
+          "label": "virtual community"
+        },
+        {
+          "code": "Q71443612",
+          "label": "wrestling video game"
+        },
+        {
+          "code": "Q6533560",
+          "label": "letter game"
+        },
+        {
+          "code": "Q97957575",
+          "label": "Japanese adventure"
+        },
+        {
+          "code": "Q11304653",
+          "label": "suspense film"
+        },
+        {
+          "code": "Q63914682",
+          "label": "drag racing video game"
+        },
+        {
+          "code": "Q11962358",
+          "label": "bridge simulator"
+        },
+        {
+          "code": "Q459435",
+          "label": "mockumentary"
+        },
+        {
+          "code": "Q114444607",
+          "label": "black comedy video game"
+        },
+        {
+          "code": "Q209075",
+          "label": "multiplayer game"
+        },
+        {
+          "code": "Q108099928",
+          "label": "billiard video game"
+        },
+        {
+          "code": "Q1054537",
+          "label": "retro style"
+        },
+        {
+          "code": "Q299191",
+          "label": "chess variant"
+        },
+        {
+          "code": "Q919036",
+          "label": "retrofuturism"
+        },
+        {
+          "code": "Q112078206",
+          "label": "analog horror"
+        },
+        {
+          "code": "Q6739884",
+          "label": "road trip"
+        },
+        {
+          "code": "Q65234770",
+          "label": "erotic game"
+        },
+        {
+          "code": "Q45045",
+          "label": "simulation"
+        },
+        {
+          "code": "Q120373215",
+          "label": "sliding puzzle video game"
+        },
+        {
+          "code": "Q185451",
+          "label": "strategy"
+        },
+        {
+          "code": "Q11771157",
+          "label": "massively multiplayer online strategy game"
+        },
+        {
+          "code": "Q537385",
+          "label": "fishing game"
+        },
+        {
+          "code": "Q111515101",
+          "label": "precision platformer"
+        },
+        {
+          "code": "Q1052059",
+          "label": "kyonyū"
+        },
+        {
+          "code": "Q2762504",
+          "label": "indie game"
+        },
+        {
+          "code": "Q1361181",
+          "label": "role-playing"
+        },
+        {
+          "code": "Q124973056",
+          "label": "cozy game"
+        },
+        {
+          "code": "Q18655723",
+          "label": "bara"
+        },
+        {
+          "code": "Q124040759",
+          "label": "abstract strategy video game"
+        },
+        {
+          "code": "Q83207",
+          "label": "crossword"
+        },
+        {
+          "code": "Q125288073",
+          "label": "combat racing"
+        },
+        {
+          "code": "Q1468908",
+          "label": "murder mystery game"
+        },
+        {
+          "code": "Q3641550",
+          "label": "body horror"
+        },
+        {
+          "code": "Q125648166",
+          "label": "found footage fiction"
+        },
+        {
+          "code": "Q100339660",
+          "label": "Christian fiction"
+        },
+        {
+          "code": "Q106943510",
+          "label": "surrealist fiction"
+        },
+        {
+          "code": "Q97621243",
+          "label": "Minecraft clone"
+        },
+        {
+          "code": "Q131698898",
+          "label": "snakes and ladders / chutes and ladders video game"
+        },
+        {
+          "code": "Q106869518",
+          "label": "memory game"
+        },
+        {
+          "code": "Q642946",
+          "label": "gamebook"
+        },
+        {
+          "code": "Q1515156",
+          "label": "dice game"
+        },
+        {
+          "code": "Q25416247",
+          "label": "skill-based video game"
+        },
+        {
+          "code": "Q123735476",
+          "label": "dress-up video game"
+        },
+        {
+          "code": "Q116236822",
+          "label": "dystopian video game"
+        },
+        {
+          "code": "Q1135821",
+          "label": "pixel art"
+        },
+        {
+          "code": "Q461524",
+          "label": "fan fiction"
+        },
+        {
+          "code": "Q132151524",
+          "label": "murder mystery game"
+        },
+        {
+          "code": "Q131521128",
+          "label": "furry"
+        },
+        {
+          "code": "Q116278106",
+          "label": "survival sandbox video game"
+        },
+        {
+          "code": "Q12221140",
+          "label": "parallel universe fiction"
+        },
+        {
+          "code": "Q116175427",
+          "label": "Western video game"
+        },
+        {
+          "code": "Q8253",
+          "label": "fiction"
+        },
+        {
+          "code": "Q1978641",
+          "label": "Netorare"
+        },
+        {
+          "code": "Q173167",
+          "label": "electronic literature"
+        },
+        {
+          "code": "Q1196556",
+          "label": "hypertext fiction"
+        },
+        {
+          "code": "Q6158564",
+          "label": "Japanese detective fiction"
+        },
+        {
+          "code": "Q919982",
+          "label": "digital poetry"
+        },
+        {
+          "code": "Q60616125",
+          "label": "political video game"
+        },
+        {
+          "code": "Q121494280",
+          "label": "generative literature"
+        },
+        {
+          "code": "Q15220419",
+          "label": "word game"
+        },
+        {
+          "code": "Q60617925",
+          "label": "logic video game"
+        },
+        {
+          "code": "Q120373196",
+          "label": "tactical video game"
+        },
+        {
+          "code": "Q129655881",
+          "label": "rock-paper-scissors video game"
+        },
+        {
+          "code": "Q16381999",
+          "label": "Myst-like"
+        },
+        {
+          "code": "Q124694932",
+          "label": "farm life sim"
+        },
+        {
+          "code": "Q130287894",
+          "label": "job simulation video game"
+        },
+        {
+          "code": "Q867123",
+          "label": "open world"
+        },
+        {
+          "code": "Q15804899",
+          "label": "deck-building game"
+        },
+        {
+          "code": "Q124365333",
+          "label": "mecha video game"
+        },
+        {
+          "code": "Q116236836",
+          "label": "action horror video game"
+        }
+      ],
+    "developers": [
+        {
+          "code": "Q742887",
+          "label": "Cinematronics"
+        },
+        {
+          "code": "Q744761",
+          "label": "Spiderweb Software"
+        },
+        {
+          "code": "Q742561",
+          "label": "Infocom"
+        },
+        {
+          "code": "Q743717",
+          "label": "Irrational Games"
+        },
+        {
+          "code": "Q743712",
+          "label": "Black Isle Studios"
+        },
+        {
+          "code": "Q24188",
+          "label": "Sega Sports R&D"
+        },
+        {
+          "code": "Q24228",
+          "label": "Halo Studios"
+        },
+        {
+          "code": "Q26188",
+          "label": "Kalypso Media"
+        },
+        {
+          "code": "Q23901",
+          "label": "Codemasters"
+        },
+        {
+          "code": "Q1467154",
+          "label": "Quintet"
+        },
+        {
+          "code": "Q1474023",
+          "label": "Funatics Software"
+        },
+        {
+          "code": "Q1466835",
+          "label": "Metropolis Software"
+        },
+        {
+          "code": "Q1470335",
+          "label": "SCS Software"
+        },
+        {
+          "code": "Q1493857",
+          "label": "GarageGames"
+        },
+        {
+          "code": "Q1493042",
+          "label": "Game Arts"
+        },
+        {
+          "code": "Q1484338",
+          "label": "G.rev"
+        },
+        {
+          "code": "Q481968",
+          "label": "Acquire"
+        },
+        {
+          "code": "Q467598",
+          "label": "Cryptic Studios"
+        },
+        {
+          "code": "Q417230",
+          "label": "Akella"
+        },
+        {
+          "code": "Q453802",
+          "label": "Imagic"
+        },
+        {
+          "code": "Q459403",
+          "label": "Ambrosia Software"
+        },
+        {
+          "code": "Q483036",
+          "label": "NCSoft"
+        },
+        {
+          "code": "Q1049502",
+          "label": "Hudson Soft"
+        },
+        {
+          "code": "Q1051538",
+          "label": "Cauldron"
+        },
+        {
+          "code": "Q1053684",
+          "label": "Polyphony Digital"
+        },
+        {
+          "code": "Q1054754",
+          "label": "Type-Moon"
+        },
+        {
+          "code": "Q753684",
+          "label": "Atari SA"
+        },
+        {
+          "code": "Q752317",
+          "label": "EA Vancouver"
+        },
+        {
+          "code": "Q746059",
+          "label": "IO Interactive"
+        },
+        {
+          "code": "Q94937",
+          "label": "2K Games"
+        },
+        {
+          "code": "Q94933",
+          "label": "Take-Two Interactive"
+        },
+        {
+          "code": "Q498812",
+          "label": "Running with Scissors"
+        },
+        {
+          "code": "Q495305",
+          "label": "KOG Studios"
+        },
+        {
+          "code": "Q496710",
+          "label": "Webzen Games"
+        },
+        {
+          "code": "Q495054",
+          "label": "ArenaNet"
+        },
+        {
+          "code": "Q780528",
+          "label": "Atlus"
+        },
+        {
+          "code": "Q775680",
+          "label": "Monster Games"
+        },
+        {
+          "code": "Q778453",
+          "label": "Chunsoft"
+        },
+        {
+          "code": "Q775346",
+          "label": "Beenox"
+        },
+        {
+          "code": "Q779114",
+          "label": "Zen Studios"
+        },
+        {
+          "code": "Q116371",
+          "label": "Q-Games"
+        },
+        {
+          "code": "Q122741",
+          "label": "Sega"
+        },
+        {
+          "code": "Q115129",
+          "label": "Silicon Knights"
+        },
+        {
+          "code": "Q83765",
+          "label": "Ex-One"
+        },
+        {
+          "code": "Q94893",
+          "label": "Rockstar North"
+        },
+        {
+          "code": "Q784330",
+          "label": "Flagship Studios"
+        },
+        {
+          "code": "Q787163",
+          "label": "Haemimont Games"
+        },
+        {
+          "code": "Q782028",
+          "label": "Game Freak"
+        },
+        {
+          "code": "Q1058704",
+          "label": "Nerve Software"
+        },
+        {
+          "code": "Q1060165",
+          "label": "Riot Games"
+        },
+        {
+          "code": "Q1639517",
+          "label": "TimeGate Studios"
+        },
+        {
+          "code": "Q1617310",
+          "label": "Pendulo Studios, S.L."
+        },
+        {
+          "code": "Q1671616",
+          "label": "Introversion Software"
+        },
+        {
+          "code": "Q1640973",
+          "label": "Hyperion Entertainment"
+        },
+        {
+          "code": "Q1637338",
+          "label": "Nihon Bussan"
+        },
+        {
+          "code": "Q1686729",
+          "label": "Jellyvision"
+        },
+        {
+          "code": "Q869104",
+          "label": "Core Design"
+        },
+        {
+          "code": "Q870122",
+          "label": "Crytek UK"
+        },
+        {
+          "code": "Q870095",
+          "label": "Rovio Entertainment"
+        },
+        {
+          "code": "Q866301",
+          "label": "Capcom Vancouver"
+        },
+        {
+          "code": "Q1102774",
+          "label": "Clover Studio"
+        },
+        {
+          "code": "Q1098120",
+          "label": "High Moon Studios"
+        },
+        {
+          "code": "Q1101463",
+          "label": "Climax Entertainment"
+        },
+        {
+          "code": "Q1102069",
+          "label": "ClockStone"
+        },
+        {
+          "code": "Q1092500",
+          "label": "Nitroplus"
+        },
+        {
+          "code": "Q1576335",
+          "label": "Visceral Games"
+        },
+        {
+          "code": "Q1574191",
+          "label": "Hanako Games"
+        },
+        {
+          "code": "Q1576758",
+          "label": "Platinum Games"
+        },
+        {
+          "code": "Q1584831",
+          "label": "Mistwalker"
+        },
+        {
+          "code": "Q1576643",
+          "label": "Sulake Corporation"
+        },
+        {
+          "code": "Q45700",
+          "label": "Konami"
+        },
+        {
+          "code": "Q26222",
+          "label": "Wargaming Seattle"
+        },
+        {
+          "code": "Q28299",
+          "label": "Pandemic Studios"
+        },
+        {
+          "code": "Q860398",
+          "label": "Active Enterprises"
+        },
+        {
+          "code": "Q864366",
+          "label": "Lump of Sugar"
+        },
+        {
+          "code": "Q861343",
+          "label": "Tale of Tales"
+        },
+        {
+          "code": "Q846884",
+          "label": "Ubisoft Shanghai"
+        },
+        {
+          "code": "Q864258",
+          "label": "Akabeisoft2"
+        },
+        {
+          "code": "Q863618",
+          "label": "Feral Interactive"
+        },
+        {
+          "code": "Q130763",
+          "label": "Tripwire Interactive"
+        },
+        {
+          "code": "Q130744",
+          "label": "Playground Games"
+        },
+        {
+          "code": "Q133482",
+          "label": "Visual Concepts"
+        },
+        {
+          "code": "Q137086",
+          "label": "Mindware Studios"
+        },
+        {
+          "code": "Q149947",
+          "label": "Midway Games"
+        },
+        {
+          "code": "Q1570468",
+          "label": "Mindscape"
+        },
+        {
+          "code": "Q1548159",
+          "label": "Criterion Games"
+        },
+        {
+          "code": "Q1563379",
+          "label": "Paon DP"
+        },
+        {
+          "code": "Q1573316",
+          "label": "SakeVisual"
+        },
+        {
+          "code": "Q1573432",
+          "label": "HeroCraft"
+        },
+        {
+          "code": "Q1546111",
+          "label": "Troika Games"
+        },
+        {
+          "code": "Q1062171",
+          "label": "The 3DO Company"
+        },
+        {
+          "code": "Q1061580",
+          "label": "Atari Games"
+        },
+        {
+          "code": "Q1062986",
+          "label": "Raven Software"
+        },
+        {
+          "code": "Q1064703",
+          "label": "PopCap Games"
+        },
+        {
+          "code": "Q800120",
+          "label": "Humongous Entertainment"
+        },
+        {
+          "code": "Q827153",
+          "label": "Surreal Software"
+        },
+        {
+          "code": "Q794750",
+          "label": "Bigbig Studios"
+        },
+        {
+          "code": "Q821910",
+          "label": "Team Soho"
+        },
+        {
+          "code": "Q821191",
+          "label": "Eat Sleep Play"
+        },
+        {
+          "code": "Q804201",
+          "label": "Black Hole Entertainment"
+        },
+        {
+          "code": "Q795583",
+          "label": "NEOWIZ"
+        },
+        {
+          "code": "Q553658",
+          "label": "Deep Silver"
+        },
+        {
+          "code": "Q547808",
+          "label": "Budcat Creations"
+        },
+        {
+          "code": "Q549221",
+          "label": "Spellbound Entertainment"
+        },
+        {
+          "code": "Q174891",
+          "label": "DTP entertainment"
+        },
+        {
+          "code": "Q169198",
+          "label": "10tacle Studios"
+        },
+        {
+          "code": "Q172323",
+          "label": "Ubisoft Romania"
+        },
+        {
+          "code": "Q166953",
+          "label": "RedLynx"
+        },
+        {
+          "code": "Q170420",
+          "label": "Nintendo Entertainment Analysis & Development"
+        },
+        {
+          "code": "Q174561",
+          "label": "Kemco"
+        },
+        {
+          "code": "Q1193678",
+          "label": "Origin Systems"
+        },
+        {
+          "code": "Q1194689",
+          "label": "Bandai Namco Entertainment"
+        },
+        {
+          "code": "Q1200947",
+          "label": "Destination Games"
+        },
+        {
+          "code": "Q1202130",
+          "label": "Robot Entertainment"
+        },
+        {
+          "code": "Q1204929",
+          "label": "2K Marin"
+        },
+        {
+          "code": "Q1502293",
+          "label": "Genki"
+        },
+        {
+          "code": "Q1515682",
+          "label": "Radical Entertainment"
+        },
+        {
+          "code": "Q1502832",
+          "label": "Reality Pump Studios"
+        },
+        {
+          "code": "Q1501379",
+          "label": "Parker Brothers"
+        },
+        {
+          "code": "Q164716",
+          "label": "Crytek"
+        },
+        {
+          "code": "Q150001",
+          "label": "Intelligent Systems"
+        },
+        {
+          "code": "Q161223",
+          "label": "07th Expansion"
+        },
+        {
+          "code": "Q1137822",
+          "label": "Gala"
+        },
+        {
+          "code": "Q1136222",
+          "label": "2K Los Angeles"
+        },
+        {
+          "code": "Q1136248",
+          "label": "Gotham Games"
+        },
+        {
+          "code": "Q1140960",
+          "label": "Sonic Team"
+        },
+        {
+          "code": "Q1134915",
+          "label": "Milestone S.r.l."
+        },
+        {
+          "code": "Q1136254",
+          "label": "BlueSky Software"
+        },
+        {
+          "code": "Q1146905",
+          "label": "Cyan Worlds"
+        },
+        {
+          "code": "Q1143795",
+          "label": "August"
+        },
+        {
+          "code": "Q1143659",
+          "label": "Nippon Ichi Software"
+        },
+        {
+          "code": "Q1157042",
+          "label": "Daedalic Entertainment"
+        },
+        {
+          "code": "Q1154544",
+          "label": "Navel"
+        },
+        {
+          "code": "Q1827127",
+          "label": "Linux Game Publishing"
+        },
+        {
+          "code": "Q1849951",
+          "label": "Milestone"
+        },
+        {
+          "code": "Q1850424",
+          "label": "Microids"
+        },
+        {
+          "code": "Q1831780",
+          "label": "Rockstar Lincoln"
+        },
+        {
+          "code": "Q1884071",
+          "label": "Magic Bytes"
+        },
+        {
+          "code": "Q1868589",
+          "label": "Loki Entertainment"
+        },
+        {
+          "code": "Q488510",
+          "label": "WeMade Entertainment"
+        },
+        {
+          "code": "Q489262",
+          "label": "Wizet"
+        },
+        {
+          "code": "Q483314",
+          "label": "Hangame"
+        },
+        {
+          "code": "Q484143",
+          "label": "Gravity Corporation"
+        },
+        {
+          "code": "Q494614",
+          "label": "Sierra Entertainment"
+        },
+        {
+          "code": "Q483233",
+          "label": "Ntreev Soft"
+        },
+        {
+          "code": "Q488551",
+          "label": "Pentavision"
+        },
+        {
+          "code": "Q1193145",
+          "label": "Slightly Mad Studios"
+        },
+        {
+          "code": "Q1191897",
+          "label": "Grasshopper Manufacture"
+        },
+        {
+          "code": "Q1193116",
+          "label": "Turtle Rock Studios"
+        },
+        {
+          "code": "Q1191932",
+          "label": "0verflow"
+        },
+        {
+          "code": "Q1134504",
+          "label": "Moonstone"
+        },
+        {
+          "code": "Q1130046",
+          "label": "LightBox Interactive"
+        },
+        {
+          "code": "Q1131475",
+          "label": "Looking Glass Studios"
+        },
+        {
+          "code": "Q1129765",
+          "label": "Warashi"
+        },
+        {
+          "code": "Q1129295",
+          "label": "Mojang Studios"
+        },
+        {
+          "code": "Q1747400",
+          "label": "Paradox France"
+        },
+        {
+          "code": "Q1725456",
+          "label": "The Chinese Room"
+        },
+        {
+          "code": "Q1770526",
+          "label": "Beautiful Game Studios"
+        },
+        {
+          "code": "Q1707830",
+          "label": "Sanzaru Games"
+        },
+        {
+          "code": "Q1742126",
+          "label": "KingsIsle Entertainment"
+        },
+        {
+          "code": "Q1750959",
+          "label": "Rockstar Leeds"
+        },
+        {
+          "code": "Q1758803",
+          "label": "Oddworld Inhabitants"
+        },
+        {
+          "code": "Q586564",
+          "label": "Illusion"
+        },
+        {
+          "code": "Q597020",
+          "label": "Danger Close Games"
+        },
+        {
+          "code": "Q582666",
+          "label": "Nitrome"
+        },
+        {
+          "code": "Q598181",
+          "label": "Team Silent"
+        },
+        {
+          "code": "Q77202",
+          "label": "1C Company"
+        },
+        {
+          "code": "Q71930",
+          "label": "Cryo Interactive"
+        },
+        {
+          "code": "Q73801",
+          "label": "Xbox Game Studios"
+        },
+        {
+          "code": "Q1809234",
+          "label": "Hothouse Creations"
+        },
+        {
+          "code": "Q1806630",
+          "label": "Silmarils"
+        },
+        {
+          "code": "Q1786683",
+          "label": "Playfish"
+        },
+        {
+          "code": "Q1806887",
+          "label": "Ritual Entertainment"
+        },
+        {
+          "code": "Q1812475",
+          "label": "Stainless Games"
+        },
+        {
+          "code": "Q1799063",
+          "label": "People Can Fly"
+        },
+        {
+          "code": "Q204961",
+          "label": "Pterodon"
+        },
+        {
+          "code": "Q212092",
+          "label": "Black Forest Games"
+        },
+        {
+          "code": "Q205500",
+          "label": "Zipper Interactive"
+        },
+        {
+          "code": "Q207784",
+          "label": "Square Enix"
+        },
+        {
+          "code": "Q527336",
+          "label": "Atari, Inc."
+        },
+        {
+          "code": "Q514059",
+          "label": "Nadeo"
+        },
+        {
+          "code": "Q521489",
+          "label": "Amaze Entertainment"
+        },
+        {
+          "code": "Q531167",
+          "label": "Retro Studios"
+        },
+        {
+          "code": "Q542018",
+          "label": "PlayStation Studios"
+        },
+        {
+          "code": "Q540817",
+          "label": "Mighty Rocket Studio"
+        },
+        {
+          "code": "Q756147",
+          "label": "Wanako Studios"
+        },
+        {
+          "code": "Q758030",
+          "label": "Attic Entertainment Software"
+        },
+        {
+          "code": "Q756510",
+          "label": "Invictus Games"
+        },
+        {
+          "code": "Q765389",
+          "label": "Lionhead Studios"
+        },
+        {
+          "code": "Q758872",
+          "label": "Audiogenic"
+        },
+        {
+          "code": "Q760096",
+          "label": "Culture Brain"
+        },
+        {
+          "code": "Q769354",
+          "label": "Red Storm Entertainment"
+        },
+        {
+          "code": "Q766278",
+          "label": "Digital Chocolate"
+        },
+        {
+          "code": "Q188273",
+          "label": "Ubisoft"
+        },
+        {
+          "code": "Q193559",
+          "label": "Valve Corporation"
+        },
+        {
+          "code": "Q577108",
+          "label": "Fox Interactive"
+        },
+        {
+          "code": "Q571862",
+          "label": "Page 44 Studios"
+        },
+        {
+          "code": "Q580866",
+          "label": "THQ"
+        },
+        {
+          "code": "Q579796",
+          "label": "Hasbro Interactive"
+        },
+        {
+          "code": "Q200491",
+          "label": "Activision Publishing"
+        },
+        {
+          "code": "Q195722",
+          "label": "Grateful Days"
+        },
+        {
+          "code": "Q1782700",
+          "label": "Infogrames"
+        },
+        {
+          "code": "Q1783815",
+          "label": "Ninja Theory"
+        },
+        {
+          "code": "Q1781791",
+          "label": "Namco Tales Studio"
+        },
+        {
+          "code": "Q1774120",
+          "label": "Kee Games"
+        },
+        {
+          "code": "Q130729",
+          "label": "Turn 10 Studios"
+        },
+        {
+          "code": "Q123018",
+          "label": "Nintendo Software Technology"
+        },
+        {
+          "code": "Q128523",
+          "label": "Silverball Studios"
+        },
+        {
+          "code": "Q1091035",
+          "label": "Success"
+        },
+        {
+          "code": "Q1092474",
+          "label": "Cinemaware"
+        },
+        {
+          "code": "Q1068734",
+          "label": "HAL Laboratory"
+        },
+        {
+          "code": "Q1087007",
+          "label": "Papyrus Design Group"
+        },
+        {
+          "code": "Q1172213",
+          "label": "Data East"
+        },
+        {
+          "code": "Q1187058",
+          "label": "Twilight Frontier"
+        },
+        {
+          "code": "Q1187273",
+          "label": "Pyro Studios"
+        },
+        {
+          "code": "Q1188050",
+          "label": "Treasure"
+        },
+        {
+          "code": "Q1172164",
+          "label": "CD Projekt RED"
+        },
+        {
+          "code": "Q1177836",
+          "label": "Davilex Games"
+        },
+        {
+          "code": "Q932631",
+          "label": "Team Ico"
+        },
+        {
+          "code": "Q937967",
+          "label": "Planet Moon Studios"
+        },
+        {
+          "code": "Q947583",
+          "label": "Gray Matter Interactive"
+        },
+        {
+          "code": "Q941340",
+          "label": "Muse Software"
+        },
+        {
+          "code": "Q935573",
+          "label": "Altar Games"
+        },
+        {
+          "code": "Q945060",
+          "label": "Ubisoft Reflections"
+        },
+        {
+          "code": "Q1517179",
+          "label": "System 3"
+        },
+        {
+          "code": "Q1526729",
+          "label": "Luxoflux"
+        },
+        {
+          "code": "Q1542578",
+          "label": "Rockstar New England"
+        },
+        {
+          "code": "Q1518612",
+          "label": "Relic Entertainment"
+        },
+        {
+          "code": "Q1537551",
+          "label": "Goodgame Studios"
+        },
+        {
+          "code": "Q1517669",
+          "label": "No Cliché"
+        },
+        {
+          "code": "Q1517490",
+          "label": "Iron Lore Entertainment"
+        },
+        {
+          "code": "Q1534407",
+          "label": "Fountainhead Entertainment"
+        },
+        {
+          "code": "Q512003",
+          "label": "Creatures"
+        },
+        {
+          "code": "Q507269",
+          "label": "Bandai"
+        },
+        {
+          "code": "Q511988",
+          "label": "DR Studios"
+        },
+        {
+          "code": "Q500799",
+          "label": "Ubisoft Toronto"
+        },
+        {
+          "code": "Q923047",
+          "label": "989 Studios"
+        },
+        {
+          "code": "Q928122",
+          "label": "Crystal Dynamics"
+        },
+        {
+          "code": "Q930222",
+          "label": "Sir-Tech"
+        },
+        {
+          "code": "Q927312",
+          "label": "Simtex"
+        },
+        {
+          "code": "Q871504",
+          "label": "Giga"
+        },
+        {
+          "code": "Q890779",
+          "label": "Bohemia Interactive"
+        },
+        {
+          "code": "Q870894",
+          "label": "Egosoft"
+        },
+        {
+          "code": "Q875485",
+          "label": "Max Design"
+        },
+        {
+          "code": "Q878724",
+          "label": "Bit Corporation"
+        },
+        {
+          "code": "Q885920",
+          "label": "Blue Tongue Entertainment"
+        },
+        {
+          "code": "Q1972036",
+          "label": "Buka Entertainment"
+        },
+        {
+          "code": "Q1979024",
+          "label": "Totally Games"
+        },
+        {
+          "code": "Q1956256",
+          "label": "Hidden Path Entertainment"
+        },
+        {
+          "code": "Q1933462",
+          "label": "SCE Studio Liverpool"
+        },
+        {
+          "code": "Q1944894",
+          "label": "Monkeystone Games"
+        },
+        {
+          "code": "Q1947354",
+          "label": "Vicarious Visions"
+        },
+        {
+          "code": "Q1143528",
+          "label": "Key"
+        },
+        {
+          "code": "Q1141245",
+          "label": "Insomniac Games"
+        },
+        {
+          "code": "Q1142226",
+          "label": "Nihon Falcom"
+        },
+        {
+          "code": "Q1268871",
+          "label": "Strategic Simulations"
+        },
+        {
+          "code": "Q1269052",
+          "label": "Dynamix"
+        },
+        {
+          "code": "Q1283542",
+          "label": "Eden Games"
+        },
+        {
+          "code": "Q1317020",
+          "label": "Tarsier Studios"
+        },
+        {
+          "code": "Q1296433",
+          "label": "Technosoft"
+        },
+        {
+          "code": "Q1304727",
+          "label": "VIS Entertainment"
+        },
+        {
+          "code": "Q903621",
+          "label": "Ubisoft Montreal"
+        },
+        {
+          "code": "Q907331",
+          "label": "Distinctive Software"
+        },
+        {
+          "code": "Q907357",
+          "label": "Monolith Productions"
+        },
+        {
+          "code": "Q185613",
+          "label": "Nival Interactive"
+        },
+        {
+          "code": "Q178824",
+          "label": "Blizzard Entertainment"
+        },
+        {
+          "code": "Q625647",
+          "label": "Netmarble"
+        },
+        {
+          "code": "Q637851",
+          "label": "Playdom"
+        },
+        {
+          "code": "Q642707",
+          "label": "Rare Ltd."
+        },
+        {
+          "code": "Q628249",
+          "label": "Interplay Entertainment"
+        },
+        {
+          "code": "Q845047",
+          "label": "Koei"
+        },
+        {
+          "code": "Q840550",
+          "label": "Alfa System"
+        },
+        {
+          "code": "Q834035",
+          "label": "Deck13 Interactive"
+        },
+        {
+          "code": "Q835847",
+          "label": "Digital Anvil"
+        },
+        {
+          "code": "Q830947",
+          "label": "Remedy Entertainment"
+        },
+        {
+          "code": "Q668735",
+          "label": "Big Fish Games"
+        },
+        {
+          "code": "Q672642",
+          "label": "Arkane Studios"
+        },
+        {
+          "code": "Q673888",
+          "label": "InnoGames"
+        },
+        {
+          "code": "Q672664",
+          "label": "Black Rock Studio"
+        },
+        {
+          "code": "Q671855",
+          "label": "Bug-Byte"
+        },
+        {
+          "code": "Q1925056",
+          "label": "Metanet Software"
+        },
+        {
+          "code": "Q1930918",
+          "label": "U.S. Gold"
+        },
+        {
+          "code": "Q564275",
+          "label": "Red Entertainment"
+        },
+        {
+          "code": "Q562078",
+          "label": "Nexon"
+        },
+        {
+          "code": "Q561385",
+          "label": "Travian Games"
+        },
+        {
+          "code": "Q565073",
+          "label": "Rainbow Arts"
+        },
+        {
+          "code": "Q570081",
+          "label": "Quantic Dream"
+        },
+        {
+          "code": "Q217493",
+          "label": "Paradox Interactive"
+        },
+        {
+          "code": "Q216611",
+          "label": "Lucasfilm Games"
+        },
+        {
+          "code": "Q1988059",
+          "label": "Bizarre Creations"
+        },
+        {
+          "code": "Q1989672",
+          "label": "Rockstar Toronto"
+        },
+        {
+          "code": "Q1986442",
+          "label": "Rage Games"
+        },
+        {
+          "code": "Q1984338",
+          "label": "Gaijin Entertainment"
+        },
+        {
+          "code": "Q1985279",
+          "label": "AlphaDream"
+        },
+        {
+          "code": "Q1239326",
+          "label": "Monolith Soft Inc."
+        },
+        {
+          "code": "Q1251435",
+          "label": "Double Fine"
+        },
+        {
+          "code": "Q1254065",
+          "label": "San Mateo Studio"
+        },
+        {
+          "code": "Q1254072",
+          "label": "San Diego Studio"
+        },
+        {
+          "code": "Q604213",
+          "label": "Nowcom"
+        },
+        {
+          "code": "Q601299",
+          "label": "Video System"
+        },
+        {
+          "code": "Q600338",
+          "label": "Big Huge Games"
+        },
+        {
+          "code": "Q610952",
+          "label": "n-Space"
+        },
+        {
+          "code": "Q610824",
+          "label": "Ubisoft Kyiv"
+        },
+        {
+          "code": "Q611487",
+          "label": "Bullfrog Productions"
+        },
+        {
+          "code": "Q2002760",
+          "label": "NovaLogic"
+        },
+        {
+          "code": "Q2012641",
+          "label": "Evryware"
+        },
+        {
+          "code": "Q2030718",
+          "label": "Rebellion Developments"
+        },
+        {
+          "code": "Q2023846",
+          "label": "Enlight Software"
+        },
+        {
+          "code": "Q2018532",
+          "label": "Love-de-Lic"
+        },
+        {
+          "code": "Q2020713",
+          "label": "Rockstar Vancouver"
+        },
+        {
+          "code": "Q684218",
+          "label": "Cavedog Entertainment"
+        },
+        {
+          "code": "Q684780",
+          "label": "Camelot Software Planning"
+        },
+        {
+          "code": "Q684425",
+          "label": "Bethesda Softworks"
+        },
+        {
+          "code": "Q689093",
+          "label": "Gameloft"
+        },
+        {
+          "code": "Q2080076",
+          "label": "Behaviour Interactive"
+        },
+        {
+          "code": "Q2081220",
+          "label": "The Sims Studio"
+        },
+        {
+          "code": "Q2080159",
+          "label": "ACE Team"
+        },
+        {
+          "code": "Q613801",
+          "label": "Kuju Ltd."
+        },
+        {
+          "code": "Q617752",
+          "label": "Irem"
+        },
+        {
+          "code": "Q617925",
+          "label": "Saffire"
+        },
+        {
+          "code": "Q615181",
+          "label": "Strategic Studies Group"
+        },
+        {
+          "code": "Q611508",
+          "label": "Creative Assembly"
+        },
+        {
+          "code": "Q616651",
+          "label": "Triumph Studios"
+        },
+        {
+          "code": "Q679933",
+          "label": "Eidos Interactive"
+        },
+        {
+          "code": "Q674686",
+          "label": "Level-5"
+        },
+        {
+          "code": "Q677273",
+          "label": "Piranha Bytes"
+        },
+        {
+          "code": "Q682039",
+          "label": "2D Boy"
+        },
+        {
+          "code": "Q980440",
+          "label": "The Omni Group"
+        },
+        {
+          "code": "Q977906",
+          "label": "Monte Cristo"
+        },
+        {
+          "code": "Q980729",
+          "label": "Firefly Studios"
+        },
+        {
+          "code": "Q974657",
+          "label": "Wooga"
+        },
+        {
+          "code": "Q979198",
+          "label": "ICOM Simulations"
+        },
+        {
+          "code": "Q976444",
+          "label": "Frog City Software"
+        },
+        {
+          "code": "Q991149",
+          "label": "1-Up Studio"
+        },
+        {
+          "code": "Q651140",
+          "label": "Media Molecule"
+        },
+        {
+          "code": "Q649297",
+          "label": "StormRegion"
+        },
+        {
+          "code": "Q651089",
+          "label": "Ascaron"
+        },
+        {
+          "code": "Q655493",
+          "label": "Petroglyph Games"
+        },
+        {
+          "code": "Q652421",
+          "label": "MicroProse"
+        },
+        {
+          "code": "Q2062521",
+          "label": "Grin"
+        },
+        {
+          "code": "Q2065466",
+          "label": "Terminal Reality"
+        },
+        {
+          "code": "Q2043303",
+          "label": "Future Games"
+        },
+        {
+          "code": "Q2061879",
+          "label": "SimBin"
+        },
+        {
+          "code": "Q2060066",
+          "label": "Revolution Software"
+        },
+        {
+          "code": "Q2039757",
+          "label": "Takumi Corporation"
+        },
+        {
+          "code": "Q2054310",
+          "label": "Nintendo Software Planning & Development"
+        },
+        {
+          "code": "Q266418",
+          "label": "London Studio"
+        },
+        {
+          "code": "Q263787",
+          "label": "Sunflowers Interactive Entertainment Software"
+        },
+        {
+          "code": "Q250426",
+          "label": "EA Mobile"
+        },
+        {
+          "code": "Q256907",
+          "label": "Argonaut Games"
+        },
+        {
+          "code": "Q258729",
+          "label": "Artificial Studios"
+        },
+        {
+          "code": "Q357663",
+          "label": "Legend Entertainment"
+        },
+        {
+          "code": "Q340209",
+          "label": "Shiny Entertainment"
+        },
+        {
+          "code": "Q369089",
+          "label": "Google Arts & Culture"
+        },
+        {
+          "code": "Q372471",
+          "label": "Wargaming"
+        },
+        {
+          "code": "Q1347787",
+          "label": "Epyx"
+        },
+        {
+          "code": "Q1358743",
+          "label": "Technōs Japan Corporation"
+        },
+        {
+          "code": "Q1358751",
+          "label": "Runic Games"
+        },
+        {
+          "code": "Q1344080",
+          "label": "Jaleco"
+        },
+        {
+          "code": "Q2298387",
+          "label": "Sun Corporation"
+        },
+        {
+          "code": "Q2291232",
+          "label": "Toaplan"
+        },
+        {
+          "code": "Q2291482",
+          "label": "Rockstar Vienna"
+        },
+        {
+          "code": "Q2298950",
+          "label": "Starbreeze Studios"
+        },
+        {
+          "code": "Q2290725",
+          "label": "Sensible Software"
+        },
+        {
+          "code": "Q921944",
+          "label": "Focus Entertainment"
+        },
+        {
+          "code": "Q907871",
+          "label": "Leaf"
+        },
+        {
+          "code": "Q916365",
+          "label": "Psikyo"
+        },
+        {
+          "code": "Q912291",
+          "label": "Mitchell Corporation"
+        },
+        {
+          "code": "Q918638",
+          "label": "Funcom"
+        },
+        {
+          "code": "Q916714",
+          "label": "Sucker Punch Productions"
+        },
+        {
+          "code": "Q1328536",
+          "label": "Sega Studios San Francisco"
+        },
+        {
+          "code": "Q1340558",
+          "label": "Ready at Dawn"
+        },
+        {
+          "code": "Q1343212",
+          "label": "Enix"
+        },
+        {
+          "code": "Q1330823",
+          "label": "Elite Systems"
+        },
+        {
+          "code": "Q1317078",
+          "label": "Sora Ltd."
+        },
+        {
+          "code": "Q1318002",
+          "label": "Sledgehammer Games"
+        },
+        {
+          "code": "Q954877",
+          "label": "SETA Corporation"
+        },
+        {
+          "code": "Q952164",
+          "label": "Hello Games"
+        },
+        {
+          "code": "Q956546",
+          "label": "Blue Sky Rangers"
+        },
+        {
+          "code": "Q958101",
+          "label": "Jagex"
+        },
+        {
+          "code": "Q959329",
+          "label": "Rockstar San Diego"
+        },
+        {
+          "code": "Q1224739",
+          "label": "Digital Extremes"
+        },
+        {
+          "code": "Q1235040",
+          "label": "Domark Software"
+        },
+        {
+          "code": "Q1207809",
+          "label": "Gust Co. Ltd."
+        },
+        {
+          "code": "Q1229035",
+          "label": "Disney Interactive Studios"
+        },
+        {
+          "code": "Q1234918",
+          "label": "Philos Laboratories"
+        },
+        {
+          "code": "Q1418015",
+          "label": "Spectrum HoloByte"
+        },
+        {
+          "code": "Q1417011",
+          "label": "Wideload Games"
+        },
+        {
+          "code": "Q1418943",
+          "label": "Fireglow Games"
+        },
+        {
+          "code": "Q1420772",
+          "label": "Fishlabs"
+        },
+        {
+          "code": "Q1425540",
+          "label": "Indie Built"
+        },
+        {
+          "code": "Q1403157",
+          "label": "WMS Industries"
+        },
+        {
+          "code": "Q1408498",
+          "label": "Ocean Software"
+        },
+        {
+          "code": "Q726675",
+          "label": "FarSight Studios"
+        },
+        {
+          "code": "Q731482",
+          "label": "Infinity Ward"
+        },
+        {
+          "code": "Q727701",
+          "label": "Bend Studio"
+        },
+        {
+          "code": "Q726988",
+          "label": "Kalisto Entertainment"
+        },
+        {
+          "code": "Q245723",
+          "label": "Zylom"
+        },
+        {
+          "code": "Q229459",
+          "label": "3D Realms"
+        },
+        {
+          "code": "Q245772",
+          "label": "Zynga"
+        },
+        {
+          "code": "Q245456",
+          "label": "5th Cell"
+        },
+        {
+          "code": "Q240924",
+          "label": "Digital Reality"
+        },
+        {
+          "code": "Q238132",
+          "label": "4J Studios"
+        },
+        {
+          "code": "Q309996",
+          "label": "Namco"
+        },
+        {
+          "code": "Q308913",
+          "label": "Ensemble Studios"
+        },
+        {
+          "code": "Q2300984",
+          "label": "Titus Interactive"
+        },
+        {
+          "code": "Q2307159",
+          "label": "Rocksteady Studios"
+        },
+        {
+          "code": "Q2310169",
+          "label": "Spieleentwicklungskombinat"
+        },
+        {
+          "code": "Q2299192",
+          "label": "Impressions Games"
+        },
+        {
+          "code": "Q2310496",
+          "label": "Palace Software"
+        },
+        {
+          "code": "Q2136378",
+          "label": "RedSpotGames"
+        },
+        {
+          "code": "Q2176341",
+          "label": "RuneSoft"
+        },
+        {
+          "code": "Q2255185",
+          "label": "KID"
+        },
+        {
+          "code": "Q2165877",
+          "label": "Rondomedia"
+        },
+        {
+          "code": "Q2248318",
+          "label": "Ice-Pick Lodge"
+        },
+        {
+          "code": "Q2146772",
+          "label": "Joymax"
+        },
+        {
+          "code": "Q2164685",
+          "label": "The Bitmap Brothers"
+        },
+        {
+          "code": "Q2130108",
+          "label": "Toys for Bob"
+        },
+        {
+          "code": "Q2166710",
+          "label": "Roseverte"
+        },
+        {
+          "code": "Q2066242",
+          "label": "Techland"
+        },
+        {
+          "code": "Q2076545",
+          "label": "Wargaming West Corporation"
+        },
+        {
+          "code": "Q2070538",
+          "label": "Ganbarion"
+        },
+        {
+          "code": "Q2077224",
+          "label": "4A Games"
+        },
+        {
+          "code": "Q2073049",
+          "label": "2K China"
+        },
+        {
+          "code": "Q286153",
+          "label": "Kaos Studios"
+        },
+        {
+          "code": "Q287168",
+          "label": "iQue"
+        },
+        {
+          "code": "Q287560",
+          "label": "Gameforge"
+        },
+        {
+          "code": "Q294587",
+          "label": "Sega AM2"
+        },
+        {
+          "code": "Q286780",
+          "label": "thatgamecompany"
+        },
+        {
+          "code": "Q290567",
+          "label": "Hacker International"
+        },
+        {
+          "code": "Q219203",
+          "label": "NEC"
+        },
+        {
+          "code": "Q219758",
+          "label": "BioWare"
+        },
+        {
+          "code": "Q1386435",
+          "label": "F4"
+        },
+        {
+          "code": "Q1388106",
+          "label": "nStigate Games"
+        },
+        {
+          "code": "Q1389810",
+          "label": "Software 2000"
+        },
+        {
+          "code": "Q1384984",
+          "label": "Team17"
+        },
+        {
+          "code": "Q1383563",
+          "label": "Telltale Games"
+        },
+        {
+          "code": "Q382543",
+          "label": "Treyarch"
+        },
+        {
+          "code": "Q383538",
+          "label": "Compile"
+        },
+        {
+          "code": "Q375667",
+          "label": "Incognito Entertainment"
+        },
+        {
+          "code": "Q379959",
+          "label": "Adventure Soft"
+        },
+        {
+          "code": "Q959759",
+          "label": "Firaxis Games"
+        },
+        {
+          "code": "Q964885",
+          "label": "Boss Game Studios"
+        },
+        {
+          "code": "Q970264",
+          "label": "Neversoft"
+        },
+        {
+          "code": "Q972745",
+          "label": "Bugbear Entertainment"
+        },
+        {
+          "code": "Q959672",
+          "label": "Daybreak Game Company"
+        },
+        {
+          "code": "Q1906072",
+          "label": "Marvin Glass and Associates"
+        },
+        {
+          "code": "Q1923795",
+          "label": "Yuke's"
+        },
+        {
+          "code": "Q1884327",
+          "label": "Magnetic Fields"
+        },
+        {
+          "code": "Q1889419",
+          "label": "New World Computing"
+        },
+        {
+          "code": "Q1907767",
+          "label": "Massive Development"
+        },
+        {
+          "code": "Q1889791",
+          "label": "Splash Damage"
+        },
+        {
+          "code": "Q1911412",
+          "label": "Pivotal Games"
+        },
+        {
+          "code": "Q1023734",
+          "label": "Cing"
+        },
+        {
+          "code": "Q995863",
+          "label": "Broderbund"
+        },
+        {
+          "code": "Q1001380",
+          "label": "BudgeCo"
+        },
+        {
+          "code": "Q1022372",
+          "label": "Kronos Digital Entertainment"
+        },
+        {
+          "code": "Q1023055",
+          "label": "CCP Games"
+        },
+        {
+          "code": "Q994003",
+          "label": "Evolution Studios"
+        },
+        {
+          "code": "Q97515952",
+          "label": "Fiendish Games"
+        },
+        {
+          "code": "Q97584703",
+          "label": "looterkings"
+        },
+        {
+          "code": "Q97657838",
+          "label": "The New Dimension"
+        },
+        {
+          "code": "Q98320548",
+          "label": "PIXIS Interactive"
+        },
+        {
+          "code": "Q98471532",
+          "label": "Bit Kid"
+        },
+        {
+          "code": "Q98539282",
+          "label": "Team Chex Quest HD"
+        },
+        {
+          "code": "Q97884048",
+          "label": "Lose"
+        },
+        {
+          "code": "Q97534061",
+          "label": "VooFoo Studios"
+        },
+        {
+          "code": "Q97704769",
+          "label": "Different Tales"
+        },
+        {
+          "code": "Q97883632",
+          "label": "7th Beat Games"
+        },
+        {
+          "code": "Q98399441",
+          "label": "Ice Bytes"
+        },
+        {
+          "code": "Q97656929",
+          "label": "hap inc."
+        },
+        {
+          "code": "Q98409855",
+          "label": "V1 Interactive"
+        },
+        {
+          "code": "Q97515864",
+          "label": "SoWhat! Software Studios"
+        },
+        {
+          "code": "Q97704292",
+          "label": "DesignWare"
+        },
+        {
+          "code": "Q97705086",
+          "label": "Headsoft"
+        },
+        {
+          "code": "Q97855436",
+          "label": "Icarus Studios"
+        },
+        {
+          "code": "Q97883518",
+          "label": "Cabbage Soft"
+        },
+        {
+          "code": "Q98411159",
+          "label": "Camouflaj"
+        },
+        {
+          "code": "Q97658495",
+          "label": "Big Pixel Studio"
+        },
+        {
+          "code": "Q97654690",
+          "label": "Mattel Electronics"
+        },
+        {
+          "code": "Q98204511",
+          "label": "Superdove Games"
+        },
+        {
+          "code": "Q98456345",
+          "label": "Precursor Games"
+        },
+        {
+          "code": "Q98521417",
+          "label": "Thunkspace"
+        },
+        {
+          "code": "Q97584474",
+          "label": "Dan & Gary Games"
+        },
+        {
+          "code": "Q97750855",
+          "label": "Silent Software"
+        },
+        {
+          "code": "Q97774087",
+          "label": "Glumberland"
+        },
+        {
+          "code": "Q98154700",
+          "label": "Twinbeard Studios"
+        },
+        {
+          "code": "Q98430180",
+          "label": "Draw Me A Pixel"
+        },
+        {
+          "code": "Q224593",
+          "label": "Snail"
+        },
+        {
+          "code": "Q220317",
+          "label": "Maxis"
+        },
+        {
+          "code": "Q222045",
+          "label": "2K Czech"
+        },
+        {
+          "code": "Q1361716",
+          "label": "D3 Publisher"
+        },
+        {
+          "code": "Q1371744",
+          "label": "Banpresto"
+        },
+        {
+          "code": "Q1372258",
+          "label": "Tokuma Shoten"
+        },
+        {
+          "code": "Q1360172",
+          "label": "N3V Games"
+        },
+        {
+          "code": "Q1377647",
+          "label": "Team Shanghai Alice"
+        },
+        {
+          "code": "Q1438774",
+          "label": "Supercell"
+        },
+        {
+          "code": "Q1425861",
+          "label": "GSC Game World"
+        },
+        {
+          "code": "Q722027",
+          "label": "DICE"
+        },
+        {
+          "code": "Q702550",
+          "label": "International Games System"
+        },
+        {
+          "code": "Q720871",
+          "label": "Naughty Dog"
+        },
+        {
+          "code": "Q99930405",
+          "label": "Five Studio Interactive"
+        },
+        {
+          "code": "Q100138679",
+          "label": "SquarePlay Games"
+        },
+        {
+          "code": "Q100268675",
+          "label": "In-D Gaming"
+        },
+        {
+          "code": "Q99541359",
+          "label": "Secret Door"
+        },
+        {
+          "code": "Q100268798",
+          "label": "Kinetic Games"
+        },
+        {
+          "code": "Q99601310",
+          "label": "FMV Future Limited"
+        },
+        {
+          "code": "Q100372424",
+          "label": "Runner Duck"
+        },
+        {
+          "code": "Q100491716",
+          "label": "Yendis Entertainment"
+        },
+        {
+          "code": "Q99841965",
+          "label": "Magellan Interactive"
+        },
+        {
+          "code": "Q100371924",
+          "label": "Coatsink"
+        },
+        {
+          "code": "Q99541342",
+          "label": "Moonshot Games"
+        },
+        {
+          "code": "Q99941833",
+          "label": "Liquid Bit, LLC"
+        },
+        {
+          "code": "Q99968931",
+          "label": "HyperSloth"
+        },
+        {
+          "code": "Q100158587",
+          "label": "New Game Order"
+        },
+        {
+          "code": "Q100343122",
+          "label": "Stormind Games"
+        },
+        {
+          "code": "Q100594219",
+          "label": "Electric Dreams"
+        },
+        {
+          "code": "Q99826060",
+          "label": "Shedworks"
+        },
+        {
+          "code": "Q99941973",
+          "label": "BumbleBear Games"
+        },
+        {
+          "code": "Q100253374",
+          "label": "Total Mayhem Games"
+        },
+        {
+          "code": "Q100371784",
+          "label": "High Tea Frog"
+        },
+        {
+          "code": "Q100333041",
+          "label": "Glass Heart Games"
+        },
+        {
+          "code": "Q100392934",
+          "label": "Darkflow Software"
+        },
+        {
+          "code": "Q99843572",
+          "label": "RASK"
+        },
+        {
+          "code": "Q100152576",
+          "label": "Softie"
+        },
+        {
+          "code": "Q100319374",
+          "label": "Romans I XVI Gaming"
+        },
+        {
+          "code": "Q100333036",
+          "label": "Alter Games"
+        },
+        {
+          "code": "Q100377389",
+          "label": "Eminoma"
+        },
+        {
+          "code": "Q100392399",
+          "label": "Nolla Games"
+        },
+        {
+          "code": "Q100400528",
+          "label": "Stone Lantern Games"
+        },
+        {
+          "code": "Q742390",
+          "label": "Dimps"
+        },
+        {
+          "code": "Q739711",
+          "label": "Epic Games"
+        },
+        {
+          "code": "Q11228013",
+          "label": "Klein"
+        },
+        {
+          "code": "Q11254284",
+          "label": "Whirlpool"
+        },
+        {
+          "code": "Q11235745",
+          "label": "NMK"
+        },
+        {
+          "code": "Q11247140",
+          "label": "sprite"
+        },
+        {
+          "code": "Q11228542",
+          "label": "Kiss"
+        },
+        {
+          "code": "Q11232792",
+          "label": "Marron"
+        },
+        {
+          "code": "Q11238063",
+          "label": "Overland"
+        },
+        {
+          "code": "Q11254017",
+          "label": "Waffle"
+        },
+        {
+          "code": "Q11245837",
+          "label": "Selen"
+        },
+        {
+          "code": "Q11229826",
+          "label": "Lass"
+        },
+        {
+          "code": "Q11235007",
+          "label": "NHK Service Center"
+        },
+        {
+          "code": "Q11236742",
+          "label": "ninetail"
+        },
+        {
+          "code": "Q11231990",
+          "label": "MOSS"
+        },
+        {
+          "code": "Q11254236",
+          "label": "West Vision"
+        },
+        {
+          "code": "Q11243482",
+          "label": "SITER SKAIN"
+        },
+        {
+          "code": "Q11250605",
+          "label": "Terios"
+        },
+        {
+          "code": "Q11230030",
+          "label": "LiLiM"
+        },
+        {
+          "code": "Q11236056",
+          "label": "NTT Solmare"
+        },
+        {
+          "code": "Q11246868",
+          "label": "softhouse-seal"
+        },
+        {
+          "code": "Q11252085",
+          "label": "Softhouse Chara"
+        },
+        {
+          "code": "Q204474",
+          "label": "id Software"
+        },
+        {
+          "code": "Q201848",
+          "label": "etoy"
+        },
+        {
+          "code": "Q282658",
+          "label": "Acclaim Studios Austin"
+        },
+        {
+          "code": "Q270119",
+          "label": "7th Level"
+        },
+        {
+          "code": "Q284989",
+          "label": "tri-Ace"
+        },
+        {
+          "code": "Q267949",
+          "label": "Westwood Studios"
+        },
+        {
+          "code": "Q282152",
+          "label": "PopTop Software"
+        },
+        {
+          "code": "Q1045344",
+          "label": "The Learning Company"
+        },
+        {
+          "code": "Q1046593",
+          "label": "Gearbox Software"
+        },
+        {
+          "code": "Q2274654",
+          "label": "Gremlin Interactive"
+        },
+        {
+          "code": "Q2288948",
+          "label": "Seibu Kaihatsu"
+        },
+        {
+          "code": "Q2264873",
+          "label": "Vivendi Games"
+        },
+        {
+          "code": "Q2271746",
+          "label": "Tose Co."
+        },
+        {
+          "code": "Q2275894",
+          "label": "TalonSoft"
+        },
+        {
+          "code": "Q1041320",
+          "label": "Ubisoft Paris"
+        },
+        {
+          "code": "Q1045037",
+          "label": "AliceSoft"
+        },
+        {
+          "code": "Q1040450",
+          "label": "Guerrilla Cambridge"
+        },
+        {
+          "code": "Q1044563",
+          "label": "Playmore"
+        },
+        {
+          "code": "Q307403",
+          "label": "Minori"
+        },
+        {
+          "code": "Q307104",
+          "label": "tri-Crescendo"
+        },
+        {
+          "code": "Q304980",
+          "label": "Nebula Device"
+        },
+        {
+          "code": "Q302251",
+          "label": "Frontier Developments"
+        },
+        {
+          "code": "Q303641",
+          "label": "FASA Studio"
+        },
+        {
+          "code": "Q2090810",
+          "label": "Lankhor"
+        },
+        {
+          "code": "Q2083043",
+          "label": "Rockstar London"
+        },
+        {
+          "code": "Q2083518",
+          "label": "Ubisoft Montpellier"
+        },
+        {
+          "code": "Q2106613",
+          "label": "Triangle Studios"
+        },
+        {
+          "code": "Q2109517",
+          "label": "NeocoreGames"
+        },
+        {
+          "code": "Q2107938",
+          "label": "WB Games Boston"
+        },
+        {
+          "code": "Q2086858",
+          "label": "Trilobyte"
+        },
+        {
+          "code": "Q1458317",
+          "label": "Deep Silver Volition"
+        },
+        {
+          "code": "Q1466613",
+          "label": "Massive Entertainment"
+        },
+        {
+          "code": "Q1441169",
+          "label": "Frictional Games"
+        },
+        {
+          "code": "Q739552",
+          "label": "Square"
+        },
+        {
+          "code": "Q735267",
+          "label": "Bungie"
+        },
+        {
+          "code": "Q734715",
+          "label": "Pseudo Interactive"
+        },
+        {
+          "code": "Q738135",
+          "label": "Aspyr"
+        },
+        {
+          "code": "Q11300281",
+          "label": "Grounding"
+        },
+        {
+          "code": "Q11293405",
+          "label": "Overdose"
+        },
+        {
+          "code": "Q11289809",
+          "label": "Experience"
+        },
+        {
+          "code": "Q11272835",
+          "label": "Debonosu Works"
+        },
+        {
+          "code": "Q11282958",
+          "label": "Axela"
+        },
+        {
+          "code": "Q11297509",
+          "label": "Qute"
+        },
+        {
+          "code": "Q11283535",
+          "label": "Astronauts"
+        },
+        {
+          "code": "Q11302282",
+          "label": "Konami Computer Entertainment Japan"
+        },
+        {
+          "code": "Q11275792",
+          "label": "Hamham-soft"
+        },
+        {
+          "code": "Q11302230",
+          "label": "COTTON SOFTWARE"
+        },
+        {
+          "code": "Q11288075",
+          "label": "WITCHCRAFT inc."
+        },
+        {
+          "code": "Q11300670",
+          "label": "Groove Box Japan"
+        },
+        {
+          "code": "Q11289760",
+          "label": "Examu"
+        },
+        {
+          "code": "Q11271688",
+          "label": "Cherry Soft"
+        },
+        {
+          "code": "Q11285547",
+          "label": "Arc Entertainment Inc."
+        },
+        {
+          "code": "Q11297257",
+          "label": "Character Soft"
+        },
+        {
+          "code": "Q11290014",
+          "label": "Escu:de"
+        },
+        {
+          "code": "Q11284007",
+          "label": "Atelier Kaguya"
+        },
+        {
+          "code": "Q11292110",
+          "label": "Otomate"
+        },
+        {
+          "code": "Q11269069",
+          "label": "Shakunage"
+        },
+        {
+          "code": "Q11276039",
+          "label": "Pajama Soft"
+        },
+        {
+          "code": "Q11256742",
+          "label": "Airyu"
+        },
+        {
+          "code": "Q12593736",
+          "label": "Dragonfly"
+        },
+        {
+          "code": "Q11959209",
+          "label": "Artplant"
+        },
+        {
+          "code": "Q12217951",
+          "label": "Semaphore"
+        },
+        {
+          "code": "Q12427844",
+          "label": "Rake in Grass"
+        },
+        {
+          "code": "Q12058832",
+          "label": "The Easy Company"
+        },
+        {
+          "code": "Q12592880",
+          "label": "devCAT Studio"
+        },
+        {
+          "code": "Q12603595",
+          "label": "Smilegate"
+        },
+        {
+          "code": "Q12606823",
+          "label": "MJ Net"
+        },
+        {
+          "code": "Q12320535",
+          "label": "JumpStart Solutions"
+        },
+        {
+          "code": "Q12062864",
+          "label": "Creoteam"
+        },
+        {
+          "code": "Q13117583",
+          "label": "Star Theory Games"
+        },
+        {
+          "code": "Q11898759",
+          "label": "Turmoil Games"
+        },
+        {
+          "code": "Q11903311",
+          "label": "Åkesoft"
+        },
+        {
+          "code": "Q12029133",
+          "label": "Keen Software House"
+        },
+        {
+          "code": "Q12482239",
+          "label": "e-FunSoft Games"
+        },
+        {
+          "code": "Q12590257",
+          "label": "Neople"
+        },
+        {
+          "code": "Q12606770",
+          "label": "XLGames"
+        },
+        {
+          "code": "Q13219333",
+          "label": "Nixxes Software"
+        },
+        {
+          "code": "Q2634015",
+          "label": "ADK"
+        },
+        {
+          "code": "Q2636715",
+          "label": "Cavia"
+        },
+        {
+          "code": "Q2655759",
+          "label": "Amusement Vision"
+        },
+        {
+          "code": "Q2659812",
+          "label": "Pack-In-Video"
+        },
+        {
+          "code": "Q2660091",
+          "label": "Griptonite Games"
+        },
+        {
+          "code": "Q2648346",
+          "label": "Two Tribes B.V."
+        },
+        {
+          "code": "Q2633052",
+          "label": "Nintendo Research & Development 1"
+        },
+        {
+          "code": "Q656710",
+          "label": "Santa Monica Studio"
+        },
+        {
+          "code": "Q657175",
+          "label": "Ninai Games"
+        },
+        {
+          "code": "Q660990",
+          "label": "Avalanche Software"
+        },
+        {
+          "code": "Q662567",
+          "label": "Ariolasoft"
+        },
+        {
+          "code": "Q665103",
+          "label": "Rogue Entertainment"
+        },
+        {
+          "code": "Q655656",
+          "label": "Heavy Iron Studios"
+        },
+        {
+          "code": "Q33545411",
+          "label": "The Brotherhood"
+        },
+        {
+          "code": "Q33508628",
+          "label": "Kyle Seeley"
+        },
+        {
+          "code": "Q33508923",
+          "label": "Michael Todd Games"
+        },
+        {
+          "code": "Q33534443",
+          "label": "DEVGRU-P"
+        },
+        {
+          "code": "Q33542517",
+          "label": "RuneStorm"
+        },
+        {
+          "code": "Q33544990",
+          "label": "OP Productions LLC"
+        },
+        {
+          "code": "Q33508052",
+          "label": "Born Ready Games Ltd."
+        },
+        {
+          "code": "Q33542254",
+          "label": "Phosphor Games Studio"
+        },
+        {
+          "code": "Q33542300",
+          "label": "Gatling Goat Studios"
+        },
+        {
+          "code": "Q33543111",
+          "label": "Silver Dollar Games"
+        },
+        {
+          "code": "Q33543336",
+          "label": "Crowbar Collective"
+        },
+        {
+          "code": "Q33508176",
+          "label": "Facepalm Games"
+        },
+        {
+          "code": "Q33509553",
+          "label": "The Game Kitchen"
+        },
+        {
+          "code": "Q33534213",
+          "label": "Fun Infused Games"
+        },
+        {
+          "code": "Q33534258",
+          "label": "Grynsoft"
+        },
+        {
+          "code": "Q33543123",
+          "label": "Toxic Games"
+        },
+        {
+          "code": "Q33546328",
+          "label": "Fenix Fire Entertainment"
+        },
+        {
+          "code": "Q33569178",
+          "label": "Circle 5 Studios"
+        },
+        {
+          "code": "Q33570408",
+          "label": "Gausswerks"
+        },
+        {
+          "code": "Q33509473",
+          "label": "Screwfly Studios"
+        },
+        {
+          "code": "Q33534310",
+          "label": "SDEnterNet"
+        },
+        {
+          "code": "Q33542636",
+          "label": "Reakktor Studios"
+        },
+        {
+          "code": "Q33570510",
+          "label": "Stellar Jockeys"
+        },
+        {
+          "code": "Q33542290",
+          "label": "Lukas Navratil"
+        },
+        {
+          "code": "Q33508224",
+          "label": "FuturLab"
+        },
+        {
+          "code": "Q33509640",
+          "label": "Leafy Games"
+        },
+        {
+          "code": "Q33534591",
+          "label": "Pinterac"
+        },
+        {
+          "code": "Q33542596",
+          "label": "Infinitap Games"
+        },
+        {
+          "code": "Q33545546",
+          "label": "stage-nana"
+        },
+        {
+          "code": "Q33546415",
+          "label": "Green Lava Studios"
+        },
+        {
+          "code": "Q33575594",
+          "label": "Mad Vulture Games"
+        },
+        {
+          "code": "Q33509251",
+          "label": "Oovee® Game Studios"
+        },
+        {
+          "code": "Q33509239",
+          "label": "Asteroid Base"
+        },
+        {
+          "code": "Q33509667",
+          "label": "Radial Games Corp"
+        },
+        {
+          "code": "Q33568859",
+          "label": "Lukewarm Media"
+        },
+        {
+          "code": "Q33509468",
+          "label": "Powerhoof"
+        },
+        {
+          "code": "Q33542873",
+          "label": "Limasse Five"
+        },
+        {
+          "code": "Q33811210",
+          "label": "Kew McParlane"
+        },
+        {
+          "code": "Q39038111",
+          "label": "Beam Team Games"
+        },
+        {
+          "code": "Q39086792",
+          "label": "Rebellion Warwick"
+        },
+        {
+          "code": "Q40881750",
+          "label": "MovingBlocks"
+        },
+        {
+          "code": "Q33789498",
+          "label": "Shinsei"
+        },
+        {
+          "code": "Q42725768",
+          "label": "Laundry Bear Games"
+        },
+        {
+          "code": "Q42851511",
+          "label": "Two Point Studios"
+        },
+        {
+          "code": "Q33575906",
+          "label": "Critical Studio"
+        },
+        {
+          "code": "Q34365390",
+          "label": "Jasper Byrne"
+        },
+        {
+          "code": "Q45319364",
+          "label": "Turbulenz"
+        },
+        {
+          "code": "Q45321060",
+          "label": "Jujubee"
+        },
+        {
+          "code": "Q39055715",
+          "label": "Loot Drop"
+        },
+        {
+          "code": "Q39047089",
+          "label": "Gamious"
+        },
+        {
+          "code": "Q39057440",
+          "label": "GolemLabs"
+        },
+        {
+          "code": "Q42818601",
+          "label": "Crafty Studios"
+        },
+        {
+          "code": "Q41573609",
+          "label": "EA Pacific"
+        },
+        {
+          "code": "Q45321140",
+          "label": "Evil Twin Artworks"
+        },
+        {
+          "code": "Q42588527",
+          "label": "Streetout Games"
+        },
+        {
+          "code": "Q42901964",
+          "label": "Reborn Games"
+        },
+        {
+          "code": "Q33576253",
+          "label": "Games Farm"
+        },
+        {
+          "code": "Q44296018",
+          "label": "Lucky Frame"
+        },
+        {
+          "code": "Q45057674",
+          "label": "InsGames"
+        },
+        {
+          "code": "Q38235328",
+          "label": "Next Games"
+        },
+        {
+          "code": "Q39058513",
+          "label": "Choice of Games"
+        },
+        {
+          "code": "Q33810505",
+          "label": "Wander MMO"
+        },
+        {
+          "code": "Q42294520",
+          "label": "Stage Clear Studios"
+        },
+        {
+          "code": "Q42324284",
+          "label": "Maschinen-Mensch"
+        },
+        {
+          "code": "Q42663892",
+          "label": "Animu Game"
+        },
+        {
+          "code": "Q47015754",
+          "label": "Yostar"
+        },
+        {
+          "code": "Q39055669",
+          "label": "Flazm"
+        },
+        {
+          "code": "Q40387616",
+          "label": "TML Studios"
+        },
+        {
+          "code": "Q694590",
+          "label": "Bigpoint GmbH"
+        },
+        {
+          "code": "Q697493",
+          "label": "AGE"
+        },
+        {
+          "code": "Q699634",
+          "label": "Factor 5"
+        },
+        {
+          "code": "Q695299",
+          "label": "Ubisoft Blue Byte"
+        },
+        {
+          "code": "Q2577247",
+          "label": "Imagineering"
+        },
+        {
+          "code": "Q2597910",
+          "label": "Kairosoft"
+        },
+        {
+          "code": "Q2568920",
+          "label": "Traveller's Tales"
+        },
+        {
+          "code": "Q2579521",
+          "label": "Vatra Games"
+        },
+        {
+          "code": "Q2602093",
+          "label": "Sumo Digital"
+        },
+        {
+          "code": "Q2577763",
+          "label": "Lucasfan Games"
+        },
+        {
+          "code": "Q2572761",
+          "label": "Housemarque"
+        },
+        {
+          "code": "Q2558169",
+          "label": "Weltenschmiede"
+        },
+        {
+          "code": "Q2567775",
+          "label": "Sports Interactive"
+        },
+        {
+          "code": "Q2549114",
+          "label": "CI Games S.A."
+        },
+        {
+          "code": "Q2560823",
+          "label": "EA Montreal"
+        },
+        {
+          "code": "Q2561594",
+          "label": "skip Ltd."
+        },
+        {
+          "code": "Q2553434",
+          "label": "Renegade Kid"
+        },
+        {
+          "code": "Q2552866",
+          "label": "Pi Studios"
+        },
+        {
+          "code": "Q104804747",
+          "label": "Evil Empire"
+        },
+        {
+          "code": "Q104828536",
+          "label": "Aldorlea Games"
+        },
+        {
+          "code": "Q104836868",
+          "label": "Brushfire Games"
+        },
+        {
+          "code": "Q104846081",
+          "label": "Blow and Try Again"
+        },
+        {
+          "code": "Q105037594",
+          "label": "Orbital Knight"
+        },
+        {
+          "code": "Q105061288",
+          "label": "Ludicrous Games"
+        },
+        {
+          "code": "Q105070842",
+          "label": "StepUnique"
+        },
+        {
+          "code": "Q104804166",
+          "label": "KAMPO Interactive"
+        },
+        {
+          "code": "Q104820566",
+          "label": "Shiny Shoe"
+        },
+        {
+          "code": "Q104862593",
+          "label": "PONOS"
+        },
+        {
+          "code": "Q104864975",
+          "label": "D3T"
+        },
+        {
+          "code": "Q104884967",
+          "label": "W3D Hub"
+        },
+        {
+          "code": "Q105070916",
+          "label": "Sirlin Games"
+        },
+        {
+          "code": "Q104846034",
+          "label": "Everplay Interactive"
+        },
+        {
+          "code": "Q104813446",
+          "label": "SuperTry Studios"
+        },
+        {
+          "code": "Q104828535",
+          "label": "Warfare Studios"
+        },
+        {
+          "code": "Q104837547",
+          "label": "GrizzlyGames"
+        },
+        {
+          "code": "Q105024509",
+          "label": "Mature Games"
+        },
+        {
+          "code": "Q105010204",
+          "label": "Flamebait Games"
+        },
+        {
+          "code": "Q105075493",
+          "label": "Ripstone"
+        },
+        {
+          "code": "Q105080681",
+          "label": "Ghost Ship Games"
+        },
+        {
+          "code": "Q104812363",
+          "label": "No More Room in Hell Team"
+        },
+        {
+          "code": "Q104830575",
+          "label": "Tribe Games"
+        },
+        {
+          "code": "Q104855953",
+          "label": "Gray Matter"
+        },
+        {
+          "code": "Q104827685",
+          "label": "Bounding Box Software"
+        },
+        {
+          "code": "Q104830824",
+          "label": "Channel 7"
+        },
+        {
+          "code": "Q104869991",
+          "label": "Alice & Smith"
+        },
+        {
+          "code": "Q104879217",
+          "label": "Plasticity Studios"
+        },
+        {
+          "code": "Q105064694",
+          "label": "Horrible Guild Games"
+        },
+        {
+          "code": "Q104884050",
+          "label": "I-Novae Studios"
+        },
+        {
+          "code": "Q105070662",
+          "label": "Purple Pwny Studios"
+        },
+        {
+          "code": "Q2461951",
+          "label": "Alchemist"
+        },
+        {
+          "code": "Q2456686",
+          "label": "Krome Studios Melbourne"
+        },
+        {
+          "code": "Q2448087",
+          "label": "The Adventure Company"
+        },
+        {
+          "code": "Q2450081",
+          "label": "Glu Mobile"
+        },
+        {
+          "code": "Q2464302",
+          "label": "Blizzard North"
+        },
+        {
+          "code": "Q2411797",
+          "label": "Eurocom"
+        },
+        {
+          "code": "Q2419591",
+          "label": "Frozenbyte"
+        },
+        {
+          "code": "Q2421339",
+          "label": "Magic Pockets"
+        },
+        {
+          "code": "Q2414469",
+          "label": "FromSoftware"
+        },
+        {
+          "code": "Q2445401",
+          "label": "Team Bondi"
+        },
+        {
+          "code": "Q2420494",
+          "label": "Mythos Games"
+        },
+        {
+          "code": "Q55562184",
+          "label": "Acclaim Studios Cheltenham"
+        },
+        {
+          "code": "Q15070340",
+          "label": "Game Refuge Inc."
+        },
+        {
+          "code": "Q15070269",
+          "label": "Agate Studio"
+        },
+        {
+          "code": "Q15070299",
+          "label": "Celestial Games"
+        },
+        {
+          "code": "Q15070342",
+          "label": "GameSim"
+        },
+        {
+          "code": "Q15070295",
+          "label": "Carbine Studios"
+        },
+        {
+          "code": "Q15070316",
+          "label": "Destineer"
+        },
+        {
+          "code": "Q15070304",
+          "label": "Level-5 Comcept"
+        },
+        {
+          "code": "Q15070356",
+          "label": "Hypnos Entertainment"
+        },
+        {
+          "code": "Q15070334",
+          "label": "Fireproof Studios"
+        },
+        {
+          "code": "Q15070355",
+          "label": "HyperDevbox Japan"
+        },
+        {
+          "code": "Q15070283",
+          "label": "AudioGaming"
+        },
+        {
+          "code": "Q15070326",
+          "label": "EA Singapore"
+        },
+        {
+          "code": "Q15070335",
+          "label": "Flying Wild Hog"
+        },
+        {
+          "code": "Q15070301",
+          "label": "Cipher Prime"
+        },
+        {
+          "code": "Q15070309",
+          "label": "Crytek USA"
+        },
+        {
+          "code": "Q15070318",
+          "label": "Dhruva Interactive"
+        },
+        {
+          "code": "Q15070320",
+          "label": "Digitalmindsoft"
+        },
+        {
+          "code": "Q15070279",
+          "label": "Armature Studio"
+        },
+        {
+          "code": "Q15070274",
+          "label": "AmnesiaGames"
+        },
+        {
+          "code": "Q15070353",
+          "label": "HipSoft"
+        },
+        {
+          "code": "Q11328870",
+          "label": "PSK"
+        },
+        {
+          "code": "Q11342996",
+          "label": "Mink"
+        },
+        {
+          "code": "Q11348564",
+          "label": "Lilith"
+        },
+        {
+          "code": "Q11733426",
+          "label": "Cinemax"
+        },
+        {
+          "code": "Q11893864",
+          "label": "Skitso Productions"
+        },
+        {
+          "code": "Q11336950",
+          "label": "BEC"
+        },
+        {
+          "code": "Q11330068",
+          "label": "Hit Maker"
+        },
+        {
+          "code": "Q11609342",
+          "label": "Yoshitsubomi"
+        },
+        {
+          "code": "Q11712407",
+          "label": "Infinite Dreams"
+        },
+        {
+          "code": "Q11345663",
+          "label": "Unicorn-A"
+        },
+        {
+          "code": "Q11331181",
+          "label": "Bullet-Proof Software"
+        },
+        {
+          "code": "Q11343886",
+          "label": "Metro Corporation"
+        },
+        {
+          "code": "Q11350205",
+          "label": "Rocket Studio"
+        },
+        {
+          "code": "Q11876358",
+          "label": "LudoCraft"
+        },
+        {
+          "code": "Q11339585",
+          "label": "Micronet"
+        },
+        {
+          "code": "Q11335922",
+          "label": "FLAME Hearts Co.,Ltd."
+        },
+        {
+          "code": "Q11346279",
+          "label": "Liar-soft"
+        },
+        {
+          "code": "Q11332510",
+          "label": "Fill-in-Cafe"
+        },
+        {
+          "code": "Q11506496",
+          "label": "Japan System Supply"
+        },
+        {
+          "code": "Q11774994",
+          "label": "Geewa"
+        },
+        {
+          "code": "Q11788342",
+          "label": "N-Fusion Interactive"
+        },
+        {
+          "code": "Q11347317",
+          "label": "LOVEPLUS PRODUCTION"
+        },
+        {
+          "code": "Q11434387",
+          "label": "Omiya Soft"
+        },
+        {
+          "code": "Q47086946",
+          "label": "Callipygian Games"
+        },
+        {
+          "code": "Q48966437",
+          "label": "Built Games"
+        },
+        {
+          "code": "Q50922586",
+          "label": "Rusty Lake"
+        },
+        {
+          "code": "Q48998693",
+          "label": "Duoyi Network"
+        },
+        {
+          "code": "Q51844719",
+          "label": "Bytro Labs"
+        },
+        {
+          "code": "Q51885684",
+          "label": "Exiled Game Team"
+        },
+        {
+          "code": "Q51834381",
+          "label": "Deconstructeam"
+        },
+        {
+          "code": "Q51936093",
+          "label": "SPVD"
+        },
+        {
+          "code": "Q51856931",
+          "label": "Paleozoic"
+        },
+        {
+          "code": "Q47110237",
+          "label": "Killspace Entertainment"
+        },
+        {
+          "code": "Q47455664",
+          "label": "Witch Beam"
+        },
+        {
+          "code": "Q51701831",
+          "label": "Team Salvato"
+        },
+        {
+          "code": "Q50896147",
+          "label": "Valofe"
+        },
+        {
+          "code": "Q47488519",
+          "label": "Kakao Games"
+        },
+        {
+          "code": "Q48911120",
+          "label": "Park ESM"
+        },
+        {
+          "code": "Q48935916",
+          "label": "Sigono"
+        },
+        {
+          "code": "Q48988791",
+          "label": "Viacom NEXT"
+        },
+        {
+          "code": "Q47103585",
+          "label": "Pocketwatch Games"
+        },
+        {
+          "code": "Q48885544",
+          "label": "MorningTec"
+        },
+        {
+          "code": "Q51179850",
+          "label": "Ubisoft Belgrade"
+        },
+        {
+          "code": "Q51897660",
+          "label": "Game Machine Studios"
+        },
+        {
+          "code": "Q33441731",
+          "label": "Question"
+        },
+        {
+          "code": "Q33441836",
+          "label": "NotGames"
+        },
+        {
+          "code": "Q33441989",
+          "label": "BadFly Interactive, a.s."
+        },
+        {
+          "code": "Q33451873",
+          "label": "SilverSphereStudios"
+        },
+        {
+          "code": "Q33454668",
+          "label": "Teeworlds Team"
+        },
+        {
+          "code": "Q33462287",
+          "label": "Over The Moon"
+        },
+        {
+          "code": "Q33462821",
+          "label": "Thunder Lotus Games"
+        },
+        {
+          "code": "Q33466242",
+          "label": "Digital Media Workshop"
+        },
+        {
+          "code": "Q33440588",
+          "label": "Vectorpark, Inc."
+        },
+        {
+          "code": "Q33462354",
+          "label": "Nyamyam"
+        },
+        {
+          "code": "Q33465537",
+          "label": "Young Horses"
+        },
+        {
+          "code": "Q33465912",
+          "label": "BeamNG"
+        },
+        {
+          "code": "Q33441896",
+          "label": "Gambrinous"
+        },
+        {
+          "code": "Q33442011",
+          "label": "Virtual Basement LLC"
+        },
+        {
+          "code": "Q33446018",
+          "label": "Fakt Software"
+        },
+        {
+          "code": "Q33461608",
+          "label": "Flippfly LLC"
+        },
+        {
+          "code": "Q33465465",
+          "label": "Monochrome, Inc"
+        },
+        {
+          "code": "Q33465495",
+          "label": "Phosfiend Systems"
+        },
+        {
+          "code": "Q33466025",
+          "label": "Iridium Studios"
+        },
+        {
+          "code": "Q33444924",
+          "label": "Stage 2 Studios"
+        },
+        {
+          "code": "Q33461477",
+          "label": "StaudSoft"
+        },
+        {
+          "code": "Q33461838",
+          "label": "B-evil"
+        },
+        {
+          "code": "Q33466155",
+          "label": "Eleon Game Studios"
+        },
+        {
+          "code": "Q33466181",
+          "label": "Outerminds Inc."
+        },
+        {
+          "code": "Q33441356",
+          "label": "Switchblade Monkeys Entertainment"
+        },
+        {
+          "code": "Q33453054",
+          "label": "Octoshark Studios"
+        },
+        {
+          "code": "Q33454713",
+          "label": "Bird in Sky"
+        },
+        {
+          "code": "Q33454973",
+          "label": "VIS - Visual Imagination Software"
+        },
+        {
+          "code": "Q33455185",
+          "label": "Silver Wish Games"
+        },
+        {
+          "code": "Q33459889",
+          "label": "Locked Door Puzzle"
+        },
+        {
+          "code": "Q33461935",
+          "label": "Zaxis Games"
+        },
+        {
+          "code": "Q33441107",
+          "label": "Cockroach Inc."
+        },
+        {
+          "code": "Q33461742",
+          "label": "Soviet Games"
+        },
+        {
+          "code": "Q33463422",
+          "label": "Flox Studios Ltd."
+        },
+        {
+          "code": "Q33449357",
+          "label": "Citeremis Inc."
+        },
+        {
+          "code": "Q33453162",
+          "label": "Psychic Software"
+        },
+        {
+          "code": "Q33465158",
+          "label": "Cornfox & Bros."
+        },
+        {
+          "code": "Q33442292",
+          "label": "Thomas Happ Games"
+        },
+        {
+          "code": "Q33466131",
+          "label": "Uppercut Games"
+        },
+        {
+          "code": "Q33459941",
+          "label": "Grapefrukt games"
+        },
+        {
+          "code": "Q2495040",
+          "label": "CAVE"
+        },
+        {
+          "code": "Q2469781",
+          "label": "Saber Interactive"
+        },
+        {
+          "code": "Q2484436",
+          "label": "KatGames"
+        },
+        {
+          "code": "Q2495576",
+          "label": "Eighting"
+        },
+        {
+          "code": "Q2482897",
+          "label": "Zono"
+        },
+        {
+          "code": "Q2505093",
+          "label": "World Forge"
+        },
+        {
+          "code": "Q2482597",
+          "label": "indieszero"
+        },
+        {
+          "code": "Q2489678",
+          "label": "Red Monkeys"
+        },
+        {
+          "code": "Q2501821",
+          "label": "Spark Unlimited"
+        },
+        {
+          "code": "Q403714",
+          "label": "Majesco Entertainment"
+        },
+        {
+          "code": "Q391183",
+          "label": "Incentive Software"
+        },
+        {
+          "code": "Q388228",
+          "label": "Creative Assembly Sofia"
+        },
+        {
+          "code": "Q389063",
+          "label": "Bit Managers"
+        },
+        {
+          "code": "Q389261",
+          "label": "Backbone Entertainment"
+        },
+        {
+          "code": "Q389526",
+          "label": "Bloober Team"
+        },
+        {
+          "code": "Q2706709",
+          "label": "h.a.n.d."
+        },
+        {
+          "code": "Q2708014",
+          "label": "Bluepoint Games"
+        },
+        {
+          "code": "Q2699057",
+          "label": "MercurySteam"
+        },
+        {
+          "code": "Q2712143",
+          "label": "inXile entertainment"
+        },
+        {
+          "code": "Q13615053",
+          "label": "Trickster Arts"
+        },
+        {
+          "code": "Q14148399",
+          "label": "EA Gothenburg"
+        },
+        {
+          "code": "Q14001326",
+          "label": "MumboJumbo"
+        },
+        {
+          "code": "Q13512393",
+          "label": "Cellufun"
+        },
+        {
+          "code": "Q13581128",
+          "label": "Grove Street Games"
+        },
+        {
+          "code": "Q113290892",
+          "label": "Seito Games"
+        },
+        {
+          "code": "Q113587505",
+          "label": "Big Up Studio"
+        },
+        {
+          "code": "Q113587510",
+          "label": "Melon Games"
+        },
+        {
+          "code": "Q113587497",
+          "label": "Toyman"
+        },
+        {
+          "code": "Q113407866",
+          "label": "Causa Creations"
+        },
+        {
+          "code": "Q113468008",
+          "label": "Modern Storyteller"
+        },
+        {
+          "code": "Q113526896",
+          "label": "Trigger Labs"
+        },
+        {
+          "code": "Q113568781",
+          "label": "Lance Games"
+        },
+        {
+          "code": "Q113587237",
+          "label": "Manic Media Productions"
+        },
+        {
+          "code": "Q113587570",
+          "label": "Creobit"
+        },
+        {
+          "code": "Q113587545",
+          "label": "GameOn Production"
+        },
+        {
+          "code": "Q113613664",
+          "label": "StarlightTree Games"
+        },
+        {
+          "code": "Q113621065",
+          "label": "Carbon Counts"
+        },
+        {
+          "code": "Q113628825",
+          "label": "Suricate Software"
+        },
+        {
+          "code": "Q113203924",
+          "label": "Fortress Forever Development Team"
+        },
+        {
+          "code": "Q113288288",
+          "label": "Mens Sana Interactive"
+        },
+        {
+          "code": "Q113568635",
+          "label": "RainbowStudio"
+        },
+        {
+          "code": "Q113568799",
+          "label": "Cronostase"
+        },
+        {
+          "code": "Q113629317",
+          "label": "Anawiki Games"
+        },
+        {
+          "code": "Q113629269",
+          "label": "Itera Laboratories"
+        },
+        {
+          "code": "Q113629284",
+          "label": "Mad Data"
+        },
+        {
+          "code": "Q113285238",
+          "label": "RunServer"
+        },
+        {
+          "code": "Q113361289",
+          "label": "Alpha Blend Interactive"
+        },
+        {
+          "code": "Q113401262",
+          "label": "YFYX GAMES"
+        },
+        {
+          "code": "Q113434061",
+          "label": "turbolento games"
+        },
+        {
+          "code": "Q113629108",
+          "label": "Lazy Turtle Games"
+        },
+        {
+          "code": "Q113126752",
+          "label": "Gravity Well"
+        },
+        {
+          "code": "Q113284512",
+          "label": "Neoclassic Games"
+        },
+        {
+          "code": "Q113288388",
+          "label": "NickRizzoGames"
+        },
+        {
+          "code": "Q113628676",
+          "label": "Parallel Studio"
+        },
+        {
+          "code": "Q113628868",
+          "label": "Puzzles By Joe"
+        },
+        {
+          "code": "Q113156099",
+          "label": "BlueTwelve Studio"
+        },
+        {
+          "code": "Q113598336",
+          "label": "Somer Games"
+        },
+        {
+          "code": "Q113628993",
+          "label": "HH-Games"
+        },
+        {
+          "code": "Q113629085",
+          "label": "Urchin Games"
+        },
+        {
+          "code": "Q113141754",
+          "label": "Subcreation Studio"
+        },
+        {
+          "code": "Q113291651",
+          "label": "Laush Studio"
+        },
+        {
+          "code": "Q113587480",
+          "label": "Studio Bidon Games"
+        },
+        {
+          "code": "Q113587526",
+          "label": "Workroom7"
+        },
+        {
+          "code": "Q113517676",
+          "label": "Molegato"
+        },
+        {
+          "code": "Q113568790",
+          "label": "resnijars"
+        },
+        {
+          "code": "Q113587382",
+          "label": "8floor"
+        },
+        {
+          "code": "Q113629383",
+          "label": "Freeze Tag"
+        },
+        {
+          "code": "Q2353010",
+          "label": "Cyanide"
+        },
+        {
+          "code": "Q2369574",
+          "label": "NinjaBee"
+        },
+        {
+          "code": "Q2352252",
+          "label": "Stormfront Studios"
+        },
+        {
+          "code": "Q2340010",
+          "label": "Croteam"
+        },
+        {
+          "code": "Q2353877",
+          "label": "Blue Planet Software"
+        },
+        {
+          "code": "Q2352604",
+          "label": "TaleWorlds"
+        },
+        {
+          "code": "Q337910",
+          "label": "Guerrilla Games"
+        },
+        {
+          "code": "Q339266",
+          "label": "Accolade"
+        },
+        {
+          "code": "Q339565",
+          "label": "Sega Wow"
+        },
+        {
+          "code": "Q334904",
+          "label": "Japan Studio"
+        },
+        {
+          "code": "Q11307497",
+          "label": "Shift"
+        },
+        {
+          "code": "Q11311852",
+          "label": "Studio Mebius"
+        },
+        {
+          "code": "Q11319816",
+          "label": "TENKY"
+        },
+        {
+          "code": "Q11328509",
+          "label": "Birthday"
+        },
+        {
+          "code": "Q11321456",
+          "label": "Tom Create"
+        },
+        {
+          "code": "Q11325442",
+          "label": "NetDragon Websoft"
+        },
+        {
+          "code": "Q11320204",
+          "label": "D.O"
+        },
+        {
+          "code": "Q11326720",
+          "label": "HAMSTER"
+        },
+        {
+          "code": "Q11315126",
+          "label": "Societa Daikanyama"
+        },
+        {
+          "code": "Q11325179",
+          "label": "Nude Maker"
+        },
+        {
+          "code": "Q11322076",
+          "label": "TORPEDO"
+        },
+        {
+          "code": "Q11328408",
+          "label": "Bandai Namco Studios"
+        },
+        {
+          "code": "Q11328535",
+          "label": "Virtual Kiss"
+        },
+        {
+          "code": "Q11318258",
+          "label": "Champion Soft"
+        },
+        {
+          "code": "Q11320972",
+          "label": "dB-SOFT"
+        },
+        {
+          "code": "Q11321917",
+          "label": "Trabulance"
+        },
+        {
+          "code": "Q11308336",
+          "label": "SILKY'S"
+        },
+        {
+          "code": "Q11189999",
+          "label": "Active"
+        },
+        {
+          "code": "Q11191283",
+          "label": "Bishop"
+        },
+        {
+          "code": "Q11195901",
+          "label": "Diva"
+        },
+        {
+          "code": "Q11198926",
+          "label": "Favorite"
+        },
+        {
+          "code": "Q11090232",
+          "label": "Gameone"
+        },
+        {
+          "code": "Q11189680",
+          "label": "ASa Project"
+        },
+        {
+          "code": "Q11198379",
+          "label": "Epics Inc"
+        },
+        {
+          "code": "Q11223729",
+          "label": "I.D."
+        },
+        {
+          "code": "Q11190359",
+          "label": "ApRicoT"
+        },
+        {
+          "code": "Q11190752",
+          "label": "B.B. Studio"
+        },
+        {
+          "code": "Q11200696",
+          "label": "G.J?"
+        },
+        {
+          "code": "Q10923087",
+          "label": "Winking Entertainment"
+        },
+        {
+          "code": "Q11223531",
+          "label": "Honeybee"
+        },
+        {
+          "code": "Q11201892",
+          "label": "GROOVER"
+        },
+        {
+          "code": "Q11224032",
+          "label": "Image craft"
+        },
+        {
+          "code": "Q10889342",
+          "label": "Pixel Soft"
+        },
+        {
+          "code": "Q11024198",
+          "label": "Black Element Software"
+        },
+        {
+          "code": "Q11190270",
+          "label": "AngelSmile"
+        },
+        {
+          "code": "Q10889280",
+          "label": "X-Legend"
+        },
+        {
+          "code": "Q11192573",
+          "label": "Bonbee!"
+        },
+        {
+          "code": "Q14891828",
+          "label": "Humble Hearts"
+        },
+        {
+          "code": "Q15018011",
+          "label": "Atari Interactive"
+        },
+        {
+          "code": "Q15070267",
+          "label": "AfreecaTV Co., Ltd."
+        },
+        {
+          "code": "Q14508400",
+          "label": "Mountain King Studios"
+        },
+        {
+          "code": "Q14947442",
+          "label": "Lucid Games"
+        },
+        {
+          "code": "Q15043527",
+          "label": "Subset Games"
+        },
+        {
+          "code": "Q15055220",
+          "label": "KamaGames"
+        },
+        {
+          "code": "Q14239494",
+          "label": "WB Games Montréal"
+        },
+        {
+          "code": "Q14760803",
+          "label": "Greenheart Games"
+        },
+        {
+          "code": "Q14913022",
+          "label": "Hitbox Team"
+        },
+        {
+          "code": "Q14791482",
+          "label": "Biart"
+        },
+        {
+          "code": "Q14913064",
+          "label": "Right Square Bracket Left Square Bracket"
+        },
+        {
+          "code": "Q105392197",
+          "label": "Blowfish Studios"
+        },
+        {
+          "code": "Q105102486",
+          "label": "Supergonk"
+        },
+        {
+          "code": "Q105335721",
+          "label": "Sunhead Games"
+        },
+        {
+          "code": "Q105355950",
+          "label": "Crazy Labs"
+        },
+        {
+          "code": "Q105356479",
+          "label": "Saigon Dragon Studios"
+        },
+        {
+          "code": "Q105163355",
+          "label": "Stuffed Wombat"
+        },
+        {
+          "code": "Q105100276",
+          "label": "Skookum Arts"
+        },
+        {
+          "code": "Q105106371",
+          "label": "Braingame Publishing"
+        },
+        {
+          "code": "Q105153955",
+          "label": "Sidebar Games"
+        },
+        {
+          "code": "Q105154362",
+          "label": "Fiftytwo"
+        },
+        {
+          "code": "Q105222217",
+          "label": "Robot House Games"
+        },
+        {
+          "code": "Q105265806",
+          "label": "TurtleBlaze"
+        },
+        {
+          "code": "Q105396095",
+          "label": "Superb Corp."
+        },
+        {
+          "code": "Q105089882",
+          "label": "Zing Games"
+        },
+        {
+          "code": "Q105114495",
+          "label": "Skeleton Crew Studio"
+        },
+        {
+          "code": "Q105152945",
+          "label": "Lowe Bros. Studios LLC"
+        },
+        {
+          "code": "Q105221692",
+          "label": "Acid Nerve"
+        },
+        {
+          "code": "Q105324825",
+          "label": "ROBI Studios"
+        },
+        {
+          "code": "Q105352121",
+          "label": "Mother Gaia"
+        },
+        {
+          "code": "Q105336498",
+          "label": "Lykke Studios"
+        },
+        {
+          "code": "Q105340331",
+          "label": "Big Green Pillow"
+        },
+        {
+          "code": "Q105364475",
+          "label": "Crescent Moon Games"
+        },
+        {
+          "code": "Q105415784",
+          "label": "Lilith Games and AlbataR"
+        },
+        {
+          "code": "Q105177879",
+          "label": "ChillyRoom"
+        },
+        {
+          "code": "Q105089922",
+          "label": "Firefly Games"
+        },
+        {
+          "code": "Q105100427",
+          "label": "Lillymo Games"
+        },
+        {
+          "code": "Q105161596",
+          "label": "State of Play"
+        },
+        {
+          "code": "Q105221824",
+          "label": "Vertigo Games"
+        },
+        {
+          "code": "Q2531521",
+          "label": "Kojima Productions"
+        },
+        {
+          "code": "Q2536056",
+          "label": "Tengen"
+        },
+        {
+          "code": "Q2509669",
+          "label": "Ossian Studios"
+        },
+        {
+          "code": "Q2510684",
+          "label": "Zynga Dallas"
+        },
+        {
+          "code": "Q2507506",
+          "label": "Eugen Systems"
+        },
+        {
+          "code": "Q2526471",
+          "label": "MAGES. GAME"
+        },
+        {
+          "code": "Q113677138",
+          "label": "Rogue Sun"
+        },
+        {
+          "code": "Q113866692",
+          "label": "Western Civilization Software"
+        },
+        {
+          "code": "Q113686579",
+          "label": "Pulsatrix Studios"
+        },
+        {
+          "code": "Q113882595",
+          "label": "Lowtek Games"
+        },
+        {
+          "code": "Q113686366",
+          "label": "Cafe Empty"
+        },
+        {
+          "code": "Q113866634",
+          "label": "Yobowargames"
+        },
+        {
+          "code": "Q113884338",
+          "label": "Shen Technologies"
+        },
+        {
+          "code": "Q113741686",
+          "label": "Azeroth, Inc."
+        },
+        {
+          "code": "Q113882479",
+          "label": "Capricia Productions"
+        },
+        {
+          "code": "Q113714258",
+          "label": "SeaCorpTech"
+        },
+        {
+          "code": "Q113866280",
+          "label": "Shenandoah Studio"
+        },
+        {
+          "code": "Q113686342",
+          "label": "Dark Amber Softworks"
+        },
+        {
+          "code": "Q113687138",
+          "label": "Exponential Games"
+        },
+        {
+          "code": "Q113866391",
+          "label": "Veitikka Studios"
+        },
+        {
+          "code": "Q113946210",
+          "label": "Ubisoft Odesa"
+        },
+        {
+          "code": "Q113686383",
+          "label": "FreeMind"
+        },
+        {
+          "code": "Q113866321",
+          "label": "The Aristocrats"
+        },
+        {
+          "code": "Q113676079",
+          "label": "Everstone Games"
+        },
+        {
+          "code": "Q113686387",
+          "label": "Console Labs"
+        },
+        {
+          "code": "Q113866304",
+          "label": "Straylight Entertainment"
+        },
+        {
+          "code": "Q113866398",
+          "label": "VR Designs"
+        },
+        {
+          "code": "Q113883572",
+          "label": "Xenofusion Studios"
+        },
+        {
+          "code": "Q113672892",
+          "label": "Duality Games"
+        },
+        {
+          "code": "Q113679910",
+          "label": "Codeglue"
+        },
+        {
+          "code": "Q113680733",
+          "label": "Z-Software"
+        },
+        {
+          "code": "Q113779761",
+          "label": "Toukana Interactive"
+        },
+        {
+          "code": "Q101086301",
+          "label": "Vogelfänger"
+        },
+        {
+          "code": "Q100907329",
+          "label": "Offworld Industries"
+        },
+        {
+          "code": "Q100975521",
+          "label": "Chiyomaru Studio"
+        },
+        {
+          "code": "Q101004619",
+          "label": "Fineway Studios"
+        },
+        {
+          "code": "Q101138557",
+          "label": "MysticGames"
+        },
+        {
+          "code": "Q101153108",
+          "label": "Screenlife Games"
+        },
+        {
+          "code": "Q101154322",
+          "label": "Little Boy Games"
+        },
+        {
+          "code": "Q101244327",
+          "label": "Dave Microwaves Games"
+        },
+        {
+          "code": "Q101584204",
+          "label": "Scriptwelder Studio"
+        },
+        {
+          "code": "Q101617829",
+          "label": "Binx Interactive"
+        },
+        {
+          "code": "Q100892539",
+          "label": "Zoom Out Games"
+        },
+        {
+          "code": "Q101153753",
+          "label": "Miracle Games"
+        },
+        {
+          "code": "Q101405731",
+          "label": "Zadbox Entertainment"
+        },
+        {
+          "code": "Q101423084",
+          "label": "PlayMagic"
+        },
+        {
+          "code": "Q100991013",
+          "label": "Deepnight Games"
+        },
+        {
+          "code": "Q101009537",
+          "label": "Corepunch Game Studio"
+        },
+        {
+          "code": "Q101364294",
+          "label": "Fusionsphere Systems"
+        },
+        {
+          "code": "Q101366848",
+          "label": "Gastronaut Studios"
+        },
+        {
+          "code": "Q101799651",
+          "label": "Triassic Games"
+        },
+        {
+          "code": "Q101065199",
+          "label": "The Knights of Unity"
+        },
+        {
+          "code": "Q101068215",
+          "label": "Jo-Mei Games"
+        },
+        {
+          "code": "Q101107953",
+          "label": "National Insecurities"
+        },
+        {
+          "code": "Q101110778",
+          "label": "REMIMORY"
+        },
+        {
+          "code": "Q101364685",
+          "label": "Graffiti Entertainment"
+        },
+        {
+          "code": "Q101069259",
+          "label": "Andrade Games"
+        },
+        {
+          "code": "Q100987671",
+          "label": "Nitrime"
+        },
+        {
+          "code": "Q101115212",
+          "label": "Earplay"
+        },
+        {
+          "code": "Q101251046",
+          "label": "Pixel by Pixel Studios"
+        },
+        {
+          "code": "Q101252542",
+          "label": "3D Oyuncu"
+        },
+        {
+          "code": "Q100873685",
+          "label": "Jetdogs Studios"
+        },
+        {
+          "code": "Q101153212",
+          "label": "Silver Lightning Software"
+        },
+        {
+          "code": "Q101213292",
+          "label": "Blue Brain Games"
+        },
+        {
+          "code": "Q101214683",
+          "label": "100 Stones Interactive"
+        },
+        {
+          "code": "Q101244437",
+          "label": "Skunk Software"
+        },
+        {
+          "code": "Q101000295",
+          "label": "horrorfantasy"
+        },
+        {
+          "code": "Q101008718",
+          "label": "Whalebox Studio"
+        },
+        {
+          "code": "Q101214003",
+          "label": "Enhance"
+        },
+        {
+          "code": "Q101215211",
+          "label": "HitGrab"
+        },
+        {
+          "code": "Q106436003",
+          "label": "Covenant.dev"
+        },
+        {
+          "code": "Q106438156",
+          "label": "Amanotes"
+        },
+        {
+          "code": "Q106463005",
+          "label": "Anirog Software"
+        },
+        {
+          "code": "Q106470371",
+          "label": "NIS America"
+        },
+        {
+          "code": "Q106489269",
+          "label": "Shorebound Studios"
+        },
+        {
+          "code": "Q106494850",
+          "label": "Pixelated Milk"
+        },
+        {
+          "code": "Q106538595",
+          "label": "Mana Games"
+        },
+        {
+          "code": "Q106636716",
+          "label": "Ego Software"
+        },
+        {
+          "code": "Q106435531",
+          "label": "Nekki"
+        },
+        {
+          "code": "Q106483441",
+          "label": "Game-Labs"
+        },
+        {
+          "code": "Q106472362",
+          "label": "Team Ladybug"
+        },
+        {
+          "code": "Q106495389",
+          "label": "Crunching Koalas"
+        },
+        {
+          "code": "Q106610148",
+          "label": "Frosty Pop"
+        },
+        {
+          "code": "Q106635418",
+          "label": "Lonely Troops"
+        },
+        {
+          "code": "Q106636911",
+          "label": "Brain Bug"
+        },
+        {
+          "code": "Q106658788",
+          "label": "Playdots"
+        },
+        {
+          "code": "Q106418737",
+          "label": "Blue Box Game Studios"
+        },
+        {
+          "code": "Q106472375",
+          "label": "Why so serious"
+        },
+        {
+          "code": "Q106474348",
+          "label": "GoodbyeWorld Games"
+        },
+        {
+          "code": "Q106581010",
+          "label": "Warchief Gaming"
+        },
+        {
+          "code": "Q106613211",
+          "label": "Bit Fry"
+        },
+        {
+          "code": "Q106592736",
+          "label": "Jump Over the Age"
+        },
+        {
+          "code": "Q106419504",
+          "label": "PM Studios"
+        },
+        {
+          "code": "Q106519419",
+          "label": "Lion Shield"
+        },
+        {
+          "code": "Q106610545",
+          "label": "Flightless"
+        },
+        {
+          "code": "Q106610773",
+          "label": "Light Brick Studio"
+        },
+        {
+          "code": "Q106675801",
+          "label": "Pixel Toys"
+        },
+        {
+          "code": "Q52030494",
+          "label": "Santa Clara Games"
+        },
+        {
+          "code": "Q52035880",
+          "label": "Birnam Wood Games"
+        },
+        {
+          "code": "Q52144653",
+          "label": "8th Day Software"
+        },
+        {
+          "code": "Q52159646",
+          "label": "North of Earth"
+        },
+        {
+          "code": "Q52159607",
+          "label": "Total Monkery"
+        },
+        {
+          "code": "Q52345503",
+          "label": "Cosmonaut Games"
+        },
+        {
+          "code": "Q52694640",
+          "label": "Noodlecake"
+        },
+        {
+          "code": "Q52539890",
+          "label": "Love Gun"
+        },
+        {
+          "code": "Q51955248",
+          "label": "EarthWork Games"
+        },
+        {
+          "code": "Q52085298",
+          "label": "Artifex Mundi"
+        },
+        {
+          "code": "Q52085723",
+          "label": "World-LooM Games"
+        },
+        {
+          "code": "Q52115738",
+          "label": "Mi-Clos Studio"
+        },
+        {
+          "code": "Q52164641",
+          "label": "HexWar Games"
+        },
+        {
+          "code": "Q52130127",
+          "label": "Super Awesome Hyper Dimensional Mega Team"
+        },
+        {
+          "code": "Q52153177",
+          "label": "Osgoode Media"
+        },
+        {
+          "code": "Q52202030",
+          "label": "Nostalgia Productions"
+        },
+        {
+          "code": "Q51959134",
+          "label": "12 Hit Combo"
+        },
+        {
+          "code": "Q52022226",
+          "label": "Witching Hour Studios"
+        },
+        {
+          "code": "Q52125123",
+          "label": "Neopica"
+        },
+        {
+          "code": "Q52159453",
+          "label": "Vision Designs"
+        },
+        {
+          "code": "Q52200626",
+          "label": "we.R.play"
+        },
+        {
+          "code": "Q52692538",
+          "label": "Above and Beyond Technologies"
+        },
+        {
+          "code": "Q52084103",
+          "label": "Hibernum Créations Inc."
+        },
+        {
+          "code": "Q52136141",
+          "label": "Blueshift Media"
+        },
+        {
+          "code": "Q52159684",
+          "label": "WhiteMoon Dreams"
+        },
+        {
+          "code": "Q52341326",
+          "label": "Cheesy Software"
+        },
+        {
+          "code": "Q52693236",
+          "label": "Idea Fabrik"
+        },
+        {
+          "code": "Q52730802",
+          "label": "Imperium42 Game Studio"
+        },
+        {
+          "code": "Q53212621",
+          "label": "Camex Games"
+        },
+        {
+          "code": "Q52139473",
+          "label": "Wellore"
+        },
+        {
+          "code": "Q52279640",
+          "label": "Enkord"
+        },
+        {
+          "code": "Q52691231",
+          "label": "WaywardXS Entertainment S.r.l."
+        },
+        {
+          "code": "Q52695329",
+          "label": "Ravenous Games"
+        },
+        {
+          "code": "Q52274946",
+          "label": "Vendel Games"
+        },
+        {
+          "code": "Q52382638",
+          "label": "Novaquark"
+        },
+        {
+          "code": "Q52084271",
+          "label": "Razzart Visual"
+        },
+        {
+          "code": "Q52087337",
+          "label": "Powerhead Games"
+        },
+        {
+          "code": "Q52163459",
+          "label": "EnjoyUp"
+        },
+        {
+          "code": "Q52340097",
+          "label": "Binary Innovations"
+        },
+        {
+          "code": "Q2737049",
+          "label": "Quest"
+        },
+        {
+          "code": "Q2719757",
+          "label": "Paradigm Entertainment"
+        },
+        {
+          "code": "Q2737059",
+          "label": "NanaOn-Sha"
+        },
+        {
+          "code": "Q2737798",
+          "label": "Edge of Reality"
+        },
+        {
+          "code": "Q2714179",
+          "label": "Empire Interactive"
+        },
+        {
+          "code": "Q2719211",
+          "label": "Next Level Games"
+        },
+        {
+          "code": "Q2735962",
+          "label": "Media.Vision"
+        },
+        {
+          "code": "Q2311125",
+          "label": "High Impact Games"
+        },
+        {
+          "code": "Q2324070",
+          "label": "Denda Games"
+        },
+        {
+          "code": "Q2329918",
+          "label": "Flight-Plan"
+        },
+        {
+          "code": "Q2324214",
+          "label": "HB Studios"
+        },
+        {
+          "code": "Q2326128",
+          "label": "Yullaby"
+        },
+        {
+          "code": "Q2319420",
+          "label": "Warner Bros. Games"
+        },
+        {
+          "code": "Q2335341",
+          "label": "Swingin' Ape Studios"
+        },
+        {
+          "code": "Q105612281",
+          "label": "SMG Studio"
+        },
+        {
+          "code": "Q105616092",
+          "label": "Moonsprout Games"
+        },
+        {
+          "code": "Q105654748",
+          "label": "Adrenalin Entertainment"
+        },
+        {
+          "code": "Q105518752",
+          "label": "Maximum Family Games"
+        },
+        {
+          "code": "Q105637181",
+          "label": "Oversight Productions"
+        },
+        {
+          "code": "Q105687032",
+          "label": "Velan Studios"
+        },
+        {
+          "code": "Q105438574",
+          "label": "Kremlingames"
+        },
+        {
+          "code": "Q105585242",
+          "label": "Anarch Entertainment"
+        },
+        {
+          "code": "Q105689463",
+          "label": "Applibot"
+        },
+        {
+          "code": "Q105494178",
+          "label": "Heaven Brotherhood"
+        },
+        {
+          "code": "Q105640480",
+          "label": "CGMatic"
+        },
+        {
+          "code": "Q105672184",
+          "label": "Ground Shatter"
+        },
+        {
+          "code": "Q105623468",
+          "label": "Scorpion Software"
+        },
+        {
+          "code": "Q105628616",
+          "label": "SNK-Games"
+        },
+        {
+          "code": "Q105658587",
+          "label": "Old Skull Games"
+        },
+        {
+          "code": "Q105683347",
+          "label": "Four Quarters"
+        },
+        {
+          "code": "Q105582975",
+          "label": "Eagre Games"
+        },
+        {
+          "code": "Q105630357",
+          "label": "Awe Interactive"
+        },
+        {
+          "code": "Q105697039",
+          "label": "SouthPAW Games"
+        },
+        {
+          "code": "Q105491139",
+          "label": "Appeal"
+        },
+        {
+          "code": "Q105450826",
+          "label": "Studio MDHR"
+        },
+        {
+          "code": "Q105529193",
+          "label": "Sakari Games"
+        },
+        {
+          "code": "Q105623524",
+          "label": "East Cube"
+        },
+        {
+          "code": "Q105640775",
+          "label": "Gamaga"
+        },
+        {
+          "code": "Q2666236",
+          "label": "Boffo Games"
+        },
+        {
+          "code": "Q2663520",
+          "label": "Vigil Games"
+        },
+        {
+          "code": "Q2665841",
+          "label": "Double Helix Games"
+        },
+        {
+          "code": "Q2660350",
+          "label": "Havok"
+        },
+        {
+          "code": "Q2661245",
+          "label": "Avalanche Studios Group"
+        },
+        {
+          "code": "Q104115259",
+          "label": "Intergalactic Development"
+        },
+        {
+          "code": "Q101807463",
+          "label": "Pikewin"
+        },
+        {
+          "code": "Q103161993",
+          "label": "Blue Chip Software"
+        },
+        {
+          "code": "Q104178634",
+          "label": "FullBluff Studio"
+        },
+        {
+          "code": "Q103821059",
+          "label": "Interactive Pictures"
+        },
+        {
+          "code": "Q104158496",
+          "label": "Resonair"
+        },
+        {
+          "code": "Q104241491",
+          "label": "Moebial Studios"
+        },
+        {
+          "code": "Q104243582",
+          "label": "Cloudscan"
+        },
+        {
+          "code": "Q102503362",
+          "label": "WizBang! Software Productions"
+        },
+        {
+          "code": "Q104176217",
+          "label": "Onion Soup Interactive"
+        },
+        {
+          "code": "Q104377097",
+          "label": "Kaizen Game Works"
+        },
+        {
+          "code": "Q101976632",
+          "label": "Quite Interesting Ltd."
+        },
+        {
+          "code": "Q102271088",
+          "label": "Gameloft Iberica"
+        },
+        {
+          "code": "Q102507446",
+          "label": "CrazyBunch"
+        },
+        {
+          "code": "Q103062354",
+          "label": "Lula Online"
+        },
+        {
+          "code": "Q104372624",
+          "label": "Second Dinner"
+        },
+        {
+          "code": "Q102429321",
+          "label": "Gungrounds"
+        },
+        {
+          "code": "Q102475413",
+          "label": "Sbug Games"
+        },
+        {
+          "code": "Q103393061",
+          "label": "RAC7 Games"
+        },
+        {
+          "code": "Q103817379",
+          "label": "Faceroll Games"
+        },
+        {
+          "code": "Q103821139",
+          "label": "Military Simulations"
+        },
+        {
+          "code": "Q103998720",
+          "label": "Nicholson NY"
+        },
+        {
+          "code": "Q104158530",
+          "label": "Monstars"
+        },
+        {
+          "code": "Q104176272",
+          "label": "Periscope Games"
+        },
+        {
+          "code": "Q102326494",
+          "label": "LKA"
+        },
+        {
+          "code": "Q101805018",
+          "label": "Random Games"
+        },
+        {
+          "code": "Q102424064",
+          "label": "Polygon Treehouse"
+        },
+        {
+          "code": "Q102426398",
+          "label": "Marmalade Game Studio"
+        },
+        {
+          "code": "Q104054449",
+          "label": "Canuck Play"
+        },
+        {
+          "code": "Q104214913",
+          "label": "Dumativa"
+        },
+        {
+          "code": "Q2541040",
+          "label": "Spike"
+        },
+        {
+          "code": "Q2540486",
+          "label": "Amanita Design"
+        },
+        {
+          "code": "Q2546713",
+          "label": "Marvelous"
+        },
+        {
+          "code": "Q2545055",
+          "label": "Molleindustria"
+        },
+        {
+          "code": "Q2538835",
+          "label": "Rampid Interactive"
+        },
+        {
+          "code": "Q2541023",
+          "label": "Frogwares"
+        },
+        {
+          "code": "Q16994105",
+          "label": "Giant Sparrow"
+        },
+        {
+          "code": "Q16839592",
+          "label": "Games Distillery"
+        },
+        {
+          "code": "Q16927629",
+          "label": "Crash Lab"
+        },
+        {
+          "code": "Q16952137",
+          "label": "Mind Candy"
+        },
+        {
+          "code": "Q16992195",
+          "label": "Firesprite"
+        },
+        {
+          "code": "Q16842446",
+          "label": "Headstrong Games"
+        },
+        {
+          "code": "Q16988330",
+          "label": "Curve Games"
+        },
+        {
+          "code": "Q16967691",
+          "label": "Press Play"
+        },
+        {
+          "code": "Q16950209",
+          "label": "Majorem"
+        },
+        {
+          "code": "Q16974203",
+          "label": "Action Button Entertainment"
+        },
+        {
+          "code": "Q16986584",
+          "label": "Slipgate Ironworks"
+        },
+        {
+          "code": "Q16926189",
+          "label": "Qifun Entertainment"
+        },
+        {
+          "code": "Q16967229",
+          "label": "Playdek"
+        },
+        {
+          "code": "Q16958749",
+          "label": "Uken Games"
+        },
+        {
+          "code": "Q16945598",
+          "label": "Shortfuse Games"
+        },
+        {
+          "code": "Q16978430",
+          "label": "Puppy Games"
+        },
+        {
+          "code": "Q2745586",
+          "label": "Genius Sonority"
+        },
+        {
+          "code": "Q2748676",
+          "label": "Victor Interactive Software"
+        },
+        {
+          "code": "Q2740414",
+          "label": "Team Ninja"
+        },
+        {
+          "code": "Q2818984",
+          "label": "ABA Games"
+        },
+        {
+          "code": "Q2822685",
+          "label": "Access Games"
+        },
+        {
+          "code": "Q2822760",
+          "label": "Acclaim Studios London"
+        },
+        {
+          "code": "Q2813753",
+          "label": "1st Playable Productions"
+        },
+        {
+          "code": "Q112245645",
+          "label": "Traffic Games"
+        },
+        {
+          "code": "Q112874946",
+          "label": "Tail Aki"
+        },
+        {
+          "code": "Q112895123",
+          "label": "Belka Games"
+        },
+        {
+          "code": "Q112895113",
+          "label": "Firecraft Studios"
+        },
+        {
+          "code": "Q112895139",
+          "label": "Redemption Games"
+        },
+        {
+          "code": "Q112958944",
+          "label": "The Sixth Hammer"
+        },
+        {
+          "code": "Q112996287",
+          "label": "Altari Games"
+        },
+        {
+          "code": "Q112277961",
+          "label": "Atomic Raccoon Studio"
+        },
+        {
+          "code": "Q112943243",
+          "label": "Abramelin Games"
+        },
+        {
+          "code": "Q112968797",
+          "label": "Cosmic Boop"
+        },
+        {
+          "code": "Q112973406",
+          "label": "Bloodious Games"
+        },
+        {
+          "code": "Q112998905",
+          "label": "GrimTalin"
+        },
+        {
+          "code": "Q113101662",
+          "label": "Pirate Software"
+        },
+        {
+          "code": "Q112987683",
+          "label": "Wallride"
+        },
+        {
+          "code": "Q112286454",
+          "label": "HypeHype"
+        },
+        {
+          "code": "Q112943479",
+          "label": "Siberian Koala"
+        },
+        {
+          "code": "Q113104834",
+          "label": "Bamtang Games"
+        },
+        {
+          "code": "Q112230816",
+          "label": "iWare Designs"
+        },
+        {
+          "code": "Q112249274",
+          "label": "Khud0"
+        },
+        {
+          "code": "Q112668937",
+          "label": "Reworks"
+        },
+        {
+          "code": "Q112895106",
+          "label": "PeopleFun"
+        },
+        {
+          "code": "Q112898642",
+          "label": "Pop Software"
+        },
+        {
+          "code": "Q112968498",
+          "label": "Dream Oni"
+        },
+        {
+          "code": "Q113009569",
+          "label": "gigantumgames"
+        },
+        {
+          "code": "Q112243930",
+          "label": "Randumb Studios"
+        },
+        {
+          "code": "Q112340849",
+          "label": "Coffeenauts"
+        },
+        {
+          "code": "Q112988986",
+          "label": "Nephilim Game Studios"
+        },
+        {
+          "code": "Q112249332",
+          "label": "Neki4 Electronics"
+        },
+        {
+          "code": "Q112426984",
+          "label": "Totem Arts"
+        },
+        {
+          "code": "Q112927646",
+          "label": "Dev9k"
+        },
+        {
+          "code": "Q112988329",
+          "label": "Kittehface"
+        },
+        {
+          "code": "Q112988863",
+          "label": "Alien Pixel Studios"
+        },
+        {
+          "code": "Q112995805",
+          "label": "Istom Games"
+        },
+        {
+          "code": "Q113027991",
+          "label": "FromSouthGames"
+        },
+        {
+          "code": "Q112303848",
+          "label": "Godville Games"
+        },
+        {
+          "code": "Q112586584",
+          "label": "Ouka Studios"
+        },
+        {
+          "code": "Q112946828",
+          "label": "Seep"
+        },
+        {
+          "code": "Q112407058",
+          "label": "Studio Drydock"
+        },
+        {
+          "code": "Q112818837",
+          "label": "OliveBloops"
+        },
+        {
+          "code": "Q112926322",
+          "label": "Gentlymad Studios"
+        },
+        {
+          "code": "Q112927315",
+          "label": "Massive Work Studio"
+        },
+        {
+          "code": "Q112943360",
+          "label": "Rose City Games"
+        },
+        {
+          "code": "Q112943556",
+          "label": "Igrek Games"
+        },
+        {
+          "code": "Q112249770",
+          "label": "lightUP"
+        },
+        {
+          "code": "Q112943219",
+          "label": "Lion's Shade"
+        },
+        {
+          "code": "Q112943608",
+          "label": "Melbot Studios"
+        },
+        {
+          "code": "Q112946754",
+          "label": "Next Game Level"
+        },
+        {
+          "code": "Q112965611",
+          "label": "Ripknot Systems"
+        },
+        {
+          "code": "Q112249746",
+          "label": "Sergey Bobrov"
+        },
+        {
+          "code": "Q105960384",
+          "label": "Flipline Studios"
+        },
+        {
+          "code": "Q106019609",
+          "label": "East Side Games"
+        },
+        {
+          "code": "Q105725001",
+          "label": "Iron Gate Studio"
+        },
+        {
+          "code": "Q105745040",
+          "label": "Quantum Giant"
+        },
+        {
+          "code": "Q105940497",
+          "label": "Taldren"
+        },
+        {
+          "code": "Q105710085",
+          "label": "Route 59"
+        },
+        {
+          "code": "Q105750143",
+          "label": "Wonderbelly Games"
+        },
+        {
+          "code": "Q105962457",
+          "label": "Highwire Games"
+        },
+        {
+          "code": "Q105722121",
+          "label": "Cobra Mobile"
+        },
+        {
+          "code": "Q105763443",
+          "label": "LMC Software"
+        },
+        {
+          "code": "Q105882858",
+          "label": "Levall Games"
+        },
+        {
+          "code": "Q105958095",
+          "label": "Dave Nutting Associates"
+        },
+        {
+          "code": "Q105987843",
+          "label": "Haven Studios"
+        },
+        {
+          "code": "Q105697920",
+          "label": "Pixel Beef Games"
+        },
+        {
+          "code": "Q105701837",
+          "label": "That Silly Studio"
+        },
+        {
+          "code": "Q105710019",
+          "label": "1 Simple Game"
+        },
+        {
+          "code": "Q105727467",
+          "label": "Dumb and Fat Games"
+        },
+        {
+          "code": "Q105745052",
+          "label": "Barbacube"
+        },
+        {
+          "code": "Q105745608",
+          "label": "Atmos Games"
+        },
+        {
+          "code": "Q105745750",
+          "label": "Lightning Rod Games"
+        },
+        {
+          "code": "Q105953305",
+          "label": "Double Stallion"
+        },
+        {
+          "code": "Q105953576",
+          "label": "Batovi Games Studio"
+        },
+        {
+          "code": "Q105785663",
+          "label": "Cold Iron Studios"
+        },
+        {
+          "code": "Q105787276",
+          "label": "Graceful Decay"
+        },
+        {
+          "code": "Q105965878",
+          "label": "Memorable Games"
+        },
+        {
+          "code": "Q105701577",
+          "label": "IzanagiGames"
+        },
+        {
+          "code": "Q105784360",
+          "label": "TallBoys"
+        },
+        {
+          "code": "Q105835569",
+          "label": "GD Studio"
+        },
+        {
+          "code": "Q105836013",
+          "label": "Studio Klondike"
+        },
+        {
+          "code": "Q106019597",
+          "label": "Leaf Mobile"
+        },
+        {
+          "code": "Q105966974",
+          "label": "Mighty Bear Games"
+        },
+        {
+          "code": "Q17297596",
+          "label": "Yager Development"
+        },
+        {
+          "code": "Q17401824",
+          "label": "Spark Plug Games"
+        },
+        {
+          "code": "Q17515562",
+          "label": "Xona Games"
+        },
+        {
+          "code": "Q17215668",
+          "label": "Parasol"
+        },
+        {
+          "code": "Q17193803",
+          "label": "Index Corporation"
+        },
+        {
+          "code": "Q17211555",
+          "label": "KITERETSU"
+        },
+        {
+          "code": "Q17239932",
+          "label": "Galette"
+        },
+        {
+          "code": "Q17216658",
+          "label": "Klon"
+        },
+        {
+          "code": "Q17561297",
+          "label": "Fullbright"
+        },
+        {
+          "code": "Q17373691",
+          "label": "Flair Software"
+        },
+        {
+          "code": "Q17640231",
+          "label": "Ubisoft Abu Dhabi"
+        },
+        {
+          "code": "Q17228185",
+          "label": "Karin Entertainment"
+        },
+        {
+          "code": "Q17231171",
+          "label": "Shiratama"
+        },
+        {
+          "code": "Q17483938",
+          "label": "Crytek Frankfurt"
+        },
+        {
+          "code": "Q17401825",
+          "label": "Quantum Mechanix"
+        },
+        {
+          "code": "Q17511176",
+          "label": "Boss Key Productions"
+        },
+        {
+          "code": "Q17228555",
+          "label": "Collavier"
+        },
+        {
+          "code": "Q2613004",
+          "label": "Jupiter"
+        },
+        {
+          "code": "Q2607531",
+          "label": "Harmonix Music Systems"
+        },
+        {
+          "code": "Q2612323",
+          "label": "Kaneko"
+        },
+        {
+          "code": "Q2617855",
+          "label": "Arc System Works"
+        },
+        {
+          "code": "Q2617918",
+          "label": "High Voltage Software"
+        },
+        {
+          "code": "Q104541491",
+          "label": "Nimble Neuron"
+        },
+        {
+          "code": "Q104591242",
+          "label": "CSP Mobile GmbH"
+        },
+        {
+          "code": "Q104636206",
+          "label": "Serenity Forge"
+        },
+        {
+          "code": "Q104771975",
+          "label": "Nekogames"
+        },
+        {
+          "code": "Q104381937",
+          "label": "Douze Dixièmes"
+        },
+        {
+          "code": "Q104420401",
+          "label": "Cyberframe Studios"
+        },
+        {
+          "code": "Q104431624",
+          "label": "FYRE Games"
+        },
+        {
+          "code": "Q104535765",
+          "label": "Bombservice"
+        },
+        {
+          "code": "Q104584199",
+          "label": "Alike Studio"
+        },
+        {
+          "code": "Q104720793",
+          "label": "Arkhouse Telegraph"
+        },
+        {
+          "code": "Q104580902",
+          "label": "Flashbulb Games"
+        },
+        {
+          "code": "Q104743368",
+          "label": "McLeodGaming"
+        },
+        {
+          "code": "Q104467592",
+          "label": "Dreams Uncorporated"
+        },
+        {
+          "code": "Q104759461",
+          "label": "Cassel Games"
+        },
+        {
+          "code": "Q104382608",
+          "label": "Shiver Entertainment"
+        },
+        {
+          "code": "Q104601306",
+          "label": "Eggcode Games"
+        },
+        {
+          "code": "Q104623258",
+          "label": "Lichtund"
+        },
+        {
+          "code": "Q104641083",
+          "label": "Flow Fire Games"
+        },
+        {
+          "code": "Q104785259",
+          "label": "Devespresso Games"
+        },
+        {
+          "code": "Q104438093",
+          "label": "Kupaa Studios"
+        },
+        {
+          "code": "Q104519227",
+          "label": "Drakhar Studio"
+        },
+        {
+          "code": "Q104761747",
+          "label": "Hijinx Studios"
+        },
+        {
+          "code": "Q104537060",
+          "label": "Astronomic Games"
+        },
+        {
+          "code": "Q104634086",
+          "label": "Origame Digital"
+        },
+        {
+          "code": "Q104638837",
+          "label": "Moonfrog"
+        },
+        {
+          "code": "Q104601053",
+          "label": "Wolfy"
+        },
+        {
+          "code": "Q104542008",
+          "label": "Rocketcat Games"
+        },
+        {
+          "code": "Q104628690",
+          "label": "The Balance Inc"
+        },
+        {
+          "code": "Q104630423",
+          "label": "Toybox Inc."
+        },
+        {
+          "code": "Q15737144",
+          "label": "Almost Human"
+        },
+        {
+          "code": "Q15070500",
+          "label": "Wildfire Studios"
+        },
+        {
+          "code": "Q15813203",
+          "label": "Spiders"
+        },
+        {
+          "code": "Q15232085",
+          "label": "Lexis Numérique"
+        },
+        {
+          "code": "Q15268911",
+          "label": "Torn Banner Studios"
+        },
+        {
+          "code": "Q15781815",
+          "label": "Aerosoft"
+        },
+        {
+          "code": "Q15623283",
+          "label": "Dennaton Games"
+        },
+        {
+          "code": "Q15070508",
+          "label": "ZettaMedia"
+        },
+        {
+          "code": "Q15294119",
+          "label": "Collecting Smiles"
+        },
+        {
+          "code": "Q15651013",
+          "label": "Dingo Inc."
+        },
+        {
+          "code": "Q15070478",
+          "label": "Tiny Bull Studios"
+        },
+        {
+          "code": "Q15070484",
+          "label": "Trickstar Games"
+        },
+        {
+          "code": "Q15240959",
+          "label": "Team Bloodlust"
+        },
+        {
+          "code": "Q15139437",
+          "label": "NEXON Korea"
+        },
+        {
+          "code": "Q15070492",
+          "label": "Universomo"
+        },
+        {
+          "code": "Q15125518",
+          "label": "VG Entertainment"
+        },
+        {
+          "code": "Q100594808",
+          "label": "Vantan International"
+        },
+        {
+          "code": "Q100734718",
+          "label": "One More Level"
+        },
+        {
+          "code": "Q100786002",
+          "label": "SadSquare Studio"
+        },
+        {
+          "code": "Q100706110",
+          "label": "Compucolor Pictures"
+        },
+        {
+          "code": "Q100741957",
+          "label": "Jpeg of Pain Games"
+        },
+        {
+          "code": "Q100871863",
+          "label": "Four Circle Interactive"
+        },
+        {
+          "code": "Q100760429",
+          "label": "Final Scene Dev"
+        },
+        {
+          "code": "Q100796552",
+          "label": "Darril Arts"
+        },
+        {
+          "code": "Q100597769",
+          "label": "Łukasz Jakowski Games"
+        },
+        {
+          "code": "Q100698479",
+          "label": "Frost Giant Studios"
+        },
+        {
+          "code": "Q18398602",
+          "label": "Minority Media"
+        },
+        {
+          "code": "Q18415238",
+          "label": "Ryu ga Gotoku Studio"
+        },
+        {
+          "code": "Q18416053",
+          "label": "Amplitude Studios"
+        },
+        {
+          "code": "Q18611508",
+          "label": "CROOZ"
+        },
+        {
+          "code": "Q18414205",
+          "label": "Future Games Of London"
+        },
+        {
+          "code": "Q18357865",
+          "label": "Masthead Studios"
+        },
+        {
+          "code": "Q18358383",
+          "label": "Sickhead Games"
+        },
+        {
+          "code": "Q18394514",
+          "label": "TinyCo"
+        },
+        {
+          "code": "Q18424822",
+          "label": "Giants Software"
+        },
+        {
+          "code": "Q18355686",
+          "label": "Flying Tiger Development"
+        },
+        {
+          "code": "Q18390435",
+          "label": "Youda Games"
+        },
+        {
+          "code": "Q18689156",
+          "label": "Shiver Games"
+        },
+        {
+          "code": "Q18454891",
+          "label": "P Studio"
+        },
+        {
+          "code": "Q18688764",
+          "label": "Grand Cru Games"
+        },
+        {
+          "code": "Q18388687",
+          "label": "Lift London"
+        },
+        {
+          "code": "Q98756957",
+          "label": "Hi-Tec Software"
+        },
+        {
+          "code": "Q98785807",
+          "label": "Westwood Pacific"
+        },
+        {
+          "code": "Q98793312",
+          "label": "MicroStyle"
+        },
+        {
+          "code": "Q98815148",
+          "label": "MacDaddy Entertainment"
+        },
+        {
+          "code": "Q98884357",
+          "label": "Fusty Game"
+        },
+        {
+          "code": "Q98961329",
+          "label": "Innersloth"
+        },
+        {
+          "code": "Q99479230",
+          "label": "Neat Corporation"
+        },
+        {
+          "code": "Q99521320",
+          "label": "Empire Oxford"
+        },
+        {
+          "code": "Q98593285",
+          "label": "Extra Mile Studios"
+        },
+        {
+          "code": "Q98785161",
+          "label": "Apogee Entertainment"
+        },
+        {
+          "code": "Q98785815",
+          "label": "DreamWorks Interactive"
+        },
+        {
+          "code": "Q98793299",
+          "label": "MicroPlay Software"
+        },
+        {
+          "code": "Q98798330",
+          "label": "Magmic Games"
+        },
+        {
+          "code": "Q99169076",
+          "label": "Rocket Juice Games"
+        },
+        {
+          "code": "Q99414382",
+          "label": "Team ViewSelect"
+        },
+        {
+          "code": "Q98760406",
+          "label": "The Voxel Agents"
+        },
+        {
+          "code": "Q98882067",
+          "label": "Team Reptile"
+        },
+        {
+          "code": "Q98884363",
+          "label": "Midgar Studio"
+        },
+        {
+          "code": "Q98894800",
+          "label": "Aerie Gaming Studios"
+        },
+        {
+          "code": "Q99167221",
+          "label": "Hyperstrange"
+        },
+        {
+          "code": "Q99479728",
+          "label": "ThroughLine Games"
+        },
+        {
+          "code": "Q98955546",
+          "label": "Creative Concepts"
+        },
+        {
+          "code": "Q98877530",
+          "label": "Suzaku"
+        },
+        {
+          "code": "Q98696090",
+          "label": "Nine Dots Studio"
+        },
+        {
+          "code": "Q99297811",
+          "label": "SELECT BUTTON Inc."
+        },
+        {
+          "code": "Q99479109",
+          "label": "Spearhead Games"
+        },
+        {
+          "code": "Q99521312",
+          "label": "Oxford Digital Enterprises Ltd"
+        },
+        {
+          "code": "Q98539285",
+          "label": "Flight School Studio"
+        },
+        {
+          "code": "Q98599250",
+          "label": "Draw Distance"
+        },
+        {
+          "code": "Q98637533",
+          "label": "Sokpop Collective"
+        },
+        {
+          "code": "Q99541306",
+          "label": "Dreamhaven"
+        },
+        {
+          "code": "Q114976733",
+          "label": "Vertigo Games"
+        },
+        {
+          "code": "Q114822405",
+          "label": "Crioland"
+        },
+        {
+          "code": "Q114834714",
+          "label": "PlayPun"
+        },
+        {
+          "code": "Q114859667",
+          "label": "EMIKA_GAMES"
+        },
+        {
+          "code": "Q114876762",
+          "label": "OnSkull Games"
+        },
+        {
+          "code": "Q114881484",
+          "label": "lbdl GameStudio"
+        },
+        {
+          "code": "Q114933322",
+          "label": "Coin Crew Games"
+        },
+        {
+          "code": "Q114956252",
+          "label": "Dragonfire Studios"
+        },
+        {
+          "code": "Q114872378",
+          "label": "Weather Factory"
+        },
+        {
+          "code": "Q114833982",
+          "label": "Pixel Plant LLC"
+        },
+        {
+          "code": "Q114860546",
+          "label": "Sunward Games"
+        },
+        {
+          "code": "Q114930905",
+          "label": "Black Cube Games"
+        },
+        {
+          "code": "Q114931758",
+          "label": "I-Inferno"
+        },
+        {
+          "code": "Q114834842",
+          "label": "Unfrozen"
+        },
+        {
+          "code": "Q114702901",
+          "label": "Sunnyside Games"
+        },
+        {
+          "code": "Q114787057",
+          "label": "Massive Monster"
+        },
+        {
+          "code": "Q114834850",
+          "label": "Ellada Games"
+        },
+        {
+          "code": "Q114841872",
+          "label": "Nerdook Productions"
+        },
+        {
+          "code": "Q114881091",
+          "label": "Lockpickle"
+        },
+        {
+          "code": "Q114881635",
+          "label": "InterAction studios"
+        },
+        {
+          "code": "Q114933041",
+          "label": "Red Fly Studio"
+        },
+        {
+          "code": "Q114953419",
+          "label": "SpaceOwl Games"
+        },
+        {
+          "code": "Q114915944",
+          "label": "Spiral House"
+        },
+        {
+          "code": "Q114822441",
+          "label": "Stail Group"
+        },
+        {
+          "code": "Q114834835",
+          "label": "Studio 61"
+        },
+        {
+          "code": "Q114881581",
+          "label": "DEL PLAYER"
+        },
+        {
+          "code": "Q114691313",
+          "label": "FREAKY DESIGN"
+        },
+        {
+          "code": "Q114816829",
+          "label": "SkyMill"
+        },
+        {
+          "code": "Q114852232",
+          "label": "3-Fold Games"
+        },
+        {
+          "code": "Q114873956",
+          "label": "NeoBards Entertainment"
+        },
+        {
+          "code": "Q114918347",
+          "label": "rose-engine"
+        },
+        {
+          "code": "Q114934212",
+          "label": "PHL Collective"
+        },
+        {
+          "code": "Q114691311",
+          "label": "Seaknot Studios"
+        },
+        {
+          "code": "Q114708539",
+          "label": "Digital Excess"
+        },
+        {
+          "code": "Q114749145",
+          "label": "Zetsubou Games"
+        },
+        {
+          "code": "Q114834846",
+          "label": "GDTeam"
+        },
+        {
+          "code": "Q114834908",
+          "label": "Clarus Victoria"
+        },
+        {
+          "code": "Q114881551",
+          "label": "Kether Studio"
+        },
+        {
+          "code": "Q114929255",
+          "label": "Half Past Yellow"
+        },
+        {
+          "code": "Q114932238",
+          "label": "LCB Game Studio"
+        },
+        {
+          "code": "Q114724986",
+          "label": "Frag Lab"
+        },
+        {
+          "code": "Q114711458",
+          "label": "Ark Heiral"
+        },
+        {
+          "code": "Q114817103",
+          "label": "VZ.lab"
+        },
+        {
+          "code": "Q114833851",
+          "label": "WASABAE Studios"
+        },
+        {
+          "code": "Q114860571",
+          "label": "The Backrooms"
+        },
+        {
+          "code": "Q114860586",
+          "label": "The House of Fables"
+        },
+        {
+          "code": "Q114896140",
+          "label": "Cadenza Interactive"
+        },
+        {
+          "code": "Q114691825",
+          "label": "Tasto Alpha"
+        },
+        {
+          "code": "Q114833755",
+          "label": "Pie On A Plate Productions"
+        },
+        {
+          "code": "Q114834848",
+          "label": "Axlebolt"
+        },
+        {
+          "code": "Q114860678",
+          "label": "Cordelia Games"
+        },
+        {
+          "code": "Q114881691",
+          "label": "Recotechnology S.L."
+        },
+        {
+          "code": "Q2373150",
+          "label": "Spicy Horse"
+        },
+        {
+          "code": "Q2383221",
+          "label": "Best Way"
+        },
+        {
+          "code": "Q2409319",
+          "label": "Vicious Cycle Software"
+        },
+        {
+          "code": "Q2389983",
+          "label": "Human Head Studios"
+        },
+        {
+          "code": "Q2373062",
+          "label": "EA Black Box"
+        },
+        {
+          "code": "Q2408214",
+          "label": "Human Entertainment"
+        },
+        {
+          "code": "Q54149873",
+          "label": "MiCROViSion Inc."
+        },
+        {
+          "code": "Q54171226",
+          "label": "Komar Games"
+        },
+        {
+          "code": "Q54255920",
+          "label": "Mobigame"
+        },
+        {
+          "code": "Q54257504",
+          "label": "MPForce, Inc."
+        },
+        {
+          "code": "Q54258978",
+          "label": "Peak Games"
+        },
+        {
+          "code": "Q54308709",
+          "label": "Super Evil Megacorp"
+        },
+        {
+          "code": "Q54150946",
+          "label": "Sol"
+        },
+        {
+          "code": "Q54151009",
+          "label": "BEC Co., Ltd."
+        },
+        {
+          "code": "Q54131639",
+          "label": "HumaNature Studios"
+        },
+        {
+          "code": "Q54121489",
+          "label": "Chubby Pixel"
+        },
+        {
+          "code": "Q54150141",
+          "label": "Atelier Double Co. Ltd."
+        },
+        {
+          "code": "Q54257201",
+          "label": "Moregames Entertainment"
+        },
+        {
+          "code": "Q54150897",
+          "label": "Design Factory"
+        },
+        {
+          "code": "Q54117155",
+          "label": "Adage Games"
+        },
+        {
+          "code": "Q54122845",
+          "label": "Crows Crows Crows"
+        },
+        {
+          "code": "Q54149161",
+          "label": "Pre-Stage Inc."
+        },
+        {
+          "code": "Q54149439",
+          "label": "Winds Co., Ltd."
+        },
+        {
+          "code": "Q54149598",
+          "label": "Painting by Numbers, Ltd."
+        },
+        {
+          "code": "Q53878765",
+          "label": "VRChat Inc."
+        },
+        {
+          "code": "Q54149220",
+          "label": "Sweets Games"
+        },
+        {
+          "code": "Q54150472",
+          "label": "The Quantum Astrophysicists Guild"
+        },
+        {
+          "code": "Q54258449",
+          "label": "Oasis Games"
+        },
+        {
+          "code": "Q54307207",
+          "label": "PVP Studio"
+        },
+        {
+          "code": "Q54130855",
+          "label": "Gunjin Games Limited"
+        },
+        {
+          "code": "Q54132750",
+          "label": "ILLION Corp"
+        },
+        {
+          "code": "Q54149499",
+          "label": "Athena Co., Ltd."
+        },
+        {
+          "code": "Q54150975",
+          "label": "Dreams Co., Ltd."
+        },
+        {
+          "code": "Q54304404",
+          "label": "PaperSeven"
+        },
+        {
+          "code": "Q54305596",
+          "label": "Psydra Games"
+        },
+        {
+          "code": "Q54150169",
+          "label": "Digital Works Entertainment Co., Ltd."
+        },
+        {
+          "code": "Q54150420",
+          "label": "ITL Co., Ltd."
+        },
+        {
+          "code": "Q54258000",
+          "label": "Neuron Games"
+        },
+        {
+          "code": "Q53310065",
+          "label": "Hit-Point"
+        },
+        {
+          "code": "Q54149152",
+          "label": "Vingt-et-un Systems Corporation"
+        },
+        {
+          "code": "Q54149560",
+          "label": "Sega AM3 R&D Division"
+        },
+        {
+          "code": "Q54149857",
+          "label": "Nurijoy Inc."
+        },
+        {
+          "code": "Q54150126",
+          "label": "Amedio Co., Ltd."
+        },
+        {
+          "code": "Q54150483",
+          "label": "Sugar & Rockets, Inc."
+        },
+        {
+          "code": "Q15070384",
+          "label": "Limbic Software"
+        },
+        {
+          "code": "Q15070391",
+          "label": "Mad Genius Software"
+        },
+        {
+          "code": "Q15070412",
+          "label": "Netdol"
+        },
+        {
+          "code": "Q15070420",
+          "label": "Oasys Mobile"
+        },
+        {
+          "code": "Q15070455",
+          "label": "Small Rockets"
+        },
+        {
+          "code": "Q15070465",
+          "label": "Sublogic"
+        },
+        {
+          "code": "Q15070396",
+          "label": "Mediatonic"
+        },
+        {
+          "code": "Q15070410",
+          "label": "NDOORS Corporation"
+        },
+        {
+          "code": "Q15070449",
+          "label": "Sherman3D"
+        },
+        {
+          "code": "Q15070367",
+          "label": "Iron Realms Entertainment"
+        },
+        {
+          "code": "Q15070395",
+          "label": "Mean Hamster Software"
+        },
+        {
+          "code": "Q15070363",
+          "label": "Innerprise Software"
+        },
+        {
+          "code": "Q15070371",
+          "label": "Jackbox Games"
+        },
+        {
+          "code": "Q15070429",
+          "label": "Playware Studios"
+        },
+        {
+          "code": "Q15070378",
+          "label": "Koramgame"
+        },
+        {
+          "code": "Q15070389",
+          "label": "Lotus Creative Entertainment"
+        },
+        {
+          "code": "Q15070400",
+          "label": "Mind's Eye Productions"
+        },
+        {
+          "code": "Q15070374",
+          "label": "Junebud"
+        },
+        {
+          "code": "Q15070403",
+          "label": "Mithis Entertainment"
+        },
+        {
+          "code": "Q15070438",
+          "label": "Razorback Developments"
+        },
+        {
+          "code": "Q15070359",
+          "label": "Illusion Labs"
+        },
+        {
+          "code": "Q15070369",
+          "label": "Island Officials"
+        },
+        {
+          "code": "Q15070370",
+          "label": "Ubisoft Ivory Tower"
+        },
+        {
+          "code": "Q3026228",
+          "label": "Propaganda Games"
+        },
+        {
+          "code": "Q3030624",
+          "label": "Technology and Entertainment Software"
+        },
+        {
+          "code": "Q3037459",
+          "label": "Double Eleven"
+        },
+        {
+          "code": "Q3026554",
+          "label": "Stainless Steel Studios"
+        },
+        {
+          "code": "Q3032258",
+          "label": "Divide By Zero"
+        },
+        {
+          "code": "Q3039227",
+          "label": "DreamForge Intertainment"
+        },
+        {
+          "code": "Q3036861",
+          "label": "Don’t Nod"
+        },
+        {
+          "code": "Q3039230",
+          "label": "DreamFactory"
+        },
+        {
+          "code": "Q2975455",
+          "label": "Clap Hanz"
+        },
+        {
+          "code": "Q2937216",
+          "label": "Capcom Production Studio 1"
+        },
+        {
+          "code": "Q2941572",
+          "label": "Cat Daddy Games"
+        },
+        {
+          "code": "Q2929065",
+          "label": "Buzz Monkey Software"
+        },
+        {
+          "code": "Q2944021",
+          "label": "Cellius"
+        },
+        {
+          "code": "Q2983159",
+          "label": "Sting Entertainment"
+        },
+        {
+          "code": "Q2981951",
+          "label": "Coktel Vision"
+        },
+        {
+          "code": "Q2981849",
+          "label": "Zombie Studios"
+        },
+        {
+          "code": "Q2981171",
+          "label": "Cobrasoft"
+        },
+        {
+          "code": "Q2937730",
+          "label": "Capybara Games"
+        },
+        {
+          "code": "Q13409231",
+          "label": "Atari, Inc."
+        },
+        {
+          "code": "Q13512339",
+          "label": "Facepunch Studios"
+        },
+        {
+          "code": "Q13459480",
+          "label": "Victory Games"
+        },
+        {
+          "code": "Q13404085",
+          "label": "Red Thread Games"
+        },
+        {
+          "code": "Q13390603",
+          "label": "22Cans"
+        },
+        {
+          "code": "Q13407941",
+          "label": "Grip Games"
+        },
+        {
+          "code": "Q54554714",
+          "label": "Black Lab Games"
+        },
+        {
+          "code": "Q54815866",
+          "label": "Artificial Life, Inc."
+        },
+        {
+          "code": "Q54858229",
+          "label": "Pixwerk"
+        },
+        {
+          "code": "Q55085218",
+          "label": "Kaiko"
+        },
+        {
+          "code": "Q54666525",
+          "label": "Revival Productions"
+        },
+        {
+          "code": "Q54825484",
+          "label": "SVG Distribution"
+        },
+        {
+          "code": "Q54822032",
+          "label": "Glock Software"
+        },
+        {
+          "code": "Q54833964",
+          "label": "Auxbrain"
+        },
+        {
+          "code": "Q54862612",
+          "label": "Soaphog Game Studio"
+        },
+        {
+          "code": "Q54868753",
+          "label": "Intellisoft"
+        },
+        {
+          "code": "Q54823201",
+          "label": "BURA"
+        },
+        {
+          "code": "Q54648724",
+          "label": "Dark Unicorn Productions"
+        },
+        {
+          "code": "Q54847659",
+          "label": "Eloquence Entertainment"
+        },
+        {
+          "code": "Q54878373",
+          "label": "Box Office Software"
+        },
+        {
+          "code": "Q55064547",
+          "label": "Fawn Dawn Studios"
+        },
+        {
+          "code": "Q54309902",
+          "label": "Tapps Games"
+        },
+        {
+          "code": "Q54652468",
+          "label": "Pavonis Interactive"
+        },
+        {
+          "code": "Q54669665",
+          "label": "Mohawk Games"
+        },
+        {
+          "code": "Q54834702",
+          "label": "phime studio"
+        },
+        {
+          "code": "Q54877457",
+          "label": "Grey Alien Games"
+        },
+        {
+          "code": "Q54911871",
+          "label": "Angelsoft"
+        },
+        {
+          "code": "Q55171146",
+          "label": "Spooky Doorway"
+        },
+        {
+          "code": "Q54878413",
+          "label": "Intelligent Design"
+        },
+        {
+          "code": "Q54897956",
+          "label": "White Giant RPG Studios"
+        },
+        {
+          "code": "Q55256948",
+          "label": "Zippo Games"
+        },
+        {
+          "code": "Q54973235",
+          "label": "Panic Button"
+        },
+        {
+          "code": "Q55003844",
+          "label": "Giant Squid"
+        },
+        {
+          "code": "Q54310561",
+          "label": "Videocult"
+        },
+        {
+          "code": "Q54647654",
+          "label": "BlitWise Productions"
+        },
+        {
+          "code": "Q54720082",
+          "label": "Ape Marina"
+        },
+        {
+          "code": "Q55027201",
+          "label": "Roberts Space Industries LLC"
+        },
+        {
+          "code": "Q55236686",
+          "label": "redBit games"
+        },
+        {
+          "code": "Q54822246",
+          "label": "Awesome Games Studio"
+        },
+        {
+          "code": "Q54890557",
+          "label": "IceSitruuna"
+        },
+        {
+          "code": "Q55004284",
+          "label": "Squanch Games"
+        },
+        {
+          "code": "Q55091126",
+          "label": "LavaMind"
+        },
+        {
+          "code": "Q55251565",
+          "label": "Funtastic"
+        },
+        {
+          "code": "Q55283017",
+          "label": "Dilmer Games"
+        },
+        {
+          "code": "Q106171121",
+          "label": "My.Games"
+        },
+        {
+          "code": "Q106342604",
+          "label": "Cartboard Games"
+        },
+        {
+          "code": "Q106159811",
+          "label": "Tender Claws"
+        },
+        {
+          "code": "Q106195741",
+          "label": "Experiment 101"
+        },
+        {
+          "code": "Q106355132",
+          "label": "Arcade Distillery"
+        },
+        {
+          "code": "Q106019646",
+          "label": "LDRLY Games"
+        },
+        {
+          "code": "Q106356310",
+          "label": "Noumenon Games"
+        },
+        {
+          "code": "Q106410157",
+          "label": "Pigeons Interactive"
+        },
+        {
+          "code": "Q106189122",
+          "label": "Mr. Nutz Studio"
+        },
+        {
+          "code": "Q106070909",
+          "label": "Mundfish"
+        },
+        {
+          "code": "Q106288684",
+          "label": "Out Of Tune Games"
+        },
+        {
+          "code": "Q106315210",
+          "label": "Cheshire Engineering"
+        },
+        {
+          "code": "Q106104223",
+          "label": "FriendTimes"
+        },
+        {
+          "code": "Q106322193",
+          "label": "Tummy Games"
+        },
+        {
+          "code": "Q106323376",
+          "label": "Qruppo"
+        },
+        {
+          "code": "Q106044684",
+          "label": "Playful Studios"
+        },
+        {
+          "code": "Q106077048",
+          "label": "Studio 9.7"
+        },
+        {
+          "code": "Q106077754",
+          "label": "Headbang Club"
+        },
+        {
+          "code": "Q106079568",
+          "label": "bvm"
+        },
+        {
+          "code": "Q106152562",
+          "label": "Lightneer"
+        },
+        {
+          "code": "Q106311529",
+          "label": "Aoca Game Lab"
+        },
+        {
+          "code": "Q106042305",
+          "label": "Astrotale Games"
+        },
+        {
+          "code": "Q106073793",
+          "label": "Studio Pango"
+        },
+        {
+          "code": "Q106075436",
+          "label": "Wolcen Studio"
+        },
+        {
+          "code": "Q106223556",
+          "label": "Detach Entertainment"
+        },
+        {
+          "code": "Q106229313",
+          "label": "RedRoc Interactive"
+        },
+        {
+          "code": "Q106290140",
+          "label": "TickTock Games"
+        },
+        {
+          "code": "Q106321382",
+          "label": "Mad About Pandas"
+        },
+        {
+          "code": "Q2984670",
+          "label": "Mythic Entertainment"
+        },
+        {
+          "code": "Q2985270",
+          "label": "Idea Factory"
+        },
+        {
+          "code": "Q2985314",
+          "label": "Tectoy"
+        },
+        {
+          "code": "Q2985996",
+          "label": "Matrix Software"
+        },
+        {
+          "code": "Q3002349",
+          "label": "Crave Entertainment"
+        },
+        {
+          "code": "Q3002104",
+          "label": "Cranberry Production"
+        },
+        {
+          "code": "Q55663530",
+          "label": "Indie Glue"
+        },
+        {
+          "code": "Q55671641",
+          "label": "Bread Team"
+        },
+        {
+          "code": "Q55566142",
+          "label": "Sparkypants Studios"
+        },
+        {
+          "code": "Q55587315",
+          "label": "Linel"
+        },
+        {
+          "code": "Q55662193",
+          "label": "Snarky Ant, LLC"
+        },
+        {
+          "code": "Q55697390",
+          "label": "Lightspeed and Quantum Studios Group"
+        },
+        {
+          "code": "Q55619706",
+          "label": "SKH Apps"
+        },
+        {
+          "code": "Q55668650",
+          "label": "Big John Games"
+        },
+        {
+          "code": "Q55662724",
+          "label": "Studio Gamaii"
+        },
+        {
+          "code": "Q113639245",
+          "label": "A Nostru"
+        },
+        {
+          "code": "Q113639299",
+          "label": "Dnovel"
+        },
+        {
+          "code": "Q113639533",
+          "label": "2by3 Games"
+        },
+        {
+          "code": "Q113639655",
+          "label": "Byzantine Games"
+        },
+        {
+          "code": "Q113639838",
+          "label": "Cat Rabbit"
+        },
+        {
+          "code": "Q113629404",
+          "label": "Deyteris Games"
+        },
+        {
+          "code": "Q113640052",
+          "label": "Owned by Gravity"
+        },
+        {
+          "code": "Q113640055",
+          "label": "Proxy Studios"
+        },
+        {
+          "code": "Q113644606",
+          "label": "Art Data Interactive"
+        },
+        {
+          "code": "Q113629428",
+          "label": "Seven Sails"
+        },
+        {
+          "code": "Q113639460",
+          "label": "FinalBoss Games"
+        },
+        {
+          "code": "Q113639953",
+          "label": "Code Force"
+        },
+        {
+          "code": "Q113639977",
+          "label": "DESTINYbit"
+        },
+        {
+          "code": "Q113640419",
+          "label": "Prime Matter"
+        },
+        {
+          "code": "Q113639374",
+          "label": "Walaber Entertainment"
+        },
+        {
+          "code": "Q113640024",
+          "label": "NorbSoftDev"
+        },
+        {
+          "code": "Q113640385",
+          "label": "Mad Head Games"
+        },
+        {
+          "code": "Q113652639",
+          "label": "Chute Apps"
+        },
+        {
+          "code": "Q113652900",
+          "label": "Bitmap Bureau"
+        },
+        {
+          "code": "Q113652655",
+          "label": "BKOM Studios"
+        },
+        {
+          "code": "Q113666658",
+          "label": "Something Wicked Games"
+        },
+        {
+          "code": "Q113634275",
+          "label": "Stranga Games"
+        },
+        {
+          "code": "Q113639186",
+          "label": "Teravision Games"
+        },
+        {
+          "code": "Q113640039",
+          "label": "On Target Simulations"
+        },
+        {
+          "code": "Q113629411",
+          "label": "PixQuake"
+        },
+        {
+          "code": "Q113639363",
+          "label": "Timberwolf Studios"
+        },
+        {
+          "code": "Q113639987",
+          "label": "Fury Software"
+        },
+        {
+          "code": "Q113638763",
+          "label": "Kanak"
+        },
+        {
+          "code": "Q113629393",
+          "label": "Meridian93 Studio"
+        },
+        {
+          "code": "Q113629421",
+          "label": "Joyful Software"
+        },
+        {
+          "code": "Q107120041",
+          "label": "BrickCream"
+        },
+        {
+          "code": "Q107147963",
+          "label": "Red Games Co."
+        },
+        {
+          "code": "Q107163183",
+          "label": "Yosemite Entertainment"
+        },
+        {
+          "code": "Q107137263",
+          "label": "Bloodlust Software"
+        },
+        {
+          "code": "Q107137326",
+          "label": "Winter Wolves"
+        },
+        {
+          "code": "Q107215620",
+          "label": "Ubisoft Mumbai"
+        },
+        {
+          "code": "Q106977372",
+          "label": "Invader Studios"
+        },
+        {
+          "code": "Q106938039",
+          "label": "Mad Fellows"
+        },
+        {
+          "code": "Q107137967",
+          "label": "Interactive Binary Illusions"
+        },
+        {
+          "code": "Q107198400",
+          "label": "Team Asobi"
+        },
+        {
+          "code": "Q106994184",
+          "label": "Uplift Games"
+        },
+        {
+          "code": "Q107215470",
+          "label": "FoamPunch"
+        },
+        {
+          "code": "Q106945444",
+          "label": "qureate"
+        },
+        {
+          "code": "Q107093729",
+          "label": "Aethon Collective"
+        },
+        {
+          "code": "Q107215601",
+          "label": "Ubisoft Australia"
+        },
+        {
+          "code": "Q107215641",
+          "label": "Ubisoft South Korea"
+        },
+        {
+          "code": "Q107038240",
+          "label": "Awaken Realms"
+        },
+        {
+          "code": "Q107111983",
+          "label": "Kuro Games"
+        },
+        {
+          "code": "Q107075327",
+          "label": "illuCalab"
+        },
+        {
+          "code": "Q107120126",
+          "label": "Tunnel Vision Games"
+        },
+        {
+          "code": "Q107185395",
+          "label": "Super X Studios"
+        },
+        {
+          "code": "Q107189268",
+          "label": "Big Evil Corporation"
+        },
+        {
+          "code": "Q106977718",
+          "label": "Elex"
+        },
+        {
+          "code": "Q107026318",
+          "label": "Eclipse Games"
+        },
+        {
+          "code": "Q107133904",
+          "label": "Stirfire Studios"
+        },
+        {
+          "code": "Q107137285",
+          "label": "Crystal Shard"
+        },
+        {
+          "code": "Q107215669",
+          "label": "Ubisoft Osaka"
+        },
+        {
+          "code": "Q3073236",
+          "label": "Flagship"
+        },
+        {
+          "code": "Q3066248",
+          "label": "Family Soft"
+        },
+        {
+          "code": "Q3087263",
+          "label": "Ubisoft Leamington"
+        },
+        {
+          "code": "Q3087792",
+          "label": "Game Republic"
+        },
+        {
+          "code": "Q3087859",
+          "label": "Frima Studio"
+        },
+        {
+          "code": "Q3055077",
+          "label": "Entertainment Software Publishing"
+        },
+        {
+          "code": "Q3061488",
+          "label": "Eversim"
+        },
+        {
+          "code": "Q3082031",
+          "label": "Sega AM3"
+        },
+        {
+          "code": "Q3066925",
+          "label": "Ubisoft Barcelona"
+        },
+        {
+          "code": "Q115109087",
+          "label": "Skydance Interactive"
+        },
+        {
+          "code": "Q115153651",
+          "label": "Visai Studios"
+        },
+        {
+          "code": "Q115633760",
+          "label": "Anarchy Enterprises"
+        },
+        {
+          "code": "Q115004830",
+          "label": "Play Publishing"
+        },
+        {
+          "code": "Q115257433",
+          "label": "ASBO Interactive"
+        },
+        {
+          "code": "Q114994534",
+          "label": "Novalink"
+        },
+        {
+          "code": "Q115010941",
+          "label": "Lucid Sheep Games"
+        },
+        {
+          "code": "Q115053634",
+          "label": "Moonbyte Games"
+        },
+        {
+          "code": "Q115108529",
+          "label": "Gaddy Games"
+        },
+        {
+          "code": "Q115110189",
+          "label": "ZeDrimeTim"
+        },
+        {
+          "code": "Q115193754",
+          "label": "JP Games"
+        },
+        {
+          "code": "Q115300169",
+          "label": "Player First Games"
+        },
+        {
+          "code": "Q115300517",
+          "label": "Picorinne Soft"
+        },
+        {
+          "code": "Q115469692",
+          "label": "Andromeda Software"
+        },
+        {
+          "code": "Q115471767",
+          "label": "Goody Gameworks"
+        },
+        {
+          "code": "Q115478292",
+          "label": "Triple Topping"
+        },
+        {
+          "code": "Q115554696",
+          "label": "Smash House Games"
+        },
+        {
+          "code": "Q115598070",
+          "label": "Ievo"
+        },
+        {
+          "code": "Q115525813",
+          "label": "Venturous"
+        },
+        {
+          "code": "Q115004489",
+          "label": "Ennui Studio"
+        },
+        {
+          "code": "Q115554866",
+          "label": "Hautecouture"
+        },
+        {
+          "code": "Q115576926",
+          "label": "Burning Goat"
+        },
+        {
+          "code": "Q115625339",
+          "label": "Light Ape Games"
+        },
+        {
+          "code": "Q115257669",
+          "label": "Herobeat Studios"
+        },
+        {
+          "code": "Q115299986",
+          "label": "Pequi studios"
+        },
+        {
+          "code": "Q115459643",
+          "label": "Cave Monsters"
+        },
+        {
+          "code": "Q115469278",
+          "label": "Top Job GmbH"
+        },
+        {
+          "code": "Q115178013",
+          "label": "Cosmonaut Studios"
+        },
+        {
+          "code": "Q115257341",
+          "label": "Diplodocus Games"
+        },
+        {
+          "code": "Q115257732",
+          "label": "Coffee Addict Studio"
+        },
+        {
+          "code": "Q115300637",
+          "label": "Insane Code"
+        },
+        {
+          "code": "Q115484020",
+          "label": "Unhexigion"
+        },
+        {
+          "code": "Q115601171",
+          "label": "Wolverine Studios"
+        },
+        {
+          "code": "Q114978830",
+          "label": "Red Dolphin Games"
+        },
+        {
+          "code": "Q115055449",
+          "label": "Resolution Games"
+        },
+        {
+          "code": "Q115120262",
+          "label": "Double Action Factory"
+        },
+        {
+          "code": "Q115120474",
+          "label": "FivexGames"
+        },
+        {
+          "code": "Q115179274",
+          "label": "Amicable Animal"
+        },
+        {
+          "code": "Q115188791",
+          "label": "Sundae Factory"
+        },
+        {
+          "code": "Q115478223",
+          "label": "Nerd Games"
+        },
+        {
+          "code": "Q115525288",
+          "label": "Nosebleed Interactive"
+        },
+        {
+          "code": "Q115633680",
+          "label": "NVIDIA Lightspeed Studios"
+        },
+        {
+          "code": "Q115182955",
+          "label": "Sonka"
+        },
+        {
+          "code": "Q114986423",
+          "label": "Honor Games"
+        },
+        {
+          "code": "Q115009523",
+          "label": "Oldblood"
+        },
+        {
+          "code": "Q115113860",
+          "label": "MP Entertainment"
+        },
+        {
+          "code": "Q115380840",
+          "label": "Studio Bside"
+        },
+        {
+          "code": "Q115459538",
+          "label": "Radical Forge"
+        },
+        {
+          "code": "Q115459682",
+          "label": "R-Next"
+        },
+        {
+          "code": "Q115554940",
+          "label": "Rikodu"
+        },
+        {
+          "code": "Q3008126",
+          "label": "CyberConnect2"
+        },
+        {
+          "code": "Q3008170",
+          "label": "Cyberlore Studios"
+        },
+        {
+          "code": "Q3023123",
+          "label": "Denki"
+        },
+        {
+          "code": "Q3021916",
+          "label": "Delta Tao Software"
+        },
+        {
+          "code": "Q3008112",
+          "label": "CyberStep"
+        },
+        {
+          "code": "Q3016360",
+          "label": "Darkworks"
+        },
+        {
+          "code": "Q3022081",
+          "label": "Unknown Worlds Entertainment"
+        },
+        {
+          "code": "Q3023462",
+          "label": "Synergistic Software"
+        },
+        {
+          "code": "Q3008156",
+          "label": "Cyberflix"
+        },
+        {
+          "code": "Q3009079",
+          "label": "Mass Media Inc."
+        },
+        {
+          "code": "Q111926509",
+          "label": "Chunkybox Games"
+        },
+        {
+          "code": "Q111941633",
+          "label": "OURPALM"
+        },
+        {
+          "code": "Q111995051",
+          "label": "Enodo Games"
+        },
+        {
+          "code": "Q112062471",
+          "label": "stillalive studios"
+        },
+        {
+          "code": "Q112113478",
+          "label": "Tegridy Made Games"
+        },
+        {
+          "code": "Q112116019",
+          "label": "Clockwork Origins"
+        },
+        {
+          "code": "Q112118206",
+          "label": "Lazy Monday Games"
+        },
+        {
+          "code": "Q111994190",
+          "label": "7k7k"
+        },
+        {
+          "code": "Q112081707",
+          "label": "Notovia"
+        },
+        {
+          "code": "Q112082058",
+          "label": "Lindasoft"
+        },
+        {
+          "code": "Q112112669",
+          "label": "SC Jogos"
+        },
+        {
+          "code": "Q112121150",
+          "label": "Zerocreation Games"
+        },
+        {
+          "code": "Q112149230",
+          "label": "Anamik Majumdar"
+        },
+        {
+          "code": "Q112152570",
+          "label": "Qene Games"
+        },
+        {
+          "code": "Q112158285",
+          "label": "Redstart Interactive"
+        },
+        {
+          "code": "Q112158270",
+          "label": "Zero Games Studios"
+        },
+        {
+          "code": "Q112148362",
+          "label": "TARO"
+        },
+        {
+          "code": "Q111994634",
+          "label": "Tin Can Studio"
+        },
+        {
+          "code": "Q112111809",
+          "label": "Enoops"
+        },
+        {
+          "code": "Q112148925",
+          "label": "Open Alpha"
+        },
+        {
+          "code": "Q112043475",
+          "label": "DAN-BALL"
+        },
+        {
+          "code": "Q112115767",
+          "label": "exDream"
+        },
+        {
+          "code": "Q112147454",
+          "label": "Cannibal Interactive"
+        },
+        {
+          "code": "Q112148938",
+          "label": "Naoka Games"
+        },
+        {
+          "code": "Q112148960",
+          "label": "Minicactus Games"
+        },
+        {
+          "code": "Q112158349",
+          "label": "Baltoro Games"
+        },
+        {
+          "code": "Q112118141",
+          "label": "TNgineers"
+        },
+        {
+          "code": "Q112131968",
+          "label": "Dream Games"
+        },
+        {
+          "code": "Q112148063",
+          "label": "Fractal Projects"
+        },
+        {
+          "code": "Q111983371",
+          "label": "Shanggame"
+        },
+        {
+          "code": "Q112020423",
+          "label": "Sernur.tech"
+        },
+        {
+          "code": "Q112149202",
+          "label": "Meng Games"
+        },
+        {
+          "code": "Q112151724",
+          "label": "BitMonster, Inc."
+        },
+        {
+          "code": "Q112198856",
+          "label": "Bedtime Digital Games"
+        },
+        {
+          "code": "Q111968498",
+          "label": "Aggro Crab"
+        },
+        {
+          "code": "Q111968084",
+          "label": "Absurdus"
+        },
+        {
+          "code": "Q112053028",
+          "label": "Sunny Side Up"
+        },
+        {
+          "code": "Q112116146",
+          "label": "Digital Entertainment"
+        },
+        {
+          "code": "Q112148550",
+          "label": "Team Soda"
+        },
+        {
+          "code": "Q112148807",
+          "label": "VeryHardMemeStudio"
+        },
+        {
+          "code": "Q112149182",
+          "label": "Morning Shift Studios"
+        },
+        {
+          "code": "Q112148702",
+          "label": "Paul Connor"
+        },
+        {
+          "code": "Q111936073",
+          "label": "Playcrab"
+        },
+        {
+          "code": "Q112112059",
+          "label": "Gremory Games Inc."
+        },
+        {
+          "code": "Q112113013",
+          "label": "Tapzen Pte. Ltd."
+        },
+        {
+          "code": "Q112148315",
+          "label": "Casual Arts"
+        },
+        {
+          "code": "Q112158244",
+          "label": "Drastic Games"
+        },
+        {
+          "code": "Q112158228",
+          "label": "Triskell Interactive"
+        },
+        {
+          "code": "Q58839689",
+          "label": "Nonadecimal"
+        },
+        {
+          "code": "Q58854381",
+          "label": "Krea Medie"
+        },
+        {
+          "code": "Q59367907",
+          "label": "TATI Mixedia"
+        },
+        {
+          "code": "Q58803916",
+          "label": "FACE"
+        },
+        {
+          "code": "Q58645612",
+          "label": "Infinite Dreams Software"
+        },
+        {
+          "code": "Q59198758",
+          "label": "Polypogon Games"
+        },
+        {
+          "code": "Q59535627",
+          "label": "Anshar Studios"
+        },
+        {
+          "code": "Q58854358",
+          "label": "Studio 1-2"
+        },
+        {
+          "code": "Q59198303",
+          "label": "Battlestate Games"
+        },
+        {
+          "code": "Q59398251",
+          "label": "Shatterline Productions"
+        },
+        {
+          "code": "Q59400716",
+          "label": "Zever Games"
+        },
+        {
+          "code": "Q58886464",
+          "label": "Kodera Software"
+        },
+        {
+          "code": "Q59247808",
+          "label": "Gameloft Software Beijing"
+        },
+        {
+          "code": "Q59276079",
+          "label": "Falcon Development"
+        },
+        {
+          "code": "Q59243906",
+          "label": "Brain in a Jar"
+        },
+        {
+          "code": "Q59247764",
+          "label": "FiniteMonkey"
+        },
+        {
+          "code": "Q59315020",
+          "label": "Resurrection Studios"
+        },
+        {
+          "code": "Q59560112",
+          "label": "Moonlight Studios"
+        },
+        {
+          "code": "Q58646362",
+          "label": "Radish Works"
+        },
+        {
+          "code": "Q58804079",
+          "label": "G-Craft"
+        },
+        {
+          "code": "Q59224980",
+          "label": "MiniChimera Game Studio"
+        },
+        {
+          "code": "Q59229674",
+          "label": "Suncrash"
+        },
+        {
+          "code": "Q59247870",
+          "label": "Mistic Software"
+        },
+        {
+          "code": "Q59254735",
+          "label": "Unfold Games"
+        },
+        {
+          "code": "Q59278955",
+          "label": "Robot Invader"
+        },
+        {
+          "code": "Q59348368",
+          "label": "D'Avekki Studios"
+        },
+        {
+          "code": "Q58674535",
+          "label": "Smiling Buddha Games"
+        },
+        {
+          "code": "Q58951713",
+          "label": "Corecell Technology Co. Ltd."
+        },
+        {
+          "code": "Q59194478",
+          "label": "Schmidt Workshops"
+        },
+        {
+          "code": "Q59222830",
+          "label": "Meltdown Interactive Media"
+        },
+        {
+          "code": "Q59559127",
+          "label": "Narratio Studios"
+        },
+        {
+          "code": "Q58646131",
+          "label": "Hexerei Games"
+        },
+        {
+          "code": "Q59524614",
+          "label": "CBS/Sony"
+        },
+        {
+          "code": "Q2680856",
+          "label": "King"
+        },
+        {
+          "code": "Q2696462",
+          "label": "Johnny Two Shoes"
+        },
+        {
+          "code": "Q2696696",
+          "label": "NetherRealm Studios"
+        },
+        {
+          "code": "Q2670031",
+          "label": "Climax Group"
+        },
+        {
+          "code": "Q2668532",
+          "label": "Nintendo Research & Development 2"
+        },
+        {
+          "code": "Q2667370",
+          "label": "EA Orlando"
+        },
+        {
+          "code": "Q116911835",
+          "label": "Old Moon"
+        },
+        {
+          "code": "Q116784327",
+          "label": "Agens"
+        },
+        {
+          "code": "Q116766148",
+          "label": "GoldKnights"
+        },
+        {
+          "code": "Q116780577",
+          "label": "Mole Eyes Entertainment"
+        },
+        {
+          "code": "Q116784509",
+          "label": "Slingshot & Satchel"
+        },
+        {
+          "code": "Q116784531",
+          "label": "Trinity Team"
+        },
+        {
+          "code": "Q116785222",
+          "label": "Tea Monster Games"
+        },
+        {
+          "code": "Q116786147",
+          "label": "Glowfish Interactive"
+        },
+        {
+          "code": "Q116786374",
+          "label": "Texelworks"
+        },
+        {
+          "code": "Q116786722",
+          "label": "Golden Gate Crew"
+        },
+        {
+          "code": "Q116786739",
+          "label": "Diamond Software"
+        },
+        {
+          "code": "Q116819340",
+          "label": "Drago Entertainment"
+        },
+        {
+          "code": "Q116819375",
+          "label": "K148 Game Studio"
+        },
+        {
+          "code": "Q116819405",
+          "label": "Rat Cliff Games"
+        },
+        {
+          "code": "Q116823245",
+          "label": "Paradark Studio"
+        },
+        {
+          "code": "Q116838649",
+          "label": "NukGames"
+        },
+        {
+          "code": "Q116838691",
+          "label": "Person of Interests"
+        },
+        {
+          "code": "Q116838781",
+          "label": "Cocodrilo Dog"
+        },
+        {
+          "code": "Q116848048",
+          "label": "Casus Ludi"
+        },
+        {
+          "code": "Q116851014",
+          "label": "Retrotainment Games"
+        },
+        {
+          "code": "Q116860968",
+          "label": "Tour De Pizza"
+        },
+        {
+          "code": "Q116897427",
+          "label": "Messier Games"
+        },
+        {
+          "code": "Q116897629",
+          "label": "Space Lizard Studio"
+        },
+        {
+          "code": "Q116897663",
+          "label": "Banana Bytes"
+        },
+        {
+          "code": "Q116897827",
+          "label": "Cellar Vault Games"
+        },
+        {
+          "code": "Q116897901",
+          "label": "Graven Visual Novels"
+        },
+        {
+          "code": "Q116897946",
+          "label": "Darkania Works"
+        },
+        {
+          "code": "Q116897961",
+          "label": "Labrador Studios"
+        },
+        {
+          "code": "Q116897977",
+          "label": "Elseware Experience"
+        },
+        {
+          "code": "Q116898265",
+          "label": "Creative Games & Computer Graphics Corporation"
+        },
+        {
+          "code": "Q116899779",
+          "label": "Liquid Pug"
+        },
+        {
+          "code": "Q116900511",
+          "label": "Softstar Technology (Beijing)"
+        },
+        {
+          "code": "Q116901082",
+          "label": "Brass Token"
+        },
+        {
+          "code": "Q116902674",
+          "label": "Purple Tree"
+        },
+        {
+          "code": "Q116909182",
+          "label": "Kiwiwalks"
+        },
+        {
+          "code": "Q116910261",
+          "label": "SuperGaming"
+        },
+        {
+          "code": "Q116910284",
+          "label": "Mayhem Studios"
+        },
+        {
+          "code": "Q116912491",
+          "label": "WorldWideSoftware"
+        },
+        {
+          "code": "Q116912581",
+          "label": "Rewind Games"
+        },
+        {
+          "code": "Q116912787",
+          "label": "Relative Software"
+        },
+        {
+          "code": "Q116923786",
+          "label": "Flux Games"
+        },
+        {
+          "code": "Q116926856",
+          "label": "Bellular Studios"
+        },
+        {
+          "code": "Q116940240",
+          "label": "fluckyMachine"
+        },
+        {
+          "code": "Q116940475",
+          "label": "909games"
+        },
+        {
+          "code": "Q116940502",
+          "label": "ViJuDa"
+        },
+        {
+          "code": "Q116961969",
+          "label": "Vertical Reach"
+        },
+        {
+          "code": "Q116897780",
+          "label": "Indigo Studios"
+        },
+        {
+          "code": "Q56935699",
+          "label": "Motelsoft"
+        },
+        {
+          "code": "Q57612578",
+          "label": "Amaterasu Software"
+        },
+        {
+          "code": "Q57901762",
+          "label": "Sabarasa Entertainment"
+        },
+        {
+          "code": "Q57746282",
+          "label": "Snowman"
+        },
+        {
+          "code": "Q56641082",
+          "label": "Terahard"
+        },
+        {
+          "code": "Q56750827",
+          "label": "Wx3 Labs"
+        },
+        {
+          "code": "Q58317347",
+          "label": "Team Hoi"
+        },
+        {
+          "code": "Q58645309",
+          "label": "Alpine Studios"
+        },
+        {
+          "code": "Q56679137",
+          "label": "Cardboard Keep"
+        },
+        {
+          "code": "Q56825525",
+          "label": "Hyper Fox Studios"
+        },
+        {
+          "code": "Q57019633",
+          "label": "Red Fox Game Studios"
+        },
+        {
+          "code": "Q57473164",
+          "label": "Loveshack Entertainment"
+        },
+        {
+          "code": "Q57612808",
+          "label": "Angry Demon Studio"
+        },
+        {
+          "code": "Q57834351",
+          "label": "ms.app"
+        },
+        {
+          "code": "Q58330185",
+          "label": "Endgame Studios"
+        },
+        {
+          "code": "Q58486335",
+          "label": "Moment Games"
+        },
+        {
+          "code": "Q58518540",
+          "label": "Cedar Beast"
+        },
+        {
+          "code": "Q56872873",
+          "label": "Opaque Space"
+        },
+        {
+          "code": "Q58645141",
+          "label": "TriSoft"
+        },
+        {
+          "code": "Q56676527",
+          "label": "Warpfish"
+        },
+        {
+          "code": "Q56754217",
+          "label": "Defiant Development"
+        },
+        {
+          "code": "Q57250474",
+          "label": "Heartomics"
+        },
+        {
+          "code": "Q57251843",
+          "label": "Worthless Bums"
+        },
+        {
+          "code": "Q57362423",
+          "label": "Bithell Games"
+        },
+        {
+          "code": "Q57476904",
+          "label": "Panic Barn"
+        },
+        {
+          "code": "Q57650411",
+          "label": "Aloft Studio"
+        },
+        {
+          "code": "Q58431288",
+          "label": "Ivanoff Interactive"
+        },
+        {
+          "code": "Q56649198",
+          "label": "Bitten Toast Games"
+        },
+        {
+          "code": "Q56752635",
+          "label": "ThriXXX"
+        },
+        {
+          "code": "Q57252431",
+          "label": "Spacepup Entertainment"
+        },
+        {
+          "code": "Q57400784",
+          "label": "Lavaboots Studios"
+        },
+        {
+          "code": "Q58234443",
+          "label": "eSail"
+        },
+        {
+          "code": "Q56604474",
+          "label": "Twice Circled"
+        },
+        {
+          "code": "Q56878935",
+          "label": "Burrik"
+        },
+        {
+          "code": "Q57017144",
+          "label": "REDFOX™ Game Studio Limited"
+        },
+        {
+          "code": "Q57249750",
+          "label": "Itharius"
+        },
+        {
+          "code": "Q57834910",
+          "label": "Shroeder Studios"
+        },
+        {
+          "code": "Q58431234",
+          "label": "GSP Games"
+        },
+        {
+          "code": "Q58461310",
+          "label": "Ynor"
+        },
+        {
+          "code": "Q56604813",
+          "label": "Amazing Studio"
+        },
+        {
+          "code": "Q56683345",
+          "label": "Cowardly Creations"
+        },
+        {
+          "code": "Q56849899",
+          "label": "Crystalline Green Ltd."
+        },
+        {
+          "code": "Q15994164",
+          "label": "Elephant Games"
+        },
+        {
+          "code": "Q16155855",
+          "label": "17-BIT"
+        },
+        {
+          "code": "Q16540469",
+          "label": "Cloud Imperium Games"
+        },
+        {
+          "code": "Q15964733",
+          "label": "C&E"
+        },
+        {
+          "code": "Q16248982",
+          "label": "Die Gute Fabrik"
+        },
+        {
+          "code": "Q16060202",
+          "label": "4Kids Games"
+        },
+        {
+          "code": "Q15950732",
+          "label": "Lianzhong"
+        },
+        {
+          "code": "Q15978532",
+          "label": "Allods Team"
+        },
+        {
+          "code": "Q16218144",
+          "label": "Singularity Software"
+        },
+        {
+          "code": "Q16466619",
+          "label": "Guerilla Tea"
+        },
+        {
+          "code": "Q15895861",
+          "label": "Press Start Inc."
+        },
+        {
+          "code": "Q15984987",
+          "label": "Star Arcade"
+        },
+        {
+          "code": "Q15895956",
+          "label": "Roklan Corporation"
+        },
+        {
+          "code": "Q15911229",
+          "label": "Dream Software"
+        },
+        {
+          "code": "Q16078481",
+          "label": "Giant Interactive"
+        },
+        {
+          "code": "Q16177300",
+          "label": "Sonnori"
+        },
+        {
+          "code": "Q16011797",
+          "label": "Ironhide Game Studio"
+        },
+        {
+          "code": "Q16248645",
+          "label": "Datcroft Games"
+        },
+        {
+          "code": "Q15905487",
+          "label": "Firedog Studio"
+        },
+        {
+          "code": "Q60695526",
+          "label": "armogames"
+        },
+        {
+          "code": "Q60811475",
+          "label": "Gamers for Good"
+        },
+        {
+          "code": "Q61357740",
+          "label": "Talesshop"
+        },
+        {
+          "code": "Q61629925",
+          "label": "Fellow Traveller"
+        },
+        {
+          "code": "Q60782408",
+          "label": "Sectordub"
+        },
+        {
+          "code": "Q60860593",
+          "label": "PlayWay"
+        },
+        {
+          "code": "Q61467256",
+          "label": "Mighty Moth"
+        },
+        {
+          "code": "Q61743495",
+          "label": "Transcendent Games"
+        },
+        {
+          "code": "Q60755494",
+          "label": "Force Field"
+        },
+        {
+          "code": "Q60740676",
+          "label": "Solid Clouds"
+        },
+        {
+          "code": "Q61194313",
+          "label": "ImpactGames"
+        },
+        {
+          "code": "Q60761534",
+          "label": "City Connection"
+        },
+        {
+          "code": "Q60696610",
+          "label": "Brimo Studio"
+        },
+        {
+          "code": "Q60739984",
+          "label": "Midway Studios San Diego"
+        },
+        {
+          "code": "Q60860500",
+          "label": "Ten Square Games"
+        },
+        {
+          "code": "Q61469155",
+          "label": "BS Studios"
+        },
+        {
+          "code": "Q61628928",
+          "label": "Lunar Ray Games"
+        },
+        {
+          "code": "Q61699211",
+          "label": "TinyMob Games"
+        },
+        {
+          "code": "Q61743556",
+          "label": "Four Leaf Studios"
+        },
+        {
+          "code": "Q61037734",
+          "label": "SukeraSparo"
+        },
+        {
+          "code": "Q61283837",
+          "label": "Joined Up Writing"
+        },
+        {
+          "code": "Q61699906",
+          "label": "Ember Entertainment"
+        },
+        {
+          "code": "Q61700161",
+          "label": "Grimm Bros"
+        },
+        {
+          "code": "Q61719561",
+          "label": "Super Icon"
+        },
+        {
+          "code": "Q61731621",
+          "label": "Viqua Games"
+        },
+        {
+          "code": "Q60748428",
+          "label": "AtGames"
+        },
+        {
+          "code": "Q20712108",
+          "label": "airG Inc."
+        },
+        {
+          "code": "Q20720708",
+          "label": "Morepork Games"
+        },
+        {
+          "code": "Q20726028",
+          "label": "ITL"
+        },
+        {
+          "code": "Q20539312",
+          "label": "Hardlight"
+        },
+        {
+          "code": "Q20181933",
+          "label": "House of Tales"
+        },
+        {
+          "code": "Q20505844",
+          "label": "Smilebit"
+        },
+        {
+          "code": "Q20529838",
+          "label": "ZA/UM"
+        },
+        {
+          "code": "Q20312521",
+          "label": "Affect"
+        },
+        {
+          "code": "Q20164507",
+          "label": "Tomorrow Corporation"
+        },
+        {
+          "code": "Q20072227",
+          "label": "Flying Cafe for Semianimals"
+        },
+        {
+          "code": "Q20312580",
+          "label": "3d6 Games"
+        },
+        {
+          "code": "Q20707755",
+          "label": "Grimlore Games"
+        },
+        {
+          "code": "Q20708202",
+          "label": "Boss Fight Entertainment"
+        },
+        {
+          "code": "Q20726296",
+          "label": "Etermax"
+        },
+        {
+          "code": "Q20642236",
+          "label": "Blacknorth"
+        },
+        {
+          "code": "Q20746324",
+          "label": "Sticky Studios"
+        },
+        {
+          "code": "Q20828788",
+          "label": "Project Soul"
+        },
+        {
+          "code": "Q20445830",
+          "label": "Devsisters"
+        },
+        {
+          "code": "Q20748936",
+          "label": "NanaWind"
+        },
+        {
+          "code": "Q20972825",
+          "label": "Nintendo Entertainment Planning & Development"
+        },
+        {
+          "code": "Q107268258",
+          "label": "1C Game Studios"
+        },
+        {
+          "code": "Q107289465",
+          "label": "Anomalous Games"
+        },
+        {
+          "code": "Q107222498",
+          "label": "Ember Lab"
+        },
+        {
+          "code": "Q107296795",
+          "label": "10 Chambers"
+        },
+        {
+          "code": "Q107316530",
+          "label": "Uvula"
+        },
+        {
+          "code": "Q107261125",
+          "label": "Nippon Cultural Broadcasting Extend"
+        },
+        {
+          "code": "Q107268316",
+          "label": "Ubisoft EMEA"
+        },
+        {
+          "code": "Q107290875",
+          "label": "Game Nation"
+        },
+        {
+          "code": "Q107228333",
+          "label": "Team HalfBeard"
+        },
+        {
+          "code": "Q107287237",
+          "label": "Noir Soft"
+        },
+        {
+          "code": "Q107288844",
+          "label": "Games Station"
+        },
+        {
+          "code": "Q107253745",
+          "label": "Salty Salty Studios"
+        },
+        {
+          "code": "Q107242621",
+          "label": "MoveGames"
+        },
+        {
+          "code": "Q107228280",
+          "label": "Tannhauser Gate"
+        },
+        {
+          "code": "Q107257663",
+          "label": "Ubisoft Düsseldorf"
+        },
+        {
+          "code": "Q107290841",
+          "label": "Autobótika"
+        },
+        {
+          "code": "Q107294171",
+          "label": "Y Press Games"
+        },
+        {
+          "code": "Q107300327",
+          "label": "RMGgames Interactive"
+        },
+        {
+          "code": "Q114083180",
+          "label": "So Romantic"
+        },
+        {
+          "code": "Q114600164",
+          "label": "Homegrown Games"
+        },
+        {
+          "code": "Q114643557",
+          "label": "Eclipse Software Design"
+        },
+        {
+          "code": "Q114669882",
+          "label": "Blindflug Studios"
+        },
+        {
+          "code": "Q114684619",
+          "label": "Salty Lemon Entertainment"
+        },
+        {
+          "code": "Q113972800",
+          "label": "DX Gameworks"
+        },
+        {
+          "code": "Q114214974",
+          "label": "Paper Bunker"
+        },
+        {
+          "code": "Q114221072",
+          "label": "DarkArts Studios"
+        },
+        {
+          "code": "Q114516136",
+          "label": "MegArts"
+        },
+        {
+          "code": "Q114517186",
+          "label": "Alcatraz Entertainment Software"
+        },
+        {
+          "code": "Q114562417",
+          "label": "Skrice Studios"
+        },
+        {
+          "code": "Q113951821",
+          "label": "Wreck Tangle Games"
+        },
+        {
+          "code": "Q113961512",
+          "label": "Digital Dialect"
+        },
+        {
+          "code": "Q113961518",
+          "label": "Playmates Interactive Entertainment"
+        },
+        {
+          "code": "Q114244646",
+          "label": "Wonderscope"
+        },
+        {
+          "code": "Q114516245",
+          "label": "Century Interactive"
+        },
+        {
+          "code": "Q114648859",
+          "label": "Bitmen Studios"
+        },
+        {
+          "code": "Q114666699",
+          "label": "IF Games"
+        },
+        {
+          "code": "Q113952093",
+          "label": "Monkey Craft"
+        },
+        {
+          "code": "Q113989998",
+          "label": "BoomBit"
+        },
+        {
+          "code": "Q114600063",
+          "label": "Cosmos Designs"
+        },
+        {
+          "code": "Q114666711",
+          "label": "Okomotive"
+        },
+        {
+          "code": "Q114687013",
+          "label": "Momo-pi"
+        },
+        {
+          "code": "Q114071467",
+          "label": "Holy Wow"
+        },
+        {
+          "code": "Q114244514",
+          "label": "Storymind Entertainment"
+        },
+        {
+          "code": "Q114567398",
+          "label": "Masterbrain Bytes"
+        },
+        {
+          "code": "Q114458531",
+          "label": "EAS Software"
+        },
+        {
+          "code": "Q114664931",
+          "label": "Awfully Nice Studios"
+        },
+        {
+          "code": "Q114268910",
+          "label": "Pocketpair"
+        },
+        {
+          "code": "Q114649089",
+          "label": "Bluehole"
+        },
+        {
+          "code": "Q113951406",
+          "label": "Brownmonster"
+        },
+        {
+          "code": "Q113972079",
+          "label": "Chihuas Games"
+        },
+        {
+          "code": "Q114066585",
+          "label": "Nova-Box"
+        },
+        {
+          "code": "Q114267858",
+          "label": "Cloak and Dagger Games"
+        },
+        {
+          "code": "Q114408713",
+          "label": "Shiisanmei"
+        },
+        {
+          "code": "Q114679058",
+          "label": "Conradical Games"
+        },
+        {
+          "code": "Q114680147",
+          "label": "Sparpweed"
+        },
+        {
+          "code": "Q113951359",
+          "label": "Balio Studio"
+        },
+        {
+          "code": "Q113972867",
+          "label": "Doublehit Games"
+        },
+        {
+          "code": "Q114220757",
+          "label": "Kritzelkratz 3000 GmbH"
+        },
+        {
+          "code": "Q114670262",
+          "label": "GratescaStudio"
+        },
+        {
+          "code": "Q117259558",
+          "label": "Lioncode Games"
+        },
+        {
+          "code": "Q117259852",
+          "label": "Hangonit Studio"
+        },
+        {
+          "code": "Q117260006",
+          "label": "Hello There Games"
+        },
+        {
+          "code": "Q117268201",
+          "label": "Tanuki Creative Studio"
+        },
+        {
+          "code": "Q117307623",
+          "label": "Thunderful Development"
+        },
+        {
+          "code": "Q117348324",
+          "label": "PortaPlay"
+        },
+        {
+          "code": "Q117348376",
+          "label": "Rocket Adrift"
+        },
+        {
+          "code": "Q117350772",
+          "label": "Kasulo Game Studio"
+        },
+        {
+          "code": "Q117406616",
+          "label": "The Parasight"
+        },
+        {
+          "code": "Q117408643",
+          "label": "Void Studios"
+        },
+        {
+          "code": "Q117424639",
+          "label": "Clover Bite"
+        },
+        {
+          "code": "Q117448568",
+          "label": "Black Tabby Games"
+        },
+        {
+          "code": "Q117451171",
+          "label": "beyondthosehills"
+        },
+        {
+          "code": "Q117461822",
+          "label": "Nightmare Productions"
+        },
+        {
+          "code": "Q117462333",
+          "label": "Steel City Interactive"
+        },
+        {
+          "code": "Q117467445",
+          "label": "Beautiful Glitch"
+        },
+        {
+          "code": "Q117472473",
+          "label": "Dirty Fox Games"
+        },
+        {
+          "code": "Q117475943",
+          "label": "TurboChilli Publishings"
+        },
+        {
+          "code": "Q117536420",
+          "label": "Sunblink"
+        },
+        {
+          "code": "Q117599219",
+          "label": "Teggno Interactive"
+        },
+        {
+          "code": "Q117599323",
+          "label": "Cool As Heck Games"
+        },
+        {
+          "code": "Q117599606",
+          "label": "Lunatic Software"
+        },
+        {
+          "code": "Q117706164",
+          "label": "Whale Rock Games"
+        },
+        {
+          "code": "Q117713039",
+          "label": "Upside Studios"
+        },
+        {
+          "code": "Q117713303",
+          "label": "Devcats"
+        },
+        {
+          "code": "Q117724660",
+          "label": "AweKteaM"
+        },
+        {
+          "code": "Q117755839",
+          "label": "Slava Bushuev"
+        },
+        {
+          "code": "Q117765818",
+          "label": "Handmade Interactive"
+        },
+        {
+          "code": "Q117808708",
+          "label": "Llamasoft"
+        },
+        {
+          "code": "Q117817678",
+          "label": "Crew Lab"
+        },
+        {
+          "code": "Q117822120",
+          "label": "My Label Game Studio"
+        },
+        {
+          "code": "Q117822428",
+          "label": "LinkSolutions"
+        },
+        {
+          "code": "Q117822453",
+          "label": "7A Games"
+        },
+        {
+          "code": "Q117824131",
+          "label": "Tequila Mobile"
+        },
+        {
+          "code": "Q117831445",
+          "label": "Smartmelon Games"
+        },
+        {
+          "code": "Q117835868",
+          "label": "For Kids"
+        },
+        {
+          "code": "Q117843625",
+          "label": "Argonica"
+        },
+        {
+          "code": "Q117857320",
+          "label": "Pixel Tales"
+        },
+        {
+          "code": "Q117968426",
+          "label": "Breadmen"
+        },
+        {
+          "code": "Q117324316",
+          "label": "Harukaze"
+        },
+        {
+          "code": "Q117811002",
+          "label": "Drama"
+        },
+        {
+          "code": "Q117846654",
+          "label": "Three Rings"
+        },
+        {
+          "code": "Q117817765",
+          "label": "Takase"
+        },
+        {
+          "code": "Q117833374",
+          "label": "Sacada"
+        },
+        {
+          "code": "Q117718917",
+          "label": "Vikerlane"
+        },
+        {
+          "code": "Q3483147",
+          "label": "Sidhe"
+        },
+        {
+          "code": "Q3506713",
+          "label": "Swordfish Studios"
+        },
+        {
+          "code": "Q3504068",
+          "label": "SuperBot Entertainment"
+        },
+        {
+          "code": "Q3483583",
+          "label": "Signal Studios"
+        },
+        {
+          "code": "Q3500956",
+          "label": "Studio 33"
+        },
+        {
+          "code": "Q3503991",
+          "label": "Sunstorm Interactive"
+        },
+        {
+          "code": "Q3512162",
+          "label": "Rainbow Studios"
+        },
+        {
+          "code": "Q3477714",
+          "label": "Sega Networks"
+        },
+        {
+          "code": "Q3484959",
+          "label": "SingleTrac"
+        },
+        {
+          "code": "Q3504740",
+          "label": "Supermassive Games"
+        },
+        {
+          "code": "Q3482130",
+          "label": "Shin'en Multimedia"
+        },
+        {
+          "code": "Q3456271",
+          "label": "Riot Sydney"
+        },
+        {
+          "code": "Q18990970",
+          "label": "Edelweiss"
+        },
+        {
+          "code": "Q19695395",
+          "label": "Masaya"
+        },
+        {
+          "code": "Q18713039",
+          "label": "Incubator Games"
+        },
+        {
+          "code": "Q18922858",
+          "label": "Little Green Men Games"
+        },
+        {
+          "code": "Q19580713",
+          "label": "Pixelopus"
+        },
+        {
+          "code": "Q18834378",
+          "label": "Imperia Online JSC"
+        },
+        {
+          "code": "Q18927002",
+          "label": "Phoenix Arts"
+        },
+        {
+          "code": "Q18908132",
+          "label": "The Code Monkeys"
+        },
+        {
+          "code": "Q19463265",
+          "label": "Mere Mortals"
+        },
+        {
+          "code": "Q19516403",
+          "label": "Playtonic Games"
+        },
+        {
+          "code": "Q18712346",
+          "label": "Inkle"
+        },
+        {
+          "code": "Q18819564",
+          "label": "First Touch Games"
+        },
+        {
+          "code": "Q18711307",
+          "label": "Gamelearn"
+        },
+        {
+          "code": "Q19579914",
+          "label": "Black Shell Games"
+        },
+        {
+          "code": "Q18710568",
+          "label": "Team Tachyon"
+        },
+        {
+          "code": "Q18712558",
+          "label": "Teotl Studios"
+        },
+        {
+          "code": "Q55344793",
+          "label": "Quick Soft"
+        },
+        {
+          "code": "Q55436731",
+          "label": "Extrokold Games"
+        },
+        {
+          "code": "Q55525574",
+          "label": "Hidden Monster Games"
+        },
+        {
+          "code": "Q55331944",
+          "label": "Emotional Pictures"
+        },
+        {
+          "code": "Q55394606",
+          "label": "Deothic"
+        },
+        {
+          "code": "Q55418696",
+          "label": "Gang of Five"
+        },
+        {
+          "code": "Q55438413",
+          "label": "Pilgrim Adventures"
+        },
+        {
+          "code": "Q55560815",
+          "label": "Buckrider Studio"
+        },
+        {
+          "code": "Q55332320",
+          "label": "XD"
+        },
+        {
+          "code": "Q55442854",
+          "label": "ustwo Games"
+        },
+        {
+          "code": "Q55314012",
+          "label": "Acid Software"
+        },
+        {
+          "code": "Q55364740",
+          "label": "Frogames"
+        },
+        {
+          "code": "Q55387181",
+          "label": "Seemingly Pointless"
+        },
+        {
+          "code": "Q55311335",
+          "label": "Enigma Variations"
+        },
+        {
+          "code": "Q55330129",
+          "label": "Orphic Software"
+        },
+        {
+          "code": "Q55363517",
+          "label": "Games From The Deep"
+        },
+        {
+          "code": "Q55437692",
+          "label": "Myroid-Type Comics"
+        },
+        {
+          "code": "Q55399813",
+          "label": "Scavengers Studio"
+        },
+        {
+          "code": "Q55402181",
+          "label": "OneOcean LLC"
+        },
+        {
+          "code": "Q55442086",
+          "label": "Omnitrend Software"
+        },
+        {
+          "code": "Q55497146",
+          "label": "CRASS Studios"
+        },
+        {
+          "code": "Q55508821",
+          "label": "Pixel Wizards"
+        },
+        {
+          "code": "Q59647789",
+          "label": "Elliptic Games"
+        },
+        {
+          "code": "Q60029546",
+          "label": "Night Owl Gaming LLC"
+        },
+        {
+          "code": "Q60169569",
+          "label": "QubicGames"
+        },
+        {
+          "code": "Q60252963",
+          "label": "FOAM Entertainment"
+        },
+        {
+          "code": "Q59662339",
+          "label": "Chumbosoft"
+        },
+        {
+          "code": "Q60198510",
+          "label": "Icetesy SPRL"
+        },
+        {
+          "code": "Q60317349",
+          "label": "Svarog Studios"
+        },
+        {
+          "code": "Q59618132",
+          "label": "Aniware AB"
+        },
+        {
+          "code": "Q59618651",
+          "label": "Hot Lava Games"
+        },
+        {
+          "code": "Q59782847",
+          "label": "3Romans"
+        },
+        {
+          "code": "Q59818425",
+          "label": "Codename Entertainment"
+        },
+        {
+          "code": "Q60179313",
+          "label": "PES Productions"
+        },
+        {
+          "code": "Q59688426",
+          "label": "Tiger Hill Entertainment"
+        },
+        {
+          "code": "Q60161310",
+          "label": "Undertow Games"
+        },
+        {
+          "code": "Q60173383",
+          "label": "BunchOD00dz"
+        },
+        {
+          "code": "Q60174436",
+          "label": "Dry Cactus"
+        },
+        {
+          "code": "Q60198528",
+          "label": "Avidly Wild Games"
+        },
+        {
+          "code": "Q59780340",
+          "label": "Nomada Studio"
+        },
+        {
+          "code": "Q60172674",
+          "label": "Revived Games"
+        },
+        {
+          "code": "Q60173749",
+          "label": "Killing Day Studios"
+        },
+        {
+          "code": "Q60221738",
+          "label": "Mutech"
+        },
+        {
+          "code": "Q59821480",
+          "label": "A44"
+        },
+        {
+          "code": "Q59617720",
+          "label": "NStorm"
+        },
+        {
+          "code": "Q60101804",
+          "label": "Infinite Monkeys Entertainment"
+        },
+        {
+          "code": "Q60174302",
+          "label": "Leti Arts"
+        },
+        {
+          "code": "Q59782853",
+          "label": "Silverfish Studios"
+        },
+        {
+          "code": "Q60221856",
+          "label": "TACTICAL Soft Inc."
+        },
+        {
+          "code": "Q60317351",
+          "label": "hyperboreanGames"
+        },
+        {
+          "code": "Q59560455",
+          "label": "BANDAI NAMCO Amusement Lab"
+        },
+        {
+          "code": "Q59786082",
+          "label": "Holy Sheep"
+        },
+        {
+          "code": "Q60169489",
+          "label": "Dark-1"
+        },
+        {
+          "code": "Q60173732",
+          "label": "Irongames Studio"
+        },
+        {
+          "code": "Q60188061",
+          "label": "Hypixel Studios"
+        },
+        {
+          "code": "Q60182664",
+          "label": "Northwood Studios"
+        },
+        {
+          "code": "Q60317347",
+          "label": "Paradox Terminal"
+        },
+        {
+          "code": "Q3049567",
+          "label": "Good-Feel"
+        },
+        {
+          "code": "Q3051166",
+          "label": "Elixir Studios"
+        },
+        {
+          "code": "Q3049588",
+          "label": "Suzak Inc."
+        },
+        {
+          "code": "Q3054268",
+          "label": "Engine Software"
+        },
+        {
+          "code": "Q3052263",
+          "label": "Omega Force"
+        },
+        {
+          "code": "Q3040525",
+          "label": "The Behemoth"
+        },
+        {
+          "code": "Q3052248",
+          "label": "Tilted Mill Entertainment"
+        },
+        {
+          "code": "Q3044734",
+          "label": "Superscape"
+        },
+        {
+          "code": "Q2859960",
+          "label": "Arcen Games"
+        },
+        {
+          "code": "Q2845962",
+          "label": "Ancient"
+        },
+        {
+          "code": "Q2858431",
+          "label": "Apogee Software"
+        },
+        {
+          "code": "Q2861280",
+          "label": "Arika"
+        },
+        {
+          "code": "Q2861565",
+          "label": "Arkedo Studio"
+        },
+        {
+          "code": "Q2842942",
+          "label": "American Game Cartridges"
+        },
+        {
+          "code": "Q2860046",
+          "label": "Archetype Interactive"
+        },
+        {
+          "code": "Q2864506",
+          "label": "Art & Magic"
+        },
+        {
+          "code": "Q2864821",
+          "label": "Artdink"
+        },
+        {
+          "code": "Q2864819",
+          "label": "ArtePiazza"
+        },
+        {
+          "code": "Q16637457",
+          "label": "Fun Bits Interactive"
+        },
+        {
+          "code": "Q16545922",
+          "label": "Dancing Dots"
+        },
+        {
+          "code": "Q16688547",
+          "label": "Mad Head Limited"
+        },
+        {
+          "code": "Q16681625",
+          "label": "Ubisoft San Francisco"
+        },
+        {
+          "code": "Q16829899",
+          "label": "Colossal Order"
+        },
+        {
+          "code": "Q16678366",
+          "label": "Swing Swing Submarine"
+        },
+        {
+          "code": "Q16833903",
+          "label": "Arrowhead Game Studios"
+        },
+        {
+          "code": "Q16625595",
+          "label": "Red Barrels"
+        },
+        {
+          "code": "Q16638900",
+          "label": "Tequila Works"
+        },
+        {
+          "code": "Q16823622",
+          "label": "2K Australia"
+        },
+        {
+          "code": "Q16546237",
+          "label": "Darkside Game Studios"
+        },
+        {
+          "code": "Q17003652",
+          "label": "BossAlien"
+        },
+        {
+          "code": "Q17018615",
+          "label": "Pitbull Studio"
+        },
+        {
+          "code": "Q17034399",
+          "label": "Silverback Productions"
+        },
+        {
+          "code": "Q17005644",
+          "label": "Inspired Media Entertainment"
+        },
+        {
+          "code": "Q17042836",
+          "label": "Royal Wins"
+        },
+        {
+          "code": "Q17066954",
+          "label": "Xishanju Games"
+        },
+        {
+          "code": "Q17108073",
+          "label": "Scopely"
+        },
+        {
+          "code": "Q17048692",
+          "label": "Simogo"
+        },
+        {
+          "code": "Q17038791",
+          "label": "Yoozoo Games"
+        },
+        {
+          "code": "Q17042562",
+          "label": "Mission Studios"
+        },
+        {
+          "code": "Q17042726",
+          "label": "Plain Vanilla Games"
+        },
+        {
+          "code": "Q17048327",
+          "label": "US Games"
+        },
+        {
+          "code": "Q17003340",
+          "label": "Black Tower Studios"
+        },
+        {
+          "code": "Q17042560",
+          "label": "Mindcraft"
+        },
+        {
+          "code": "Q17042331",
+          "label": "Hexage"
+        },
+        {
+          "code": "Q17042830",
+          "label": "Room 8 Studio"
+        },
+        {
+          "code": "Q17048722",
+          "label": "Socialpoint"
+        },
+        {
+          "code": "Q17048785",
+          "label": "Starship Group"
+        },
+        {
+          "code": "Q17033596",
+          "label": "Wangyuan Shengtang"
+        },
+        {
+          "code": "Q3516982",
+          "label": "Koei Tecmo Games"
+        },
+        {
+          "code": "Q3547645",
+          "label": "Ubisoft Annecy"
+        },
+        {
+          "code": "Q3518266",
+          "label": "Krisalis Software"
+        },
+        {
+          "code": "Q3539040",
+          "label": "Paradox Development Studio"
+        },
+        {
+          "code": "Q3515535",
+          "label": "Tapulous"
+        },
+        {
+          "code": "Q3521625",
+          "label": "The Logic Factory"
+        },
+        {
+          "code": "Q3530472",
+          "label": "Tokkun Studio"
+        },
+        {
+          "code": "Q62603430",
+          "label": "Innovative Minds"
+        },
+        {
+          "code": "Q63184796",
+          "label": "Longbow Games"
+        },
+        {
+          "code": "Q63226072",
+          "label": "thriXXX"
+        },
+        {
+          "code": "Q62559241",
+          "label": "A Wave, Inc."
+        },
+        {
+          "code": "Q62561027",
+          "label": "Glodia"
+        },
+        {
+          "code": "Q62561410",
+          "label": "Armor Project"
+        },
+        {
+          "code": "Q62561535",
+          "label": "Virgin Studios London"
+        },
+        {
+          "code": "Q62701530",
+          "label": "Unconditional Studios LLC"
+        },
+        {
+          "code": "Q62702348",
+          "label": "Bplus"
+        },
+        {
+          "code": "Q62742439",
+          "label": "Minato Giken"
+        },
+        {
+          "code": "Q62743005",
+          "label": "Machatin, Inc."
+        },
+        {
+          "code": "Q63229847",
+          "label": "Zitrix Megalomedia"
+        },
+        {
+          "code": "Q62761254",
+          "label": "Sarepta Studio"
+        },
+        {
+          "code": "Q63226426",
+          "label": "Liquid"
+        },
+        {
+          "code": "Q62565447",
+          "label": "Running Pillow"
+        },
+        {
+          "code": "Q62701245",
+          "label": "Kouyousha Co., Ltd."
+        },
+        {
+          "code": "Q63088961",
+          "label": "T-Enterprise"
+        },
+        {
+          "code": "Q63229851",
+          "label": "5Wolf"
+        },
+        {
+          "code": "Q62618895",
+          "label": "DigixArt"
+        },
+        {
+          "code": "Q62561494",
+          "label": "KAN's Co., Ltd."
+        },
+        {
+          "code": "Q62561683",
+          "label": "Viz Design"
+        },
+        {
+          "code": "Q62572926",
+          "label": "Black System"
+        },
+        {
+          "code": "Q62603618",
+          "label": "UnrealDevelopment"
+        },
+        {
+          "code": "Q62604390",
+          "label": "No Code"
+        },
+        {
+          "code": "Q62740896",
+          "label": "Trisys Corp."
+        },
+        {
+          "code": "Q63155271",
+          "label": "Babylon Software"
+        },
+        {
+          "code": "Q62561310",
+          "label": "Russ, Ltd."
+        },
+        {
+          "code": "Q62746588",
+          "label": "Shade, Inc."
+        },
+        {
+          "code": "Q62920094",
+          "label": "Grundislav Games"
+        },
+        {
+          "code": "Q63226155",
+          "label": "D-Dub Software"
+        },
+        {
+          "code": "Q62559500",
+          "label": "Pixel Reef"
+        },
+        {
+          "code": "Q62561322",
+          "label": "Communication Group Plum"
+        },
+        {
+          "code": "Q62561444",
+          "label": "Nexus Interact, Ltd."
+        },
+        {
+          "code": "Q62651923",
+          "label": "Eclipse Software"
+        },
+        {
+          "code": "Q62702123",
+          "label": "Pegasus Japan Corp."
+        },
+        {
+          "code": "Q62704187",
+          "label": "Seamless Entertainment, Inc."
+        },
+        {
+          "code": "Q62704452",
+          "label": "Black Lantern Studios, Inc."
+        },
+        {
+          "code": "Q63229950",
+          "label": "Tonic Games"
+        },
+        {
+          "code": "Q63012395",
+          "label": "PinkySwear"
+        },
+        {
+          "code": "Q63143595",
+          "label": "Time Warp Productions"
+        },
+        {
+          "code": "Q107329000",
+          "label": "Chuhai Labs"
+        },
+        {
+          "code": "Q107337014",
+          "label": "Redhill Games"
+        },
+        {
+          "code": "Q107340189",
+          "label": "Creashock studios"
+        },
+        {
+          "code": "Q107357086",
+          "label": "davemakes"
+        },
+        {
+          "code": "Q107357116",
+          "label": "Tactile Games"
+        },
+        {
+          "code": "Q107358290",
+          "label": "MobilityWare"
+        },
+        {
+          "code": "Q107358425",
+          "label": "Freshplanet"
+        },
+        {
+          "code": "Q107345633",
+          "label": "AGL Studios"
+        },
+        {
+          "code": "Q107349531",
+          "label": "Doodle Mobile Ltd."
+        },
+        {
+          "code": "Q107358613",
+          "label": "Dadako"
+        },
+        {
+          "code": "Q107377476",
+          "label": "Madmind Studio"
+        },
+        {
+          "code": "Q107450464",
+          "label": "Ripple Effect Studios"
+        },
+        {
+          "code": "Q107327361",
+          "label": "Vertex Pop"
+        },
+        {
+          "code": "Q107362102",
+          "label": "Blackrose Industries"
+        },
+        {
+          "code": "Q107343860",
+          "label": "Studio Fizbin"
+        },
+        {
+          "code": "Q107329136",
+          "label": "Noble Robot"
+        },
+        {
+          "code": "Q107353446",
+          "label": "TPM.CO Soft Works"
+        },
+        {
+          "code": "Q107365220",
+          "label": "Landkarte"
+        },
+        {
+          "code": "Q107378372",
+          "label": "Polyslash"
+        },
+        {
+          "code": "Q107420121",
+          "label": "Sword & Axe"
+        },
+        {
+          "code": "Q107442068",
+          "label": "Consumer Softproducts"
+        },
+        {
+          "code": "Q107349471",
+          "label": "Kristanix Games"
+        },
+        {
+          "code": "Q107361875",
+          "label": "Invidec Games"
+        },
+        {
+          "code": "Q3358943",
+          "label": "Overworks"
+        },
+        {
+          "code": "Q3345370",
+          "label": "Novarama"
+        },
+        {
+          "code": "Q3359559",
+          "label": "PAM Development"
+        },
+        {
+          "code": "Q3375309",
+          "label": "Perfect Entertainment"
+        },
+        {
+          "code": "Q3337383",
+          "label": "Nazca Corporation"
+        },
+        {
+          "code": "Q3327169",
+          "label": "Topo Soft"
+        },
+        {
+          "code": "Q3338727",
+          "label": "Neutron Games"
+        },
+        {
+          "code": "Q3368440",
+          "label": "Pastagames"
+        },
+        {
+          "code": "Q3339538",
+          "label": "Nibris"
+        },
+        {
+          "code": "Q3325177",
+          "label": "Motion Twin"
+        },
+        {
+          "code": "Q3337882",
+          "label": "Neko Entertainment"
+        },
+        {
+          "code": "Q3346039",
+          "label": "Nucleosys"
+        },
+        {
+          "code": "Q3337438",
+          "label": "Nintendo Cube"
+        },
+        {
+          "code": "Q116204775",
+          "label": "Baggy Cat Entertainment"
+        },
+        {
+          "code": "Q116205675",
+          "label": "Happy Volcano"
+        },
+        {
+          "code": "Q116460164",
+          "label": "Will Winn Games"
+        },
+        {
+          "code": "Q116258896",
+          "label": "BorderLeap"
+        },
+        {
+          "code": "Q116473880",
+          "label": "Miracle Tea"
+        },
+        {
+          "code": "Q116205585",
+          "label": "Broken Bear Games"
+        },
+        {
+          "code": "Q116259919",
+          "label": "Lazyrays Games"
+        },
+        {
+          "code": "Q116474658",
+          "label": "Hiding Spot"
+        },
+        {
+          "code": "Q116259965",
+          "label": "Ghost Pattern"
+        },
+        {
+          "code": "Q116260888",
+          "label": "Cygnus Entertainment"
+        },
+        {
+          "code": "Q116265782",
+          "label": "Aviary Films"
+        },
+        {
+          "code": "Q116460186",
+          "label": "Ludic Studios"
+        },
+        {
+          "code": "Q116474344",
+          "label": "MassHive Media"
+        },
+        {
+          "code": "Q116474512",
+          "label": "Simteract"
+        },
+        {
+          "code": "Q116201046",
+          "label": "Third World Productions"
+        },
+        {
+          "code": "Q116205622",
+          "label": "FlutterBeam"
+        },
+        {
+          "code": "Q116472123",
+          "label": "weltenbauer."
+        },
+        {
+          "code": "Q116645060",
+          "label": "Monochrome Paris"
+        },
+        {
+          "code": "Q116678044",
+          "label": "Satur Entertainment"
+        },
+        {
+          "code": "Q116678498",
+          "label": "Black Mermaid"
+        },
+        {
+          "code": "Q116688430",
+          "label": "Axis Games"
+        },
+        {
+          "code": "Q116688476",
+          "label": "Springloaded"
+        },
+        {
+          "code": "Q116691364",
+          "label": "Trick Nostalgie"
+        },
+        {
+          "code": "Q116719676",
+          "label": "Snickerdoodle Games"
+        },
+        {
+          "code": "Q116730748",
+          "label": "Metamorphosis Games"
+        },
+        {
+          "code": "Q116738569",
+          "label": "PowerZ"
+        },
+        {
+          "code": "Q116739652",
+          "label": "91Act"
+        },
+        {
+          "code": "Q116749904",
+          "label": "ArcAngels"
+        },
+        {
+          "code": "Q116756703",
+          "label": "Veritable Joy Studios"
+        },
+        {
+          "code": "Q116756722",
+          "label": "Vile Monarch"
+        },
+        {
+          "code": "Q116757024",
+          "label": "Morningstar Game Studio"
+        },
+        {
+          "code": "Q116757040",
+          "label": "Pixel Heart Studio"
+        },
+        {
+          "code": "Q116757149",
+          "label": "Kikai Digital"
+        },
+        {
+          "code": "Q116757244",
+          "label": "Saber Interactive Porto"
+        },
+        {
+          "code": "Q116757302",
+          "label": "Red Limb Studio"
+        },
+        {
+          "code": "Q116757381",
+          "label": "PolyCrunch Games"
+        },
+        {
+          "code": "Q116758563",
+          "label": "Armogaste"
+        },
+        {
+          "code": "Q116761402",
+          "label": "Província Studio"
+        },
+        {
+          "code": "Q116761429",
+          "label": "Render Cube"
+        },
+        {
+          "code": "Q116763713",
+          "label": "Xaloc Studios"
+        },
+        {
+          "code": "Q116764194",
+          "label": "Acme Gamestudio"
+        },
+        {
+          "code": "Q116764529",
+          "label": "VestGames"
+        },
+        {
+          "code": "Q116764575",
+          "label": "Blue Sunset Games"
+        },
+        {
+          "code": "Q116766024",
+          "label": "Fireline Games"
+        },
+        {
+          "code": "Q116486467",
+          "label": "A Heartful of Games"
+        },
+        {
+          "code": "Q116486446",
+          "label": "Neverjam Studio"
+        },
+        {
+          "code": "Q116265746",
+          "label": "The Outsiders"
+        },
+        {
+          "code": "Q116377312",
+          "label": "Mojiken Studio"
+        },
+        {
+          "code": "Q3143111",
+          "label": "HumanSoft"
+        },
+        {
+          "code": "Q3147892",
+          "label": "Deck Nine"
+        },
+        {
+          "code": "Q3148885",
+          "label": "Imageepoch"
+        },
+        {
+          "code": "Q3154543",
+          "label": "Ironclad Games"
+        },
+        {
+          "code": "Q3177903",
+          "label": "Telenet Japan"
+        },
+        {
+          "code": "Q3153614",
+          "label": "Interstel Corporation"
+        },
+        {
+          "code": "Q3149912",
+          "label": "Incinerator Studios"
+        },
+        {
+          "code": "Q3178586",
+          "label": "Coffee Stain Studios"
+        },
+        {
+          "code": "Q3146388",
+          "label": "I'Max"
+        },
+        {
+          "code": "Q63436632",
+          "label": "MDickie Limited"
+        },
+        {
+          "code": "Q63644316",
+          "label": "K2 LLC"
+        },
+        {
+          "code": "Q64348689",
+          "label": "ELOI Productions"
+        },
+        {
+          "code": "Q64167647",
+          "label": "ReadySoft Incorporated"
+        },
+        {
+          "code": "Q63369994",
+          "label": "Future Proof Games"
+        },
+        {
+          "code": "Q64210835",
+          "label": "Synergy Inc."
+        },
+        {
+          "code": "Q64224536",
+          "label": "Majestic Studios"
+        },
+        {
+          "code": "Q64225362",
+          "label": "Defence Alliance Team"
+        },
+        {
+          "code": "Q63781104",
+          "label": "Triangle Factory"
+        },
+        {
+          "code": "Q63244075",
+          "label": "askiisoft"
+        },
+        {
+          "code": "Q63371044",
+          "label": "Maggese"
+        },
+        {
+          "code": "Q63368306",
+          "label": "Sisyphus.Rocks"
+        },
+        {
+          "code": "Q64167382",
+          "label": "OPeNBooK Co., Ltd."
+        },
+        {
+          "code": "Q64167889",
+          "label": "Dream Factory Co., Ltd."
+        },
+        {
+          "code": "Q64212358",
+          "label": "Street Lamp Games"
+        },
+        {
+          "code": "Q64348340",
+          "label": "Exact"
+        },
+        {
+          "code": "Q63373798",
+          "label": "BáiYù"
+        },
+        {
+          "code": "Q63386205",
+          "label": "HopFrog"
+        },
+        {
+          "code": "Q64210654",
+          "label": "Travellers Tales (UK) Ltd."
+        },
+        {
+          "code": "Q64210805",
+          "label": "Universal Interactive Studios, Inc."
+        },
+        {
+          "code": "Q64014355",
+          "label": "Troglobytes Games"
+        },
+        {
+          "code": "Q64073735",
+          "label": "Playsport Games"
+        },
+        {
+          "code": "Q64014139",
+          "label": "Pathea Games"
+        },
+        {
+          "code": "Q64141528",
+          "label": "E-Line Media"
+        },
+        {
+          "code": "Q64155494",
+          "label": "Krealit"
+        },
+        {
+          "code": "Q64210390",
+          "label": "Clockwork Games Limited"
+        },
+        {
+          "code": "Q64222333",
+          "label": "doinksoft"
+        },
+        {
+          "code": "Q63643873",
+          "label": "Tose Software (HangZhou) Co., Ltd."
+        },
+        {
+          "code": "Q64152354",
+          "label": "Hyperbole Studios"
+        },
+        {
+          "code": "Q64167842",
+          "label": "Destiny Software Productions"
+        },
+        {
+          "code": "Q63244035",
+          "label": "Mnemonic Studios"
+        },
+        {
+          "code": "Q63367925",
+          "label": "SexGameDevil"
+        },
+        {
+          "code": "Q63466558",
+          "label": "Rebel Planet Creations"
+        },
+        {
+          "code": "Q63494636",
+          "label": "Skybound Games"
+        },
+        {
+          "code": "Q63638920",
+          "label": "Pixile Studios"
+        },
+        {
+          "code": "Q63644030",
+          "label": "SEGA Europe"
+        },
+        {
+          "code": "Q63867244",
+          "label": "SEGA of America"
+        },
+        {
+          "code": "Q64167606",
+          "label": "Action Graphics"
+        },
+        {
+          "code": "Q3281900",
+          "label": "Malfador Machinations"
+        },
+        {
+          "code": "Q3303197",
+          "label": "Altron"
+        },
+        {
+          "code": "Q3320502",
+          "label": "S2 Games"
+        },
+        {
+          "code": "Q3322748",
+          "label": "Opera Soft"
+        },
+        {
+          "code": "Q3300783",
+          "label": "Bethesda Game Studios"
+        },
+        {
+          "code": "Q3276945",
+          "label": "TAD Corporation"
+        },
+        {
+          "code": "Q3094998",
+          "label": "Gamestar"
+        },
+        {
+          "code": "Q3094256",
+          "label": "Gaelco"
+        },
+        {
+          "code": "Q3094364",
+          "label": "Choice Provisions"
+        },
+        {
+          "code": "Q3110271",
+          "label": "Vanillaware"
+        },
+        {
+          "code": "Q3125951",
+          "label": "Halfbrick Studios"
+        },
+        {
+          "code": "Q3090767",
+          "label": "Full Fat"
+        },
+        {
+          "code": "Q3137484",
+          "label": "Snowblind Studios"
+        },
+        {
+          "code": "Q3137798",
+          "label": "Playdead"
+        },
+        {
+          "code": "Q3108816",
+          "label": "Left Field Productions"
+        },
+        {
+          "code": "Q108536722",
+          "label": "TeamKill Media"
+        },
+        {
+          "code": "Q108537188",
+          "label": "Shift Up"
+        },
+        {
+          "code": "Q108444709",
+          "label": "Black Matter"
+        },
+        {
+          "code": "Q108473768",
+          "label": "[2.21]"
+        },
+        {
+          "code": "Q108490913",
+          "label": "Revolt Games"
+        },
+        {
+          "code": "Q108867489",
+          "label": "Atypique Studio"
+        },
+        {
+          "code": "Q108910285",
+          "label": "Starward Industries"
+        },
+        {
+          "code": "Q108438121",
+          "label": "COWCAT Games"
+        },
+        {
+          "code": "Q108659876",
+          "label": "Octro, Inc."
+        },
+        {
+          "code": "Q108830228",
+          "label": "Gears for Breakfast"
+        },
+        {
+          "code": "Q108874194",
+          "label": "Killerfish Games"
+        },
+        {
+          "code": "Q108915658",
+          "label": "Usurpator AB"
+        },
+        {
+          "code": "Q108815228",
+          "label": "BOKE"
+        },
+        {
+          "code": "Q108915495",
+          "label": "Critical Games"
+        },
+        {
+          "code": "Q108472693",
+          "label": "Beethoven and Dinosaur"
+        },
+        {
+          "code": "Q108923987",
+          "label": "iGP Games"
+        },
+        {
+          "code": "Q108466940",
+          "label": "Noble Muffins"
+        },
+        {
+          "code": "Q108915665",
+          "label": "Midoki"
+        },
+        {
+          "code": "Q108628374",
+          "label": "ORCA"
+        },
+        {
+          "code": "Q108811815",
+          "label": "Alim"
+        },
+        {
+          "code": "Q108533541",
+          "label": "The Mighty Troglodytes"
+        },
+        {
+          "code": "Q108575885",
+          "label": "Owl Studio"
+        },
+        {
+          "code": "Q108626960",
+          "label": "M Theory"
+        },
+        {
+          "code": "Q108785454",
+          "label": "Bleakmill"
+        },
+        {
+          "code": "Q108818831",
+          "label": "niceplay games"
+        },
+        {
+          "code": "Q108525814",
+          "label": "Codigames"
+        },
+        {
+          "code": "Q108536518",
+          "label": "Flow Studio"
+        },
+        {
+          "code": "Q108571011",
+          "label": "Mechanistry"
+        },
+        {
+          "code": "Q108626533",
+          "label": "Oddboy"
+        },
+        {
+          "code": "Q108659965",
+          "label": "Captain Games"
+        },
+        {
+          "code": "Q108858780",
+          "label": "Studio Thunderhorse"
+        },
+        {
+          "code": "Q23303211",
+          "label": "Joe Williams"
+        },
+        {
+          "code": "Q23252179",
+          "label": "Playful"
+        },
+        {
+          "code": "Q23252700",
+          "label": "Turbo Button"
+        },
+        {
+          "code": "Q23303120",
+          "label": "Parabole"
+        },
+        {
+          "code": "Q22906795",
+          "label": "Blackbird Interactive"
+        },
+        {
+          "code": "Q23045055",
+          "label": "Fingersoft"
+        },
+        {
+          "code": "Q23253363",
+          "label": "White Door Games"
+        },
+        {
+          "code": "Q23303412",
+          "label": "Clever Endeavour Games"
+        },
+        {
+          "code": "Q23302382",
+          "label": "Badim"
+        },
+        {
+          "code": "Q23253782",
+          "label": "Gunfire Games"
+        },
+        {
+          "code": "Q23303470",
+          "label": "Blacklight Interactive"
+        },
+        {
+          "code": "Q22908904",
+          "label": "Hipster Whale"
+        },
+        {
+          "code": "Q23301389",
+          "label": "Psytec Games"
+        },
+        {
+          "code": "Q23303309",
+          "label": "kChamp Games"
+        },
+        {
+          "code": "Q23303466",
+          "label": "Those Awesome Guys"
+        },
+        {
+          "code": "Q22907543",
+          "label": "OtherSide Entertainment"
+        },
+        {
+          "code": "Q23045305",
+          "label": "Recoil Games"
+        },
+        {
+          "code": "Q23303488",
+          "label": "Radiant Entertainment"
+        },
+        {
+          "code": "Q23301955",
+          "label": "Team Gotham"
+        },
+        {
+          "code": "Q23303331",
+          "label": "Giant Army"
+        },
+        {
+          "code": "Q23303404",
+          "label": "Rooster Teeth Games"
+        },
+        {
+          "code": "Q22906632",
+          "label": "Machine Zone"
+        },
+        {
+          "code": "Q22908766",
+          "label": "Grumpyface Studios"
+        },
+        {
+          "code": "Q23253748",
+          "label": "Carbon Games"
+        },
+        {
+          "code": "Q23301680",
+          "label": "Kitfox Games"
+        },
+        {
+          "code": "Q23303395",
+          "label": "Robot Gentleman"
+        },
+        {
+          "code": "Q23303461",
+          "label": "Madruga Works"
+        },
+        {
+          "code": "Q61987093",
+          "label": "General Arcade"
+        },
+        {
+          "code": "Q62027232",
+          "label": "Racing Bros"
+        },
+        {
+          "code": "Q62027541",
+          "label": "Lemix game"
+        },
+        {
+          "code": "Q62027610",
+          "label": "Ignis Sanat"
+        },
+        {
+          "code": "Q61814947",
+          "label": "Interactive Strip"
+        },
+        {
+          "code": "Q61986296",
+          "label": "Ion Lands"
+        },
+        {
+          "code": "Q61793216",
+          "label": "Triband"
+        },
+        {
+          "code": "Q61943448",
+          "label": "Pujia8 Studio"
+        },
+        {
+          "code": "Q62027283",
+          "label": "IMEX Media"
+        },
+        {
+          "code": "Q62027462",
+          "label": "Terapoly"
+        },
+        {
+          "code": "Q61942576",
+          "label": "Lo-Fi Games"
+        },
+        {
+          "code": "Q61947965",
+          "label": "Cantaloupe Kids"
+        },
+        {
+          "code": "Q61964782",
+          "label": "Ektomarch"
+        },
+        {
+          "code": "Q62027691",
+          "label": "SS Studios"
+        },
+        {
+          "code": "Q61989487",
+          "label": "The Game Atelier"
+        },
+        {
+          "code": "Q61757094",
+          "label": "Studio Cypix"
+        },
+        {
+          "code": "Q61959692",
+          "label": "Atom Team"
+        },
+        {
+          "code": "Q61976435",
+          "label": "1Games"
+        },
+        {
+          "code": "Q61994680",
+          "label": "Paper Cult"
+        },
+        {
+          "code": "Q62027357",
+          "label": "AEL Entertainment"
+        },
+        {
+          "code": "Q62027314",
+          "label": "Digital Software"
+        },
+        {
+          "code": "Q61748010",
+          "label": "Radical Fish Games"
+        },
+        {
+          "code": "Q61756986",
+          "label": "Joathrent Studios"
+        },
+        {
+          "code": "Q61791904",
+          "label": "Barkers Crest Studio"
+        },
+        {
+          "code": "Q61819949",
+          "label": "Radiation Blue"
+        },
+        {
+          "code": "Q61986732",
+          "label": "Desk Plant"
+        },
+        {
+          "code": "Q61993639",
+          "label": "Stellar Entertainment"
+        },
+        {
+          "code": "Q62011455",
+          "label": "NetEase Games"
+        },
+        {
+          "code": "Q62019148",
+          "label": "Juncture Media"
+        },
+        {
+          "code": "Q62022508",
+          "label": "Distant Games"
+        },
+        {
+          "code": "Q62022445",
+          "label": "Phony Game Studios"
+        },
+        {
+          "code": "Q62022435",
+          "label": "RewindApp"
+        },
+        {
+          "code": "Q61942296",
+          "label": "DNT Games"
+        },
+        {
+          "code": "Q61977217",
+          "label": "Lightning Game Studios"
+        },
+        {
+          "code": "Q18001341",
+          "label": "increpare games"
+        },
+        {
+          "code": "Q18352597",
+          "label": "Dreamatrix Game Studios"
+        },
+        {
+          "code": "Q18154650",
+          "label": "Mighty Rabbit Studios"
+        },
+        {
+          "code": "Q18206497",
+          "label": "Disco Pixel"
+        },
+        {
+          "code": "Q18345499",
+          "label": "Psyonix"
+        },
+        {
+          "code": "Q18353957",
+          "label": "Limbic Entertainment"
+        },
+        {
+          "code": "Q18002302",
+          "label": "Skilltree Studios"
+        },
+        {
+          "code": "Q18031627",
+          "label": "Crytek Hungary"
+        },
+        {
+          "code": "Q18210616",
+          "label": "Kiro'o Games"
+        },
+        {
+          "code": "Q17986552",
+          "label": "Cloudgine"
+        },
+        {
+          "code": "Q18002304",
+          "label": "Gaming Minds Studios"
+        },
+        {
+          "code": "Q18215959",
+          "label": "Pinkerton Road Studio"
+        },
+        {
+          "code": "Q18293836",
+          "label": "TicBits Ltd."
+        },
+        {
+          "code": "Q17747126",
+          "label": "Fox Digital Entertainment"
+        },
+        {
+          "code": "Q18338969",
+          "label": "Pygmy Studio"
+        },
+        {
+          "code": "Q18161696",
+          "label": "SFB Games"
+        },
+        {
+          "code": "Q18151782",
+          "label": "Nightdive Studios"
+        },
+        {
+          "code": "Q18336575",
+          "label": "Asobimo"
+        },
+        {
+          "code": "Q18343647",
+          "label": "Poppermost Productions"
+        },
+        {
+          "code": "Q2866089",
+          "label": "Arxel Tribe"
+        },
+        {
+          "code": "Q2917037",
+          "label": "Vanpool"
+        },
+        {
+          "code": "Q2865851",
+          "label": "Artoon"
+        },
+        {
+          "code": "Q2924219",
+          "label": "BreakAway Games"
+        },
+        {
+          "code": "Q2866735",
+          "label": "Asobo Studio"
+        },
+        {
+          "code": "Q2870052",
+          "label": "Attention to Detail"
+        },
+        {
+          "code": "Q2864855",
+          "label": "Artefacts Studio"
+        },
+        {
+          "code": "Q2902116",
+          "label": "Big Ape Productions"
+        },
+        {
+          "code": "Q2912131",
+          "label": "Studio Ryokucha"
+        },
+        {
+          "code": "Q3208757",
+          "label": "UEP Systems"
+        },
+        {
+          "code": "Q3190271",
+          "label": "Just Add Water"
+        },
+        {
+          "code": "Q3195411",
+          "label": "Kerberos Productions"
+        },
+        {
+          "code": "Q3196163",
+          "label": "Kheops Studio"
+        },
+        {
+          "code": "Q3242292",
+          "label": "Liquid Entertainment"
+        },
+        {
+          "code": "Q3259558",
+          "label": "Loriciels"
+        },
+        {
+          "code": "Q3181534",
+          "label": "Klei Entertainment"
+        },
+        {
+          "code": "Q3274623",
+          "label": "AQ Interactive"
+        },
+        {
+          "code": "Q3189994",
+          "label": "Junction Point Studios"
+        },
+        {
+          "code": "Q3267193",
+          "label": "Second-party"
+        },
+        {
+          "code": "Q3206159",
+          "label": "Light & Shadow Production"
+        },
+        {
+          "code": "Q117075729",
+          "label": "Dico"
+        },
+        {
+          "code": "Q117007773",
+          "label": "Solaris Mobile"
+        },
+        {
+          "code": "Q116970850",
+          "label": "Rekka Games"
+        },
+        {
+          "code": "Q116977097",
+          "label": "Dream-Up"
+        },
+        {
+          "code": "Q116982316",
+          "label": "My Night Sun Games"
+        },
+        {
+          "code": "Q116982475",
+          "label": "Jumpship"
+        },
+        {
+          "code": "Q116982495",
+          "label": "Microids Studio Paris"
+        },
+        {
+          "code": "Q116982507",
+          "label": "Microids Studio Lyon"
+        },
+        {
+          "code": "Q116983237",
+          "label": "IC Games"
+        },
+        {
+          "code": "Q116983311",
+          "label": "Bit Golem"
+        },
+        {
+          "code": "Q116983322",
+          "label": "Steel Mantis"
+        },
+        {
+          "code": "Q116983776",
+          "label": "Virtual Arts Studio"
+        },
+        {
+          "code": "Q116983814",
+          "label": "Sewer Cat"
+        },
+        {
+          "code": "Q116983871",
+          "label": "Coffee Stain North"
+        },
+        {
+          "code": "Q116986654",
+          "label": "Team ADOM"
+        },
+        {
+          "code": "Q116986691",
+          "label": "Amata K.K."
+        },
+        {
+          "code": "Q116994481",
+          "label": "Piece of Cake studios"
+        },
+        {
+          "code": "Q117004607",
+          "label": "Bravo Game Studios"
+        },
+        {
+          "code": "Q117004908",
+          "label": "Paradox Tectonic"
+        },
+        {
+          "code": "Q117005437",
+          "label": "Tunnel Vision Studio"
+        },
+        {
+          "code": "Q117006160",
+          "label": "Gamecom Team"
+        },
+        {
+          "code": "Q117006652",
+          "label": "Medallion Games"
+        },
+        {
+          "code": "Q117006669",
+          "label": "Upstairs Digital"
+        },
+        {
+          "code": "Q117006683",
+          "label": "Fika Productions"
+        },
+        {
+          "code": "Q117006722",
+          "label": "Red Martyr Entertainment"
+        },
+        {
+          "code": "Q117007016",
+          "label": "GOAT Games"
+        },
+        {
+          "code": "Q117007602",
+          "label": "Colossus Game Studio"
+        },
+        {
+          "code": "Q117023460",
+          "label": "Funktronic Labs"
+        },
+        {
+          "code": "Q117061560",
+          "label": "Illusion Ray"
+        },
+        {
+          "code": "Q117066260",
+          "label": "Dume Games Studio"
+        },
+        {
+          "code": "Q117066284",
+          "label": "Mayo Games"
+        },
+        {
+          "code": "Q117067575",
+          "label": "CarloC"
+        },
+        {
+          "code": "Q117067608",
+          "label": "Dionous Games"
+        },
+        {
+          "code": "Q117083142",
+          "label": "Pixpil"
+        },
+        {
+          "code": "Q117083246",
+          "label": "Jinthree Studio"
+        },
+        {
+          "code": "Q117083307",
+          "label": "DangerousBob Studio"
+        },
+        {
+          "code": "Q117083333",
+          "label": "Digital Kingdom"
+        },
+        {
+          "code": "Q117127767",
+          "label": "Fool's Theory"
+        },
+        {
+          "code": "Q117193823",
+          "label": "CP Verlag"
+        },
+        {
+          "code": "Q117199707",
+          "label": "Chronos Unterhaltungssoftware"
+        },
+        {
+          "code": "Q117199772",
+          "label": "Red Beard Games"
+        },
+        {
+          "code": "Q117199924",
+          "label": "SwordSwipe Studios"
+        },
+        {
+          "code": "Q117211871",
+          "label": "SomniumSoft"
+        },
+        {
+          "code": "Q117222605",
+          "label": "Goodhustle Studios"
+        },
+        {
+          "code": "Q117225226",
+          "label": "Regular Studio"
+        },
+        {
+          "code": "Q117225666",
+          "label": "tone work's"
+        },
+        {
+          "code": "Q117159750",
+          "label": "Mission Ctrl Studios"
+        },
+        {
+          "code": "Q60462896",
+          "label": "Square USA, Inc."
+        },
+        {
+          "code": "Q60515726",
+          "label": "General Consumer Electronics"
+        },
+        {
+          "code": "Q60579597",
+          "label": "Direlight"
+        },
+        {
+          "code": "Q60616886",
+          "label": "Maverick Game Studio"
+        },
+        {
+          "code": "Q60618445",
+          "label": "GFX47"
+        },
+        {
+          "code": "Q60594218",
+          "label": "Mountains"
+        },
+        {
+          "code": "Q60462988",
+          "label": "Tuetue Kombinato Co., Ltd."
+        },
+        {
+          "code": "Q60564866",
+          "label": "Ghost_RUS Games"
+        },
+        {
+          "code": "Q60566327",
+          "label": "Acrued Insolence"
+        },
+        {
+          "code": "Q60630224",
+          "label": "Outer Planet Studios"
+        },
+        {
+          "code": "Q60633910",
+          "label": "Galope"
+        },
+        {
+          "code": "Q60463228",
+          "label": "Pinsleep Inc."
+        },
+        {
+          "code": "Q60476133",
+          "label": "Zeppelin Games"
+        },
+        {
+          "code": "Q60629897",
+          "label": "Bulwark Studios"
+        },
+        {
+          "code": "Q60660128",
+          "label": "Race Cat"
+        },
+        {
+          "code": "Q60539951",
+          "label": "Sleepless Knights"
+        },
+        {
+          "code": "Q60354586",
+          "label": "Hazelight Studios"
+        },
+        {
+          "code": "Q60616885",
+          "label": "Three Guys Game Studio"
+        },
+        {
+          "code": "Q60581905",
+          "label": "Alligator Pit"
+        },
+        {
+          "code": "Q60618995",
+          "label": "Rockwell Studios, LLC"
+        },
+        {
+          "code": "Q60463033",
+          "label": "D4A Co., Ltd."
+        },
+        {
+          "code": "Q60462863",
+          "label": "Tears Ichikawa Software Co., Ltd."
+        },
+        {
+          "code": "Q60614515",
+          "label": "Merge Games"
+        },
+        {
+          "code": "Q60324673",
+          "label": "VizionEck"
+        },
+        {
+          "code": "Q60394420",
+          "label": "Oxymoron Games"
+        },
+        {
+          "code": "Q60616882",
+          "label": "Gethsemane Games"
+        },
+        {
+          "code": "Q106839575",
+          "label": "Kung Fu Games"
+        },
+        {
+          "code": "Q106869094",
+          "label": "Lucky Mountain Games"
+        },
+        {
+          "code": "Q106689276",
+          "label": "PixelHive"
+        },
+        {
+          "code": "Q106753220",
+          "label": "Adikus"
+        },
+        {
+          "code": "Q106864235",
+          "label": "Hamster On Coke Games"
+        },
+        {
+          "code": "Q106909098",
+          "label": "Vizor Games"
+        },
+        {
+          "code": "Q106823270",
+          "label": "Charles Games"
+        },
+        {
+          "code": "Q106823346",
+          "label": "Paintbucket Games"
+        },
+        {
+          "code": "Q106823479",
+          "label": "Foolish Mortals"
+        },
+        {
+          "code": "Q106841841",
+          "label": "ArtGame"
+        },
+        {
+          "code": "Q106857748",
+          "label": "mastercode studio"
+        },
+        {
+          "code": "Q106874704",
+          "label": "Inkline"
+        },
+        {
+          "code": "Q106918819",
+          "label": "Starni Games"
+        },
+        {
+          "code": "Q106684722",
+          "label": "Downpour Interactive"
+        },
+        {
+          "code": "Q106805418",
+          "label": "Owlcat Games"
+        },
+        {
+          "code": "Q106865364",
+          "label": "Striking Distance Studios"
+        },
+        {
+          "code": "Q106875268",
+          "label": "Nord Unit"
+        },
+        {
+          "code": "Q106937031",
+          "label": "Vertical Robot"
+        },
+        {
+          "code": "Q106767114",
+          "label": "General Interactive Co."
+        },
+        {
+          "code": "Q106918849",
+          "label": "Klabater"
+        },
+        {
+          "code": "Q106697791",
+          "label": "Intoxicate Studios"
+        },
+        {
+          "code": "Q106765673",
+          "label": "Snoozy Kazoo"
+        },
+        {
+          "code": "Q106803275",
+          "label": "Hyperbolic Magnetism"
+        },
+        {
+          "code": "Q106803078",
+          "label": "kunabi brother"
+        },
+        {
+          "code": "Q106862101",
+          "label": "Gamma Play"
+        },
+        {
+          "code": "Q106874663",
+          "label": "Sennep Games"
+        },
+        {
+          "code": "Q106775805",
+          "label": "Room-C Games"
+        },
+        {
+          "code": "Q106870946",
+          "label": "Semidome Inc."
+        },
+        {
+          "code": "Q106875311",
+          "label": "Grant & Bert Studios"
+        },
+        {
+          "code": "Q108935442",
+          "label": "Exe-Create"
+        },
+        {
+          "code": "Q108945355",
+          "label": "JM Neto Game Dev"
+        },
+        {
+          "code": "Q109003498",
+          "label": "Cococucumber"
+        },
+        {
+          "code": "Q109007293",
+          "label": "Lunic Games"
+        },
+        {
+          "code": "Q109063277",
+          "label": "ChiliDog Interactive"
+        },
+        {
+          "code": "Q109063696",
+          "label": "Firebeast"
+        },
+        {
+          "code": "Q109078092",
+          "label": "Boomfire Games"
+        },
+        {
+          "code": "Q109007233",
+          "label": "Outer Heaven"
+        },
+        {
+          "code": "Q108945721",
+          "label": "DCF Studios"
+        },
+        {
+          "code": "Q109050596",
+          "label": "Sundae Month"
+        },
+        {
+          "code": "Q109081789",
+          "label": "EpiXR Games"
+        },
+        {
+          "code": "Q108934209",
+          "label": "Citadel Studios"
+        },
+        {
+          "code": "Q109060082",
+          "label": "Motorsport Games"
+        },
+        {
+          "code": "Q109079674",
+          "label": "Dolores Entertainment"
+        },
+        {
+          "code": "Q108949682",
+          "label": "Ritual Games"
+        },
+        {
+          "code": "Q109061875",
+          "label": "Petoons Studio"
+        },
+        {
+          "code": "Q109064515",
+          "label": "Synthetic Domain"
+        },
+        {
+          "code": "Q108940857",
+          "label": "Sometimes You"
+        },
+        {
+          "code": "Q109064497",
+          "label": "Big Way Games"
+        },
+        {
+          "code": "Q109077833",
+          "label": "JanduSoft"
+        },
+        {
+          "code": "Q109062190",
+          "label": "Brave Giant"
+        },
+        {
+          "code": "Q109007355",
+          "label": "Cracked Heads Games"
+        },
+        {
+          "code": "Q64667160",
+          "label": "MARS Corporation"
+        },
+        {
+          "code": "Q65046575",
+          "label": "AdHoc Studio"
+        },
+        {
+          "code": "Q65053854",
+          "label": "Studio Oleomingus"
+        },
+        {
+          "code": "Q64626727",
+          "label": "Lancarse"
+        },
+        {
+          "code": "Q64814857",
+          "label": "Voodoo"
+        },
+        {
+          "code": "Q65032803",
+          "label": "Silence"
+        },
+        {
+          "code": "Q64682507",
+          "label": "Pixel"
+        },
+        {
+          "code": "Q64692220",
+          "label": "Random House Co., Ltd."
+        },
+        {
+          "code": "Q64826875",
+          "label": "Benjamin Rivers Inc."
+        },
+        {
+          "code": "Q65044269",
+          "label": "Purple Lamp"
+        },
+        {
+          "code": "Q65068121",
+          "label": "Tuque Games"
+        },
+        {
+          "code": "Q65089362",
+          "label": "Bonfire Studios"
+        },
+        {
+          "code": "Q64826716",
+          "label": "Dispari"
+        },
+        {
+          "code": "Q64667243",
+          "label": "Fun Unit"
+        },
+        {
+          "code": "Q64667188",
+          "label": "Scap Trust"
+        },
+        {
+          "code": "Q64682389",
+          "label": "Gevo Entertainment Pte Ltd"
+        },
+        {
+          "code": "Q64626859",
+          "label": "Aim at Entertainment, Inc."
+        },
+        {
+          "code": "Q64682289",
+          "label": "Zerodiv"
+        },
+        {
+          "code": "Q64685211",
+          "label": "AurumDust"
+        },
+        {
+          "code": "Q64760758",
+          "label": "Studio Turtledove"
+        },
+        {
+          "code": "Q64826763",
+          "label": "Ebullience Games"
+        },
+        {
+          "code": "Q65032710",
+          "label": "Studio Saizensen"
+        },
+        {
+          "code": "Q65048713",
+          "label": "Fan-na"
+        },
+        {
+          "code": "Q65090107",
+          "label": "Heart Machine"
+        },
+        {
+          "code": "Q64626732",
+          "label": "Betop"
+        },
+        {
+          "code": "Q64626843",
+          "label": "Team Aquila"
+        },
+        {
+          "code": "Q65073419",
+          "label": "Tenami"
+        },
+        {
+          "code": "Q64626751",
+          "label": "Killaware Co.,Ltd."
+        },
+        {
+          "code": "Q64667291",
+          "label": "Althi Inc."
+        },
+        {
+          "code": "Q64729751",
+          "label": "GB Patch Games"
+        },
+        {
+          "code": "Q65088849",
+          "label": "Digital Eclipse"
+        },
+        {
+          "code": "Q64826844",
+          "label": "Straywire"
+        },
+        {
+          "code": "Q64995462",
+          "label": "Salamander Factory Co., Ltd."
+        },
+        {
+          "code": "Q65038828",
+          "label": "Konami Computer Entertainment Osaka"
+        },
+        {
+          "code": "Q109275005",
+          "label": "iLLogika"
+        },
+        {
+          "code": "Q109339335",
+          "label": "Timeslip Softworks"
+        },
+        {
+          "code": "Q109420021",
+          "label": "Turner Interactive"
+        },
+        {
+          "code": "Q109227649",
+          "label": "Orcsoft"
+        },
+        {
+          "code": "Q109327213",
+          "label": "Hunted Cow Studios"
+        },
+        {
+          "code": "Q109381699",
+          "label": "RedDeerGames"
+        },
+        {
+          "code": "Q109084319",
+          "label": "Team SolEtude"
+        },
+        {
+          "code": "Q109085735",
+          "label": "Gearhead Games"
+        },
+        {
+          "code": "Q109128312",
+          "label": "EfimovMax"
+        },
+        {
+          "code": "Q109300214",
+          "label": "Pyramid Games"
+        },
+        {
+          "code": "Q109407566",
+          "label": "Pine Studio"
+        },
+        {
+          "code": "Q109085363",
+          "label": "Joindots"
+        },
+        {
+          "code": "Q109255042",
+          "label": "Bigmoon Entertainment"
+        },
+        {
+          "code": "Q109422605",
+          "label": "Arrowiz"
+        },
+        {
+          "code": "Q109357931",
+          "label": "Wobbly Tooth"
+        },
+        {
+          "code": "Q109342583",
+          "label": "Game Science"
+        },
+        {
+          "code": "Q109278508",
+          "label": "Kano Apps"
+        },
+        {
+          "code": "Q109384885",
+          "label": "HitP Studio"
+        },
+        {
+          "code": "Q109234150",
+          "label": "Jetpack Interactive"
+        },
+        {
+          "code": "Q109305962",
+          "label": "Exkee"
+        },
+        {
+          "code": "Q109357960",
+          "label": "ZlonGame"
+        },
+        {
+          "code": "Q109418010",
+          "label": "Bunnyhug"
+        },
+        {
+          "code": "Q22128987",
+          "label": "More"
+        },
+        {
+          "code": "Q22130729",
+          "label": "Smile"
+        },
+        {
+          "code": "Q22123955",
+          "label": "Kojima Productions"
+        },
+        {
+          "code": "Q22815063",
+          "label": "Bay 12 Games"
+        },
+        {
+          "code": "Q21777038",
+          "label": "Bemani"
+        },
+        {
+          "code": "Q22098668",
+          "label": "TiMi Studio Group"
+        },
+        {
+          "code": "Q22078683",
+          "label": "Sysnet Info-Tech"
+        },
+        {
+          "code": "Q22098678",
+          "label": "Timi Studio"
+        },
+        {
+          "code": "Q22031476",
+          "label": "Image & Form"
+        },
+        {
+          "code": "Q22079511",
+          "label": "Telesys"
+        },
+        {
+          "code": "Q22100076",
+          "label": "PeasSoft"
+        },
+        {
+          "code": "Q22238198",
+          "label": "bildundtonfabrik"
+        },
+        {
+          "code": "Q22099099",
+          "label": "Wucai Shi Gongzuo Shi"
+        },
+        {
+          "code": "Q22099234",
+          "label": "Quantum Studios"
+        },
+        {
+          "code": "Q22099665",
+          "label": "MoreFun Studio Group"
+        },
+        {
+          "code": "Q22099242",
+          "label": "Jade Studio"
+        },
+        {
+          "code": "Q55807196",
+          "label": "Viking Tao"
+        },
+        {
+          "code": "Q56224237",
+          "label": "CookieByte Entertainment"
+        },
+        {
+          "code": "Q56439382",
+          "label": "Brainwash Gang"
+        },
+        {
+          "code": "Q56545189",
+          "label": "Oh, a Rock! Studios"
+        },
+        {
+          "code": "Q56433268",
+          "label": "Pandora"
+        },
+        {
+          "code": "Q55765109",
+          "label": "The World Outside"
+        },
+        {
+          "code": "Q56278668",
+          "label": "Takeru"
+        },
+        {
+          "code": "Q56273928",
+          "label": "DotGEARS"
+        },
+        {
+          "code": "Q55813555",
+          "label": "Bypass Game Studios"
+        },
+        {
+          "code": "Q55864413",
+          "label": "Bluemoon Interactive"
+        },
+        {
+          "code": "Q56037094",
+          "label": "Messenger2050 Technologies"
+        },
+        {
+          "code": "Q56056109",
+          "label": "SimFabric"
+        },
+        {
+          "code": "Q56440780",
+          "label": "Gamepires"
+        },
+        {
+          "code": "Q56517074",
+          "label": "Bonfire Studios"
+        },
+        {
+          "code": "Q55936642",
+          "label": "MVP Software"
+        },
+        {
+          "code": "Q56092170",
+          "label": "Creative Materials"
+        },
+        {
+          "code": "Q56348898",
+          "label": "Microsoft Casual Games"
+        },
+        {
+          "code": "Q56419712",
+          "label": "Micro Fun"
+        },
+        {
+          "code": "Q56451383",
+          "label": "Landfall West"
+        },
+        {
+          "code": "Q56247133",
+          "label": "Tigress Marketing"
+        },
+        {
+          "code": "Q56448478",
+          "label": "ILMxLAB"
+        },
+        {
+          "code": "Q56064073",
+          "label": "Vavel Games"
+        },
+        {
+          "code": "Q55735496",
+          "label": "Pearl Abyss"
+        },
+        {
+          "code": "Q56046987",
+          "label": "The RamJam Corporation"
+        },
+        {
+          "code": "Q56056311",
+          "label": "Decabry"
+        },
+        {
+          "code": "Q56061956",
+          "label": "Major Developments"
+        },
+        {
+          "code": "Q56151982",
+          "label": "Pixel Federation"
+        },
+        {
+          "code": "Q55758953",
+          "label": "House Pixel Games"
+        },
+        {
+          "code": "Q55804338",
+          "label": "Soon Studios"
+        },
+        {
+          "code": "Q55839772",
+          "label": "Necrosoft Games"
+        },
+        {
+          "code": "Q56203953",
+          "label": "TwoPM Studios"
+        },
+        {
+          "code": "Q56204891",
+          "label": "Drama Drifters"
+        },
+        {
+          "code": "Q115971678",
+          "label": "Parallel Circles"
+        },
+        {
+          "code": "Q115973753",
+          "label": "YAW Studios"
+        },
+        {
+          "code": "Q116038299",
+          "label": "Studio Goya"
+        },
+        {
+          "code": "Q116040686",
+          "label": "Blender Games"
+        },
+        {
+          "code": "Q116153683",
+          "label": "Renderise"
+        },
+        {
+          "code": "Q115971514",
+          "label": "Spoonbox Studio"
+        },
+        {
+          "code": "Q115978584",
+          "label": "Translimit"
+        },
+        {
+          "code": "Q116141727",
+          "label": "1564 Studio"
+        },
+        {
+          "code": "Q116152605",
+          "label": "Perun Creative"
+        },
+        {
+          "code": "Q116197571",
+          "label": "Redblack Spade"
+        },
+        {
+          "code": "Q115676606",
+          "label": "Xigma Games"
+        },
+        {
+          "code": "Q115787047",
+          "label": "EnsenaSoft"
+        },
+        {
+          "code": "Q115804631",
+          "label": "Half Asleep"
+        },
+        {
+          "code": "Q116009543",
+          "label": "Half Mermaid Productions"
+        },
+        {
+          "code": "Q116014108",
+          "label": "CodeHatch"
+        },
+        {
+          "code": "Q115651958",
+          "label": "Two Star Games"
+        },
+        {
+          "code": "Q115692520",
+          "label": "Mekujira"
+        },
+        {
+          "code": "Q116141666",
+          "label": "Rockhead Studios"
+        },
+        {
+          "code": "Q116166351",
+          "label": "DreadXP"
+        },
+        {
+          "code": "Q116008675",
+          "label": "Raylight Games"
+        },
+        {
+          "code": "Q116152747",
+          "label": "Clever Plays"
+        },
+        {
+          "code": "Q116152631",
+          "label": "Reborn Entertainment"
+        },
+        {
+          "code": "Q116152580",
+          "label": "Waking Oni Games"
+        },
+        {
+          "code": "Q116175872",
+          "label": "Follow The Fun"
+        },
+        {
+          "code": "Q116192823",
+          "label": "Freaky Creations"
+        },
+        {
+          "code": "Q115661734",
+          "label": "EverCats"
+        },
+        {
+          "code": "Q115662084",
+          "label": "Ascendant Studios"
+        },
+        {
+          "code": "Q115988556",
+          "label": "SoftColors"
+        },
+        {
+          "code": "Q116009408",
+          "label": "Yippee Entertainment"
+        },
+        {
+          "code": "Q116025628",
+          "label": "John and Evan Szymanski"
+        },
+        {
+          "code": "Q116040395",
+          "label": "Perverse Games"
+        },
+        {
+          "code": "Q116143207",
+          "label": "ROLVe Community"
+        },
+        {
+          "code": "Q115725772",
+          "label": "Piccolo Studio"
+        },
+        {
+          "code": "Q115962750",
+          "label": "Massive Miniteam"
+        },
+        {
+          "code": "Q116009638",
+          "label": "Splashteam"
+        },
+        {
+          "code": "Q116154818",
+          "label": "FastGame"
+        },
+        {
+          "code": "Q116175936",
+          "label": "TigerQiuQiu"
+        },
+        {
+          "code": "Q116181559",
+          "label": "Squiddershins"
+        },
+        {
+          "code": "Q116154591",
+          "label": "Victoria Games"
+        },
+        {
+          "code": "Q116181323",
+          "label": "Crema"
+        },
+        {
+          "code": "Q115898873",
+          "label": "Studio Somewhere"
+        },
+        {
+          "code": "Q115988119",
+          "label": "Vewo Interactive"
+        },
+        {
+          "code": "Q116000210",
+          "label": "YummyYummyTummy"
+        },
+        {
+          "code": "Q116141767",
+          "label": "Pixadome"
+        },
+        {
+          "code": "Q115965629",
+          "label": "Plastic"
+        },
+        {
+          "code": "Q23385117",
+          "label": "Rogue Factor"
+        },
+        {
+          "code": "Q23385983",
+          "label": "3Division"
+        },
+        {
+          "code": "Q23385811",
+          "label": "The Innocent Devils"
+        },
+        {
+          "code": "Q23762835",
+          "label": "I-Illusions"
+        },
+        {
+          "code": "Q23762917",
+          "label": "Tammeka Games"
+        },
+        {
+          "code": "Q23763151",
+          "label": "Phaser Lock Interactive"
+        },
+        {
+          "code": "Q23759377",
+          "label": "Lazy Bear Games"
+        },
+        {
+          "code": "Q23759360",
+          "label": "Oxide Games"
+        },
+        {
+          "code": "Q23759640",
+          "label": "高考恋爱委员会"
+        },
+        {
+          "code": "Q23760851",
+          "label": "Manic Game Studios"
+        },
+        {
+          "code": "Q23761586",
+          "label": "Night School Studio"
+        },
+        {
+          "code": "Q23541586",
+          "label": "Moon Studios"
+        },
+        {
+          "code": "Q23762991",
+          "label": "AAD Productions"
+        },
+        {
+          "code": "Q23762984",
+          "label": "Alpha Wave Entertainment"
+        },
+        {
+          "code": "Q23386385",
+          "label": "cupholder"
+        },
+        {
+          "code": "Q23759525",
+          "label": "Paradox North"
+        },
+        {
+          "code": "Q23761546",
+          "label": "Colibri Games"
+        },
+        {
+          "code": "Q23762856",
+          "label": "Futuretown"
+        },
+        {
+          "code": "Q23763011",
+          "label": "Cloudhead Games"
+        },
+        {
+          "code": "Q23763001",
+          "label": "Wevr, Inc."
+        },
+        {
+          "code": "Q23386559",
+          "label": "Out of the Park Developments"
+        },
+        {
+          "code": "Q23759334",
+          "label": "Dylan Fitterer"
+        },
+        {
+          "code": "Q23759529",
+          "label": "Parallax Arts Studio"
+        },
+        {
+          "code": "Q23762997",
+          "label": "Phr00t's Software"
+        },
+        {
+          "code": "Q23309247",
+          "label": "QianZhiHuDong Network Technology Co., Ltd."
+        },
+        {
+          "code": "Q23759646",
+          "label": "橘子班"
+        },
+        {
+          "code": "Q23762623",
+          "label": "PixelTail Games"
+        },
+        {
+          "code": "Q23762827",
+          "label": "Stress Level Zero"
+        },
+        {
+          "code": "Q62476905",
+          "label": "Axes Art Amuse"
+        },
+        {
+          "code": "Q62416270",
+          "label": "Cobra Team"
+        },
+        {
+          "code": "Q62470561",
+          "label": "Sixjoy Hong Kong Limited"
+        },
+        {
+          "code": "Q62477188",
+          "label": "Shin-Nihon Laser Soft Co., Ltd."
+        },
+        {
+          "code": "Q62559123",
+          "label": "Universal Co., Ltd."
+        },
+        {
+          "code": "Q62507653",
+          "label": "Melody"
+        },
+        {
+          "code": "Q62508662",
+          "label": "Actress"
+        },
+        {
+          "code": "Q62493810",
+          "label": "Cream"
+        },
+        {
+          "code": "Q62076102",
+          "label": "Voltage Entertainment"
+        },
+        {
+          "code": "Q62399464",
+          "label": "Almanic Corp."
+        },
+        {
+          "code": "Q62409048",
+          "label": "Copya System Ltd."
+        },
+        {
+          "code": "Q62476879",
+          "label": "Affect Co.,Ltd"
+        },
+        {
+          "code": "Q62488003",
+          "label": "Mi'pu'mi Games"
+        },
+        {
+          "code": "Q62508188",
+          "label": "Ant Software"
+        },
+        {
+          "code": "Q62559087",
+          "label": "Fupac"
+        },
+        {
+          "code": "Q62559062",
+          "label": "Starfish Inc."
+        },
+        {
+          "code": "Q62116277",
+          "label": "Stadia Games and Entertainment"
+        },
+        {
+          "code": "Q62124210",
+          "label": "Medl Mobile"
+        },
+        {
+          "code": "Q62399517",
+          "label": "Viacom New Media"
+        },
+        {
+          "code": "Q62476023",
+          "label": "Crosstalk Inc."
+        },
+        {
+          "code": "Q62061729",
+          "label": "Hempuli Oy"
+        },
+        {
+          "code": "Q62108890",
+          "label": "Visiontrick Media AB."
+        },
+        {
+          "code": "Q62399685",
+          "label": "Ringler Studios"
+        },
+        {
+          "code": "Q62402531",
+          "label": "Multimedia Intelligence Transfer Co., Ltd."
+        },
+        {
+          "code": "Q62559104",
+          "label": "GAME STUDIO Inc."
+        },
+        {
+          "code": "Q62477290",
+          "label": "TNN"
+        },
+        {
+          "code": "Q62032408",
+          "label": "Virtual Regatta SAS"
+        },
+        {
+          "code": "Q62476129",
+          "label": "RSP, Inc."
+        },
+        {
+          "code": "Q62508098",
+          "label": "Dodge Roll"
+        },
+        {
+          "code": "Q62186099",
+          "label": "Hardsuit Labs"
+        },
+        {
+          "code": "Q62507619",
+          "label": "Presage Software"
+        },
+        {
+          "code": "Q62544287",
+          "label": "Wegenbartho"
+        },
+        {
+          "code": "Q62559227",
+          "label": "Max Entertainment"
+        },
+        {
+          "code": "Q62559152",
+          "label": "A-Max"
+        },
+        {
+          "code": "Q62128173",
+          "label": "Star Maid Games"
+        },
+        {
+          "code": "Q62416197",
+          "label": "J-Force"
+        },
+        {
+          "code": "Q62501511",
+          "label": "Goblinz Studio"
+        },
+        {
+          "code": "Q62403327",
+          "label": "Gray Matter Inc."
+        },
+        {
+          "code": "Q62416379",
+          "label": "Marionette Co., Ltd."
+        },
+        {
+          "code": "Q107742141",
+          "label": "Anomaly Games"
+        },
+        {
+          "code": "Q107863970",
+          "label": "creā-ture Studios"
+        },
+        {
+          "code": "Q107936595",
+          "label": "Geometa"
+        },
+        {
+          "code": "Q107963087",
+          "label": "Stairway Games"
+        },
+        {
+          "code": "Q107998861",
+          "label": "Colorspace Studios"
+        },
+        {
+          "code": "Q107999169",
+          "label": "Hollow Tree Games"
+        },
+        {
+          "code": "Q108000732",
+          "label": "Cradle Games"
+        },
+        {
+          "code": "Q108104920",
+          "label": "Union Workshop"
+        },
+        {
+          "code": "Q107985918",
+          "label": "RZE Studio"
+        },
+        {
+          "code": "Q108076890",
+          "label": "Cafundo Estudio Criativo Eireli"
+        },
+        {
+          "code": "Q108104984",
+          "label": "Virtual Rail Creations"
+        },
+        {
+          "code": "Q107980182",
+          "label": "aPriori Digital"
+        },
+        {
+          "code": "Q107998686",
+          "label": "Smug Marmot Studios"
+        },
+        {
+          "code": "Q107999215",
+          "label": "Seaven Studio"
+        },
+        {
+          "code": "Q108104886",
+          "label": "High Iron Simulations"
+        },
+        {
+          "code": "Q108027688",
+          "label": "Team WIBY"
+        },
+        {
+          "code": "Q108028438",
+          "label": "Worldwalker Games"
+        },
+        {
+          "code": "Q108063491",
+          "label": "Woodland Games"
+        },
+        {
+          "code": "Q108104944",
+          "label": "RSSLO"
+        },
+        {
+          "code": "Q108104974",
+          "label": "Skyhook Games Studio"
+        },
+        {
+          "code": "Q107741697",
+          "label": "Norsfell Games Inc."
+        },
+        {
+          "code": "Q108000666",
+          "label": "Retrific"
+        },
+        {
+          "code": "Q108027609",
+          "label": "Soaring Pixels Games"
+        },
+        {
+          "code": "Q108036221",
+          "label": "Mongoose Rodeo"
+        },
+        {
+          "code": "Q108104900",
+          "label": "Just Trains"
+        },
+        {
+          "code": "Q108104909",
+          "label": "Thomson Interactive"
+        },
+        {
+          "code": "Q107750700",
+          "label": "Malaysia Studio"
+        },
+        {
+          "code": "Q107897747",
+          "label": "Unexpected Studio"
+        },
+        {
+          "code": "Q107975870",
+          "label": "Shadow Raven Studios"
+        },
+        {
+          "code": "Q108001909",
+          "label": "ANENPA"
+        },
+        {
+          "code": "Q108104998",
+          "label": "Digital Train Model"
+        },
+        {
+          "code": "Q108104927",
+          "label": "virtualRailroads"
+        },
+        {
+          "code": "Q108105007",
+          "label": "The Loco Shop"
+        },
+        {
+          "code": "Q108104962",
+          "label": "Smokebox"
+        },
+        {
+          "code": "Q107746640",
+          "label": "Crafting Legends"
+        },
+        {
+          "code": "Q107885598",
+          "label": "Halcyon Winds"
+        },
+        {
+          "code": "Q107806350",
+          "label": "Scumhead"
+        },
+        {
+          "code": "Q107907315",
+          "label": "The Molasses Flood"
+        },
+        {
+          "code": "Q108104895",
+          "label": "Bossman Games"
+        },
+        {
+          "code": "Q108104799",
+          "label": "Rivet Games"
+        },
+        {
+          "code": "Q21563329",
+          "label": "DMA Design"
+        },
+        {
+          "code": "Q21208888",
+          "label": "MAG Interactive"
+        },
+        {
+          "code": "Q21463158",
+          "label": "Harebrained Schemes"
+        },
+        {
+          "code": "Q21405666",
+          "label": "SkyBox Labs"
+        },
+        {
+          "code": "Q21463008",
+          "label": "DC Studios"
+        },
+        {
+          "code": "Q21190892",
+          "label": "Nintendo Platform Technology Development"
+        },
+        {
+          "code": "Q21481957",
+          "label": "Mommy's Best Games"
+        },
+        {
+          "code": "Q21708180",
+          "label": "Atelier 801"
+        },
+        {
+          "code": "Q21245163",
+          "label": "Red Dot Games"
+        },
+        {
+          "code": "Q21563289",
+          "label": "Chucklefish"
+        },
+        {
+          "code": "Q123201183",
+          "label": "Among Giants"
+        },
+        {
+          "code": "Q123124336",
+          "label": "Hyper Productions"
+        },
+        {
+          "code": "Q123124491",
+          "label": "Katsu Entertainment"
+        },
+        {
+          "code": "Q123134836",
+          "label": "Gold Skull Studios"
+        },
+        {
+          "code": "Q123134974",
+          "label": "SandBloom Studio"
+        },
+        {
+          "code": "Q123135007",
+          "label": "Estudios Kremlinois"
+        },
+        {
+          "code": "Q123161535",
+          "label": "Skyreach Studio"
+        },
+        {
+          "code": "Q123173416",
+          "label": "Digital Sun"
+        },
+        {
+          "code": "Q123179668",
+          "label": "Kungfu Takeaway"
+        },
+        {
+          "code": "Q123180291",
+          "label": "SpaceMyFriend"
+        },
+        {
+          "code": "Q123180329",
+          "label": "HOF Studios"
+        },
+        {
+          "code": "Q123180384",
+          "label": "Spicy Gyro Games"
+        },
+        {
+          "code": "Q123180489",
+          "label": "Shiny Dolphin Games"
+        },
+        {
+          "code": "Q123196349",
+          "label": "Point Blank Games"
+        },
+        {
+          "code": "Q123199926",
+          "label": "Grimbart Tales"
+        },
+        {
+          "code": "Q123201045",
+          "label": "Second Impact Games"
+        },
+        {
+          "code": "Q123201449",
+          "label": "Bamboo Bandit"
+        },
+        {
+          "code": "Q123204164",
+          "label": "Apple Cider"
+        },
+        {
+          "code": "Q123206482",
+          "label": "LimboLane"
+        },
+        {
+          "code": "Q123206722",
+          "label": "MindSpan"
+        },
+        {
+          "code": "Q123206859",
+          "label": "RazorSoft"
+        },
+        {
+          "code": "Q123221055",
+          "label": "Yume Game Studio"
+        },
+        {
+          "code": "Q123221122",
+          "label": "NC Studio"
+        },
+        {
+          "code": "Q123229848",
+          "label": "xLand"
+        },
+        {
+          "code": "Q123249881",
+          "label": "Time Galleon"
+        },
+        {
+          "code": "Q123250004",
+          "label": "Grip Top Games"
+        },
+        {
+          "code": "Q123281883",
+          "label": "Rootless Studio"
+        },
+        {
+          "code": "Q123282210",
+          "label": "Route 5 Games"
+        },
+        {
+          "code": "Q123293536",
+          "label": "Gameloft Montréal"
+        },
+        {
+          "code": "Q123300231",
+          "label": "TechnoCat Games"
+        },
+        {
+          "code": "Q123300330",
+          "label": "Double Mizzle"
+        },
+        {
+          "code": "Q123312606",
+          "label": "Odyssey Interactive"
+        },
+        {
+          "code": "Q123325053",
+          "label": "DuCats Games Studio"
+        },
+        {
+          "code": "Q123339808",
+          "label": "Ludus future"
+        },
+        {
+          "code": "Q123340162",
+          "label": "Software Scribes S.L.U."
+        },
+        {
+          "code": "Q123340200",
+          "label": "Produktivkeller Studios"
+        },
+        {
+          "code": "Q123351977",
+          "label": "Saona Studios"
+        },
+        {
+          "code": "Q123369921",
+          "label": "Gellyberry Studios"
+        },
+        {
+          "code": "Q123371166",
+          "label": "Browny Application"
+        },
+        {
+          "code": "Q123375941",
+          "label": "TAIWAN TGL CORPORATION"
+        },
+        {
+          "code": "Q123377537",
+          "label": "ABShot"
+        },
+        {
+          "code": "Q123378025",
+          "label": "Cosmo Gatto"
+        },
+        {
+          "code": "Q123387668",
+          "label": "Purple Nebula"
+        },
+        {
+          "code": "Q123394891",
+          "label": "Not For You Games"
+        },
+        {
+          "code": "Q123398613",
+          "label": "Exit 73 Studios"
+        },
+        {
+          "code": "Q123405078",
+          "label": "Sierra Northwest"
+        },
+        {
+          "code": "Q123406838",
+          "label": "Yesbox Studios"
+        },
+        {
+          "code": "Q123409579",
+          "label": "Gravity Lagoon"
+        },
+        {
+          "code": "Q123409631",
+          "label": "Epic Marketing"
+        },
+        {
+          "code": "Q123423685",
+          "label": "Netlex Studio"
+        },
+        {
+          "code": "Q123206563",
+          "label": "Embers"
+        },
+        {
+          "code": "Q123177658",
+          "label": "Monsterland"
+        },
+        {
+          "code": "Q108105065",
+          "label": "Victory Works"
+        },
+        {
+          "code": "Q108105151",
+          "label": "Seven Hills Simulations"
+        },
+        {
+          "code": "Q108141691",
+          "label": "4Co"
+        },
+        {
+          "code": "Q108254137",
+          "label": "Drop Bear Bytes"
+        },
+        {
+          "code": "Q108105161",
+          "label": "G-TraX Simulations"
+        },
+        {
+          "code": "Q108105114",
+          "label": "MatrixTrains"
+        },
+        {
+          "code": "Q108105173",
+          "label": "Romantic Railroads"
+        },
+        {
+          "code": "Q108105186",
+          "label": "Reppo"
+        },
+        {
+          "code": "Q108105019",
+          "label": "Travel by Train"
+        },
+        {
+          "code": "Q108131316",
+          "label": "Bad Dream Games"
+        },
+        {
+          "code": "Q108255837",
+          "label": "Les Joueurs Français"
+        },
+        {
+          "code": "Q108282612",
+          "label": "1047 Games"
+        },
+        {
+          "code": "Q108304729",
+          "label": "Onion Games"
+        },
+        {
+          "code": "Q108325233",
+          "label": "Blayze Games"
+        },
+        {
+          "code": "Q108326280",
+          "label": "Iggymob"
+        },
+        {
+          "code": "Q108169852",
+          "label": "Creative Bytes Studios"
+        },
+        {
+          "code": "Q108169843",
+          "label": "Falling Squirrel"
+        },
+        {
+          "code": "Q108304927",
+          "label": "Twin Otter Studios"
+        },
+        {
+          "code": "Q108326205",
+          "label": "Enlightened Robot Entertainment"
+        },
+        {
+          "code": "Q108418694",
+          "label": "RetroSoft Studios"
+        },
+        {
+          "code": "Q108105049",
+          "label": "Milepost Simulations"
+        },
+        {
+          "code": "Q108105108",
+          "label": "Trains & Drivers"
+        },
+        {
+          "code": "Q108328664",
+          "label": "Reply Game Studios"
+        },
+        {
+          "code": "Q108429026",
+          "label": "Battlecruiser Games"
+        },
+        {
+          "code": "Q108105225",
+          "label": "Creative Rail"
+        },
+        {
+          "code": "Q108159652",
+          "label": "Glitch Pitch"
+        },
+        {
+          "code": "Q108169831",
+          "label": "Binogure Studio"
+        },
+        {
+          "code": "Q108432665",
+          "label": "TiGames"
+        },
+        {
+          "code": "Q108316235",
+          "label": "Raccoon Logic"
+        },
+        {
+          "code": "Q108105214",
+          "label": "All Aboard"
+        },
+        {
+          "code": "Q108393001",
+          "label": "Primula"
+        },
+        {
+          "code": "Q108129450",
+          "label": "Orthrus Studios"
+        },
+        {
+          "code": "Q108142406",
+          "label": "TiliaSoft"
+        },
+        {
+          "code": "Q108316129",
+          "label": "Brave Lamb Studio"
+        },
+        {
+          "code": "Q108431347",
+          "label": "White Paper Games"
+        },
+        {
+          "code": "Q108105077",
+          "label": "Armstrong Powerhouse"
+        },
+        {
+          "code": "Q108105101",
+          "label": "MeshTools"
+        },
+        {
+          "code": "Q108105087",
+          "label": "SimTech Vision"
+        },
+        {
+          "code": "Q108304656",
+          "label": "OverBorder Studio"
+        },
+        {
+          "code": "Q108329069",
+          "label": "Prideful Sloth"
+        },
+        {
+          "code": "Q3566461",
+          "label": "Warthog Games"
+        },
+        {
+          "code": "Q3564274",
+          "label": "Centauri Production"
+        },
+        {
+          "code": "Q3569449",
+          "label": "Wisdom Tree"
+        },
+        {
+          "code": "Q3547650",
+          "label": "Ubisoft Quebec"
+        },
+        {
+          "code": "Q3550703",
+          "label": "United Front Games"
+        },
+        {
+          "code": "Q3566785",
+          "label": "WayForward Technologies"
+        },
+        {
+          "code": "Q3567003",
+          "label": "Webfoot Technologies"
+        },
+        {
+          "code": "Q3561117",
+          "label": "ZeniMax Online Studios"
+        },
+        {
+          "code": "Q107479081",
+          "label": "Sneaky Yak Studio"
+        },
+        {
+          "code": "Q107723587",
+          "label": "Pawley Games"
+        },
+        {
+          "code": "Q107611582",
+          "label": "N3TWORK"
+        },
+        {
+          "code": "Q107660550",
+          "label": "Spokko"
+        },
+        {
+          "code": "Q107690913",
+          "label": "That's No Moon"
+        },
+        {
+          "code": "Q107737246",
+          "label": "Studio Inkyfox UG"
+        },
+        {
+          "code": "Q107631647",
+          "label": "Mighty Yell"
+        },
+        {
+          "code": "Q107650864",
+          "label": "Chasing Rats Games"
+        },
+        {
+          "code": "Q107718847",
+          "label": "Warpzone Studios"
+        },
+        {
+          "code": "Q107630742",
+          "label": "Artisan Studios"
+        },
+        {
+          "code": "Q107458700",
+          "label": "The Game Creators"
+        },
+        {
+          "code": "Q107458579",
+          "label": "AOUProductions"
+        },
+        {
+          "code": "Q107505605",
+          "label": "Karoshi Corporation"
+        },
+        {
+          "code": "Q107557576",
+          "label": "BrainGames"
+        },
+        {
+          "code": "Q107643213",
+          "label": "Phigames"
+        },
+        {
+          "code": "Q107656732",
+          "label": "OperaHouse"
+        },
+        {
+          "code": "Q107465454",
+          "label": "althi"
+        },
+        {
+          "code": "Q107523662",
+          "label": "PlayStation Studios XDev"
+        },
+        {
+          "code": "Q107479280",
+          "label": "Bitrich.info"
+        },
+        {
+          "code": "Q107507707",
+          "label": "Computer Emuzone Games Studio"
+        },
+        {
+          "code": "Q107557526",
+          "label": "Matra Computer Automations"
+        },
+        {
+          "code": "Q107633440",
+          "label": "Somnium Games"
+        },
+        {
+          "code": "Q107679670",
+          "label": "Wanda Software"
+        },
+        {
+          "code": "Q107452237",
+          "label": "Electric Square"
+        },
+        {
+          "code": "Q107686294",
+          "label": "Century Games"
+        },
+        {
+          "code": "Q23303519",
+          "label": "Fervent"
+        },
+        {
+          "code": "Q23303494",
+          "label": "Mirinae"
+        },
+        {
+          "code": "Q23303493",
+          "label": "Blaze Gamers"
+        },
+        {
+          "code": "Q23303507",
+          "label": "Harvester Games"
+        },
+        {
+          "code": "Q23307367",
+          "label": "GNISoft"
+        },
+        {
+          "code": "Q23308016",
+          "label": "Happy Tuesday"
+        },
+        {
+          "code": "Q23309239",
+          "label": "Tachi"
+        },
+        {
+          "code": "Q23303512",
+          "label": "Hunter Studio"
+        },
+        {
+          "code": "Q23307442",
+          "label": "Batholith Entertainment"
+        },
+        {
+          "code": "Q23307399",
+          "label": "Electric Games"
+        },
+        {
+          "code": "Q23309227",
+          "label": "FIVE-BN"
+        },
+        {
+          "code": "Q23309220",
+          "label": "KROBON station"
+        },
+        {
+          "code": "Q23304751",
+          "label": "Cardboard Robot Games"
+        },
+        {
+          "code": "Q23304799",
+          "label": "VaragtP"
+        },
+        {
+          "code": "Q23308039",
+          "label": "FLAT12"
+        },
+        {
+          "code": "Q23307997",
+          "label": "Daniel Wright"
+        },
+        {
+          "code": "Q23303502",
+          "label": "Date Nighto"
+        },
+        {
+          "code": "Q23304796",
+          "label": "CreSpirit"
+        },
+        {
+          "code": "Q23306212",
+          "label": "Ankama Canada"
+        },
+        {
+          "code": "Q23306630",
+          "label": "SnoutUp"
+        },
+        {
+          "code": "Q23308042",
+          "label": "AIVIK LLC"
+        },
+        {
+          "code": "Q23309234",
+          "label": "IMC Games"
+        },
+        {
+          "code": "Q23303497",
+          "label": "Altfuture"
+        },
+        {
+          "code": "Q23303504",
+          "label": "Guru Games"
+        },
+        {
+          "code": "Q23303509",
+          "label": "Incodra"
+        },
+        {
+          "code": "Q23303506",
+          "label": "Screen 7"
+        },
+        {
+          "code": "Q23308036",
+          "label": "Absolutist Ltd."
+        },
+        {
+          "code": "Q23303593",
+          "label": "Big Corporation"
+        },
+        {
+          "code": "Q23303500",
+          "label": "Microblast Games"
+        },
+        {
+          "code": "Q23307504",
+          "label": "Nickervision Studios"
+        },
+        {
+          "code": "Q23307432",
+          "label": "Wayward Prophet"
+        },
+        {
+          "code": "Q23308044",
+          "label": "Pixellore"
+        },
+        {
+          "code": "Q23309241",
+          "label": "Studio Wildcard"
+        },
+        {
+          "code": "Q3640745",
+          "label": "Black Ops Entertainment"
+        },
+        {
+          "code": "Q3592548",
+          "label": "Étranges Libellules"
+        },
+        {
+          "code": "Q3606516",
+          "label": "Agetec"
+        },
+        {
+          "code": "Q3601595",
+          "label": "Ideaworks Game Studio"
+        },
+        {
+          "code": "Q3604604",
+          "label": "Acornsoft"
+        },
+        {
+          "code": "Q3570077",
+          "label": "Wow Entertainment, Inc."
+        },
+        {
+          "code": "Q3604168",
+          "label": "Acclaim Studios Teesside"
+        },
+        {
+          "code": "Q3613462",
+          "label": "Alvion"
+        },
+        {
+          "code": "Q3569706",
+          "label": "Wolfire Games"
+        },
+        {
+          "code": "Q3569530",
+          "label": "Wizarbox"
+        },
+        {
+          "code": "Q3576010",
+          "label": "Zoo Corporation"
+        },
+        {
+          "code": "Q23774718",
+          "label": "Ghost Machine"
+        },
+        {
+          "code": "Q23774390",
+          "label": "Isaac Cohen"
+        },
+        {
+          "code": "Q23774400",
+          "label": "Shaun Williams"
+        },
+        {
+          "code": "Q23763242",
+          "label": "Eerie Bear Games"
+        },
+        {
+          "code": "Q23774375",
+          "label": "Marcus Nichols"
+        },
+        {
+          "code": "Q23775623",
+          "label": "HandMade Game"
+        },
+        {
+          "code": "Q23775613",
+          "label": "Legend Studio"
+        },
+        {
+          "code": "Q23774360",
+          "label": "Ape Law"
+        },
+        {
+          "code": "Q23774372",
+          "label": "Alzan Studios, LLC"
+        },
+        {
+          "code": "Q23774683",
+          "label": "Mechabit Ltd"
+        },
+        {
+          "code": "Q23775627",
+          "label": "Flatbox Studios"
+        },
+        {
+          "code": "Q23775601",
+          "label": "narayana games UG"
+        },
+        {
+          "code": "Q23775615",
+          "label": "Ruce"
+        },
+        {
+          "code": "Q23763230",
+          "label": "Stephen Long"
+        },
+        {
+          "code": "Q23774351",
+          "label": "Indimo Labs LLC"
+        },
+        {
+          "code": "Q23774353",
+          "label": "Immersive VR Education Ltd."
+        },
+        {
+          "code": "Q23774392",
+          "label": "Innerspace VR"
+        },
+        {
+          "code": "Q23774363",
+          "label": "Pompaduo"
+        },
+        {
+          "code": "Q23775611",
+          "label": "Scornz"
+        },
+        {
+          "code": "Q23775632",
+          "label": "realities.io"
+        },
+        {
+          "code": "Q23774356",
+          "label": "Marc Ellis"
+        },
+        {
+          "code": "Q23763206",
+          "label": "Triangular Pixels"
+        },
+        {
+          "code": "Q23774479",
+          "label": "MAG Studios"
+        },
+        {
+          "code": "Q23775625",
+          "label": "GuidiGermano"
+        },
+        {
+          "code": "Q23774371",
+          "label": "Descendent Studios"
+        },
+        {
+          "code": "Q23774385",
+          "label": "Foreignvr"
+        },
+        {
+          "code": "Q23775629",
+          "label": "Buffalo Vision"
+        },
+        {
+          "code": "Q23775617",
+          "label": "Lucky You Studio"
+        },
+        {
+          "code": "Q23763468",
+          "label": "Hourences"
+        },
+        {
+          "code": "Q23775620",
+          "label": "Namazu Studios"
+        },
+        {
+          "code": "Q23774365",
+          "label": "RUST LTD."
+        },
+        {
+          "code": "Q23775604",
+          "label": "Metaware Limited, LLC"
+        },
+        {
+          "code": "Q23775608",
+          "label": "Red River Studio LLC"
+        },
+        {
+          "code": "Q23763181",
+          "label": "VRUnicorns"
+        },
+        {
+          "code": "Q23763238",
+          "label": "Virtualex"
+        },
+        {
+          "code": "Q23774394",
+          "label": "Hammer Labs"
+        },
+        {
+          "code": "Q23774721",
+          "label": "Oasis VR"
+        },
+        {
+          "code": "Q23774728",
+          "label": "Schell Games"
+        },
+        {
+          "code": "Q23775593",
+          "label": "Lucid Sight, Inc."
+        },
+        {
+          "code": "Q23775596",
+          "label": "Taranasus Studio"
+        },
+        {
+          "code": "Q21170271",
+          "label": "Night Light Interactive"
+        },
+        {
+          "code": "Q21036514",
+          "label": "Starbyte"
+        },
+        {
+          "code": "Q21086348",
+          "label": "XGen Studios"
+        },
+        {
+          "code": "Q21170272",
+          "label": "Rogue Rocket Games"
+        },
+        {
+          "code": "Q21178686",
+          "label": "Mektek Studios"
+        },
+        {
+          "code": "Q21189808",
+          "label": "tinyBuild Games"
+        },
+        {
+          "code": "Q21131706",
+          "label": "FortuneFish"
+        },
+        {
+          "code": "Q20975602",
+          "label": "Rayark Inc."
+        },
+        {
+          "code": "Q21043360",
+          "label": "Virtual Programming"
+        },
+        {
+          "code": "Q21189538",
+          "label": "Motive Studio"
+        },
+        {
+          "code": "Q21189695",
+          "label": "Pixel Press"
+        },
+        {
+          "code": "Q21018850",
+          "label": "A.I Co., Ltd."
+        },
+        {
+          "code": "Q21131681",
+          "label": "Deep Silver Dambuster Studios"
+        },
+        {
+          "code": "Q21170267",
+          "label": "CM Games"
+        },
+        {
+          "code": "Q19802998",
+          "label": "IllFonic"
+        },
+        {
+          "code": "Q19864761",
+          "label": "Artifice Studio"
+        },
+        {
+          "code": "Q19902562",
+          "label": "King Art Games"
+        },
+        {
+          "code": "Q20052760",
+          "label": "Behold Studios"
+        },
+        {
+          "code": "Q19773186",
+          "label": "Smoking Gun Interactive"
+        },
+        {
+          "code": "Q19817108",
+          "label": "Brainy Studio LLC"
+        },
+        {
+          "code": "Q19866605",
+          "label": "Critical Gameplay"
+        },
+        {
+          "code": "Q19873165",
+          "label": "Failbetter Games"
+        },
+        {
+          "code": "Q19876460",
+          "label": "Blue Isle Studios"
+        },
+        {
+          "code": "Q19903340",
+          "label": "Infamous Quests"
+        },
+        {
+          "code": "Q20045086",
+          "label": "Scarab Studio"
+        },
+        {
+          "code": "Q19844300",
+          "label": "Unreal Software"
+        },
+        {
+          "code": "Q19953035",
+          "label": "Bits Laboratory"
+        },
+        {
+          "code": "Q20044986",
+          "label": "SILKY'S PLUS"
+        },
+        {
+          "code": "Q20045200",
+          "label": "Sega Interactive"
+        },
+        {
+          "code": "Q19704710",
+          "label": "Ketchapp"
+        },
+        {
+          "code": "Q19903189",
+          "label": "Bulldog Interactive"
+        },
+        {
+          "code": "Q19952795",
+          "label": "Advance Communication"
+        },
+        {
+          "code": "Q19966324",
+          "label": "Loftur Studio"
+        },
+        {
+          "code": "Q122829725",
+          "label": "Ratata Arts"
+        },
+        {
+          "code": "Q122832051",
+          "label": "Echidna Software Development"
+        },
+        {
+          "code": "Q122834495",
+          "label": "DOMO Production"
+        },
+        {
+          "code": "Q122834601",
+          "label": "CosmicNobab"
+        },
+        {
+          "code": "Q122850663",
+          "label": "Weasel Token"
+        },
+        {
+          "code": "Q122865060",
+          "label": "Geometric Interactive"
+        },
+        {
+          "code": "Q122872239",
+          "label": "One Up Plus"
+        },
+        {
+          "code": "Q122872553",
+          "label": "Ichigoichie"
+        },
+        {
+          "code": "Q122884856",
+          "label": "Sweet Bandits Studios"
+        },
+        {
+          "code": "Q122912940",
+          "label": "Postmodern Adventures"
+        },
+        {
+          "code": "Q122920414",
+          "label": "Table 9 Studio"
+        },
+        {
+          "code": "Q122920539",
+          "label": "Tidbits Play"
+        },
+        {
+          "code": "Q122943784",
+          "label": "Digital Kids"
+        },
+        {
+          "code": "Q122945594",
+          "label": "Credici"
+        },
+        {
+          "code": "Q122947014",
+          "label": "Dream Holdings"
+        },
+        {
+          "code": "Q122947076",
+          "label": "TAKAGISM Inc."
+        },
+        {
+          "code": "Q122947845",
+          "label": "KOMODO"
+        },
+        {
+          "code": "Q122948123",
+          "label": "Galaxy Grove"
+        },
+        {
+          "code": "Q122955755",
+          "label": "Team Coreupt LLC"
+        },
+        {
+          "code": "Q122955958",
+          "label": "Siege Camp"
+        },
+        {
+          "code": "Q122963711",
+          "label": "Hakababunko"
+        },
+        {
+          "code": "Q123018094",
+          "label": "Yarrow Games"
+        },
+        {
+          "code": "Q123019724",
+          "label": "1001 Software Development"
+        },
+        {
+          "code": "Q123053971",
+          "label": "mc2games"
+        },
+        {
+          "code": "Q123054017",
+          "label": "Black Salt Games"
+        },
+        {
+          "code": "Q123058824",
+          "label": "Rapid Snail"
+        },
+        {
+          "code": "Q123058945",
+          "label": "Bonus Level Entertainment"
+        },
+        {
+          "code": "Q123059007",
+          "label": "NeoBird"
+        },
+        {
+          "code": "Q123059011",
+          "label": "Wild Monkey"
+        },
+        {
+          "code": "Q123059017",
+          "label": "YiTi Games"
+        },
+        {
+          "code": "Q123059052",
+          "label": "Canari Games"
+        },
+        {
+          "code": "Q123059106",
+          "label": "RapidEyeMovers"
+        },
+        {
+          "code": "Q123109121",
+          "label": "Statera Studio"
+        },
+        {
+          "code": "Q123117750",
+          "label": "CGA Studio Games"
+        },
+        {
+          "code": "Q123117982",
+          "label": "Fossilized Games"
+        },
+        {
+          "code": "Q123118118",
+          "label": "Persona Theory Games"
+        },
+        {
+          "code": "Q123118215",
+          "label": "Not a Sailor Studios"
+        },
+        {
+          "code": "Q123118273",
+          "label": "Poppy Works"
+        },
+        {
+          "code": "Q123118339",
+          "label": "FrozenPixel Studios"
+        },
+        {
+          "code": "Q123123880",
+          "label": "Tanuki Game Studio"
+        },
+        {
+          "code": "Q123124207",
+          "label": "Super Villain Games"
+        },
+        {
+          "code": "Q122921174",
+          "label": "Gangbusters"
+        },
+        {
+          "code": "Q120970822",
+          "label": "Rionix"
+        },
+        {
+          "code": "Q120970837",
+          "label": "Nova Ideas"
+        },
+        {
+          "code": "Q120971159",
+          "label": "Jaibo Games"
+        },
+        {
+          "code": "Q120971176",
+          "label": "Amegami"
+        },
+        {
+          "code": "Q120971524",
+          "label": "Trine Game Studios"
+        },
+        {
+          "code": "Q120979218",
+          "label": "Volens Nolens Games"
+        },
+        {
+          "code": "Q120980027",
+          "label": "Payara Games"
+        },
+        {
+          "code": "Q120981336",
+          "label": "Anvate Games"
+        },
+        {
+          "code": "Q120983484",
+          "label": "Michael Rfdshir"
+        },
+        {
+          "code": "Q121008793",
+          "label": "Cave+Barn Studios"
+        },
+        {
+          "code": "Q121008805",
+          "label": "Pipe Dream Interactive"
+        },
+        {
+          "code": "Q121084128",
+          "label": "Professional Villains"
+        },
+        {
+          "code": "Q121085942",
+          "label": "ZagZag"
+        },
+        {
+          "code": "Q121086530",
+          "label": "C&C Game Studio"
+        },
+        {
+          "code": "Q121092866",
+          "label": "Old Bit Studio"
+        },
+        {
+          "code": "Q121097589",
+          "label": "VG Games"
+        },
+        {
+          "code": "Q121097684",
+          "label": "Malatsa Games"
+        },
+        {
+          "code": "Q121097692",
+          "label": "MoyBatya"
+        },
+        {
+          "code": "Q121129844",
+          "label": "Never Knows Best"
+        },
+        {
+          "code": "Q121139344",
+          "label": "Tiny Warrior Games"
+        },
+        {
+          "code": "Q121168407",
+          "label": "Creepy Brothers"
+        },
+        {
+          "code": "Q121170179",
+          "label": "Flashback Games"
+        },
+        {
+          "code": "Q121202343",
+          "label": "Robotizar Games"
+        },
+        {
+          "code": "Q121302197",
+          "label": "Cranberry Software"
+        },
+        {
+          "code": "Q121306865",
+          "label": "Timelock Studio"
+        },
+        {
+          "code": "Q121307049",
+          "label": "Croteam VR"
+        },
+        {
+          "code": "Q121307058",
+          "label": "Croteam Publishing"
+        },
+        {
+          "code": "Q121307115",
+          "label": "EroticGamesClub"
+        },
+        {
+          "code": "Q121307146",
+          "label": "Octo Games"
+        },
+        {
+          "code": "Q121364338",
+          "label": "Videlectrix"
+        },
+        {
+          "code": "Q121436214",
+          "label": "Canvas Software"
+        },
+        {
+          "code": "Q121546400",
+          "label": "Clean Master Games"
+        },
+        {
+          "code": "Q121555259",
+          "label": "Umoni"
+        },
+        {
+          "code": "Q121590517",
+          "label": "Rebel Wolves"
+        },
+        {
+          "code": "Q121637922",
+          "label": "Starlance Studios"
+        },
+        {
+          "code": "Q121637982",
+          "label": "Ironward"
+        },
+        {
+          "code": "Q121749189",
+          "label": "Mr Chip Software"
+        },
+        {
+          "code": "Q121781862",
+          "label": "Langang Entertainment"
+        },
+        {
+          "code": "Q121793342",
+          "label": "Lunagames"
+        },
+        {
+          "code": "Q121821090",
+          "label": "Firebug Games"
+        },
+        {
+          "code": "Q121842892",
+          "label": "Studio Mono"
+        },
+        {
+          "code": "Q121879351",
+          "label": "Sinister Games"
+        },
+        {
+          "code": "Q121890534",
+          "label": "Féérik Games"
+        },
+        {
+          "code": "Q122070252",
+          "label": "Deep Type Games"
+        },
+        {
+          "code": "Q122130432",
+          "label": "Double Dagger Studio"
+        },
+        {
+          "code": "Q122197045",
+          "label": "Combat Waffle Studios"
+        },
+        {
+          "code": "Q122197106",
+          "label": "Beyond Frames Entertainment"
+        },
+        {
+          "code": "Q122241209",
+          "label": "Toadman Interactive"
+        },
+        {
+          "code": "Q122277804",
+          "label": "Sabotage Studio"
+        },
+        {
+          "code": "Q122278373",
+          "label": "Digitality Games"
+        },
+        {
+          "code": "Q122326698",
+          "label": "Incarnate Games"
+        },
+        {
+          "code": "Q122335277",
+          "label": "Snowcastle Games"
+        },
+        {
+          "code": "Q121300731",
+          "label": "Korkeken Interactive Studio"
+        },
+        {
+          "code": "Q121694127",
+          "label": "Fragaria"
+        },
+        {
+          "code": "Q109589494",
+          "label": "GrandMA Studios"
+        },
+        {
+          "code": "Q109683325",
+          "label": "Infinigon Games"
+        },
+        {
+          "code": "Q109592799",
+          "label": "Fabraz"
+        },
+        {
+          "code": "Q109610462",
+          "label": "PlaySide"
+        },
+        {
+          "code": "Q109650434",
+          "label": "Humble Grove"
+        },
+        {
+          "code": "Q109690048",
+          "label": "Draknek & Friends"
+        },
+        {
+          "code": "Q109595477",
+          "label": "Metacore Games"
+        },
+        {
+          "code": "Q109669088",
+          "label": "The Wandering Band"
+        },
+        {
+          "code": "Q109600605",
+          "label": "Azarashi Software"
+        },
+        {
+          "code": "Q109619982",
+          "label": "Chaos Group Games"
+        },
+        {
+          "code": "Q109682965",
+          "label": "Art Games Studio"
+        },
+        {
+          "code": "Q109626376",
+          "label": "AZAMATIKA"
+        },
+        {
+          "code": "Q109658900",
+          "label": "3DClouds"
+        },
+        {
+          "code": "Q109659404",
+          "label": "Prime Bit Games"
+        },
+        {
+          "code": "Q109668958",
+          "label": "Fantastico Studio"
+        },
+        {
+          "code": "Q109669285",
+          "label": "Stray Kite Studios"
+        },
+        {
+          "code": "Q109656786",
+          "label": "Team Amorous"
+        },
+        {
+          "code": "Q109658995",
+          "label": "Kodo Linija"
+        },
+        {
+          "code": "Q109662465",
+          "label": "The Moon Pirates"
+        },
+        {
+          "code": "Q109622375",
+          "label": "Crystal Game Works"
+        },
+        {
+          "code": "Q109659415",
+          "label": "Finite Reflection Studios"
+        },
+        {
+          "code": "Q109669676",
+          "label": "Radical Phi"
+        },
+        {
+          "code": "Q3685133",
+          "label": "Compile Heart"
+        },
+        {
+          "code": "Q3729020",
+          "label": "Magical Company"
+        },
+        {
+          "code": "Q3739871",
+          "label": "Image Space Incorporated"
+        },
+        {
+          "code": "Q3745969",
+          "label": "Firemonkeys Studios"
+        },
+        {
+          "code": "Q3641158",
+          "label": "Blue Fang Games"
+        },
+        {
+          "code": "Q3643494",
+          "label": "AGD Interactive"
+        },
+        {
+          "code": "Q3658005",
+          "label": "Capstone Software"
+        },
+        {
+          "code": "Q3705312",
+          "label": "Demiurge Studios"
+        },
+        {
+          "code": "Q3739267",
+          "label": "Towa Chiki"
+        },
+        {
+          "code": "Q109444944",
+          "label": "Dapper Penguin Studios"
+        },
+        {
+          "code": "Q109533609",
+          "label": "neko.works"
+        },
+        {
+          "code": "Q109422763",
+          "label": "Skeleton Crew Studios"
+        },
+        {
+          "code": "Q109517024",
+          "label": "Theta Division"
+        },
+        {
+          "code": "Q109569807",
+          "label": "FrostPeek Studio"
+        },
+        {
+          "code": "Q109587987",
+          "label": "Goloso Games"
+        },
+        {
+          "code": "Q109587952",
+          "label": "Star Drifters"
+        },
+        {
+          "code": "Q109514289",
+          "label": "Limestone Games"
+        },
+        {
+          "code": "Q109468711",
+          "label": "Polygon Art"
+        },
+        {
+          "code": "Q109556005",
+          "label": "Chaosmonger Studio"
+        },
+        {
+          "code": "Q109569089",
+          "label": "Djinnworks"
+        },
+        {
+          "code": "Q109588130",
+          "label": "Ant Workshop"
+        },
+        {
+          "code": "Q109453384",
+          "label": "Actoon Studio"
+        },
+        {
+          "code": "Q109473725",
+          "label": "Vaka Game Magazine"
+        },
+        {
+          "code": "Q109501387",
+          "label": "BonusXP"
+        },
+        {
+          "code": "Q109581933",
+          "label": "O.T.K Games"
+        },
+        {
+          "code": "Q109588071",
+          "label": "LEAP Game Studios"
+        },
+        {
+          "code": "Q109531223",
+          "label": "NetEase Games Montréal"
+        },
+        {
+          "code": "Q109533350",
+          "label": "Gosatsu Visual Novels"
+        },
+        {
+          "code": "Q109556818",
+          "label": "Red Phantom Games"
+        },
+        {
+          "code": "Q109531508",
+          "label": "Koei Tecmo Europe"
+        },
+        {
+          "code": "Q109532839",
+          "label": "Sokaikan"
+        },
+        {
+          "code": "Q109582894",
+          "label": "SakuraGame"
+        },
+        {
+          "code": "Q109422953",
+          "label": "Flaming Fowl Studios"
+        },
+        {
+          "code": "Q109435482",
+          "label": "Lightwood Games"
+        },
+        {
+          "code": "Q109449065",
+          "label": "Euphoria Games"
+        },
+        {
+          "code": "Q109451614",
+          "label": "Trainwreck Studios"
+        },
+        {
+          "code": "Q109469631",
+          "label": "AdamVision Studios"
+        },
+        {
+          "code": "Q109469683",
+          "label": "SneakyBox"
+        },
+        {
+          "code": "Q109530835",
+          "label": "24 Entertainment"
+        },
+        {
+          "code": "Q109533025",
+          "label": "2ndBoss"
+        },
+        {
+          "code": "Q109564605",
+          "label": "Urnique Studio"
+        },
+        {
+          "code": "Q4260602",
+          "label": "Eutechnyx"
+        },
+        {
+          "code": "Q4156567",
+          "label": "Retrospec"
+        },
+        {
+          "code": "Q4162513",
+          "label": "Kiloo"
+        },
+        {
+          "code": "Q4155560",
+          "label": "Two Guys from Andromeda"
+        },
+        {
+          "code": "Q4248906",
+          "label": "Ambrella"
+        },
+        {
+          "code": "Q4631169",
+          "label": "21st Street Games"
+        },
+        {
+          "code": "Q4315842",
+          "label": "Nevosoft"
+        },
+        {
+          "code": "Q4355671",
+          "label": "Parallax Software"
+        },
+        {
+          "code": "Q4566909",
+          "label": "Amuze"
+        },
+        {
+          "code": "Q4326636",
+          "label": "Noviy Disk"
+        },
+        {
+          "code": "Q4351336",
+          "label": "Pipeworks Software"
+        },
+        {
+          "code": "Q4206181",
+          "label": "K-D Lab"
+        },
+        {
+          "code": "Q4035517",
+          "label": "Burut CT"
+        },
+        {
+          "code": "Q4037154",
+          "label": "Dejobaan Games"
+        },
+        {
+          "code": "Q4036654",
+          "label": "Creat Studios"
+        },
+        {
+          "code": "Q4035139",
+          "label": "Bits Studios"
+        },
+        {
+          "code": "Q4035237",
+          "label": "Krafton"
+        },
+        {
+          "code": "Q4037549",
+          "label": "DotEmu"
+        },
+        {
+          "code": "Q4036368",
+          "label": "Codo Technologies"
+        },
+        {
+          "code": "Q4037132",
+          "label": "Deep Shadows"
+        },
+        {
+          "code": "Q3410210",
+          "label": "Psygnosis"
+        },
+        {
+          "code": "Q3414457",
+          "label": "Quicksilver Software"
+        },
+        {
+          "code": "Q3429407",
+          "label": "Rhino Studios Inc."
+        },
+        {
+          "code": "Q3436367",
+          "label": "Innerloop Studios"
+        },
+        {
+          "code": "Q3402678",
+          "label": "Presto Studios"
+        },
+        {
+          "code": "Q3422645",
+          "label": "RedWolf Design"
+        },
+        {
+          "code": "Q3412383",
+          "label": "Q Entertainment"
+        },
+        {
+          "code": "Q3407134",
+          "label": "Project Sora"
+        },
+        {
+          "code": "Q3415889",
+          "label": "Rabbit Ears Productions"
+        },
+        {
+          "code": "Q3421656",
+          "label": "Realtime Worlds"
+        },
+        {
+          "code": "Q3412336",
+          "label": "Quantum Quality Productions"
+        },
+        {
+          "code": "Q64370451",
+          "label": "Soft Pro International"
+        },
+        {
+          "code": "Q64441576",
+          "label": "Buddiez, Inc."
+        },
+        {
+          "code": "Q64448758",
+          "label": "Funcom Dublin Ltd."
+        },
+        {
+          "code": "Q64507510",
+          "label": "Platinum Egg Inc."
+        },
+        {
+          "code": "Q64507718",
+          "label": "EA Studios Japan"
+        },
+        {
+          "code": "Q64391452",
+          "label": "BrainGrey"
+        },
+        {
+          "code": "Q64624928",
+          "label": "Digitalware, Inc."
+        },
+        {
+          "code": "Q64447391",
+          "label": "Time Warner Interactive Ltd."
+        },
+        {
+          "code": "Q64606675",
+          "label": "Magnin & Associates"
+        },
+        {
+          "code": "Q64625005",
+          "label": "Banpresoft Co., Ltd."
+        },
+        {
+          "code": "Q64624820",
+          "label": "ParityBit"
+        },
+        {
+          "code": "Q64358517",
+          "label": "Konami Software Shanghai, Inc."
+        },
+        {
+          "code": "Q64443578",
+          "label": "Tamtex"
+        },
+        {
+          "code": "Q64569426",
+          "label": "CODE:Phantasm"
+        },
+        {
+          "code": "Q64569485",
+          "label": "Covenant Studios"
+        },
+        {
+          "code": "Q64606841",
+          "label": "Konami Computer Entertainment Studios Yokohama"
+        },
+        {
+          "code": "Q64625002",
+          "label": "Goshow Inc."
+        },
+        {
+          "code": "Q64371147",
+          "label": "Special FX Software Ltd."
+        },
+        {
+          "code": "Q64392212",
+          "label": "HI Corporation"
+        },
+        {
+          "code": "Q64508655",
+          "label": "Dice Co., Ltd."
+        },
+        {
+          "code": "Q64624944",
+          "label": "Cerny Games, Inc."
+        },
+        {
+          "code": "Q64507047",
+          "label": "Ehrgeiz"
+        },
+        {
+          "code": "Q64584595",
+          "label": "Nevosoft"
+        },
+        {
+          "code": "Q64358413",
+          "label": "InterActive Vision A/S"
+        },
+        {
+          "code": "Q64364510",
+          "label": "Equilibrium, Inc."
+        },
+        {
+          "code": "Q64364571",
+          "label": "Ignition Banbury"
+        },
+        {
+          "code": "Q64391225",
+          "label": "Humming Bird Soft"
+        },
+        {
+          "code": "Q64620877",
+          "label": "Team Fabulous"
+        },
+        {
+          "code": "Q64625027",
+          "label": "ODenis Studio"
+        },
+        {
+          "code": "Q64348970",
+          "label": "Creative Edge Software"
+        },
+        {
+          "code": "Q64426310",
+          "label": "HyperGryph"
+        },
+        {
+          "code": "Q64442666",
+          "label": "Sirtech Canada Ltd."
+        },
+        {
+          "code": "Q64447552",
+          "label": "Konami Computer Entertainment Sapporo Co., Ltd"
+        },
+        {
+          "code": "Q64447665",
+          "label": "Jamsworks Co., Ltd."
+        },
+        {
+          "code": "Q64447764",
+          "label": "Kawada Co., Ltd."
+        },
+        {
+          "code": "Q64348983",
+          "label": "Full Fat Productions Ltd."
+        },
+        {
+          "code": "Q64364545",
+          "label": "Taxan USA Corp."
+        },
+        {
+          "code": "Q64392067",
+          "label": "Six by Nine Ltd"
+        },
+        {
+          "code": "Q64447230",
+          "label": "ZAP Corporation"
+        },
+        {
+          "code": "Q24081023",
+          "label": "Daniel Mullins Games"
+        },
+        {
+          "code": "Q24081281",
+          "label": "△○□× (Miwashiba)"
+        },
+        {
+          "code": "Q24229399",
+          "label": "The Astronauts"
+        },
+        {
+          "code": "Q24255578",
+          "label": "Носков Сергей"
+        },
+        {
+          "code": "Q23776812",
+          "label": "Skobbejak Games"
+        },
+        {
+          "code": "Q23795654",
+          "label": "Justin Moravetz"
+        },
+        {
+          "code": "Q24079919",
+          "label": "RocketWerkz"
+        },
+        {
+          "code": "Q24081286",
+          "label": "Schulenburg Software"
+        },
+        {
+          "code": "Q23775644",
+          "label": "Ionized Games"
+        },
+        {
+          "code": "Q23795644",
+          "label": "Radial Games"
+        },
+        {
+          "code": "Q24079987",
+          "label": "Endless Loop Studios"
+        },
+        {
+          "code": "Q24228237",
+          "label": "U-Play Online"
+        },
+        {
+          "code": "Q23795630",
+          "label": "Steel Wool Studios"
+        },
+        {
+          "code": "Q24079925",
+          "label": "BigScreen, Inc."
+        },
+        {
+          "code": "Q24079889",
+          "label": "TreeFortress Games"
+        },
+        {
+          "code": "Q24080184",
+          "label": "Brace Yourself Games"
+        },
+        {
+          "code": "Q24080224",
+          "label": "Pixel Ferrets"
+        },
+        {
+          "code": "Q24081287",
+          "label": "Muse Games"
+        },
+        {
+          "code": "Q23775671",
+          "label": "Nefarious Dimensions Inc."
+        },
+        {
+          "code": "Q23795626",
+          "label": "Fishing Planet LLC"
+        },
+        {
+          "code": "Q23927578",
+          "label": "Monomi Park"
+        },
+        {
+          "code": "Q24079884",
+          "label": "Acceleroto, Inc."
+        },
+        {
+          "code": "Q24080817",
+          "label": "Killmonday Games HB"
+        },
+        {
+          "code": "Q24083597",
+          "label": "Glitchers"
+        },
+        {
+          "code": "Q23775674",
+          "label": "Tyler Hurd"
+        },
+        {
+          "code": "Q23795636",
+          "label": "Northway Games"
+        },
+        {
+          "code": "Q23775758",
+          "label": "Paul Eckhardt"
+        },
+        {
+          "code": "Q24079856",
+          "label": "TURBOGUN"
+        },
+        {
+          "code": "Q24079944",
+          "label": "Zenz VR"
+        },
+        {
+          "code": "Q24080237",
+          "label": "Spiderling Studios"
+        },
+        {
+          "code": "Q24079935",
+          "label": "Barry McCabe"
+        },
+        {
+          "code": "Q24079979",
+          "label": "Sad Panda Studios"
+        },
+        {
+          "code": "Q24081031",
+          "label": "iNK Stories"
+        },
+        {
+          "code": "Q23775648",
+          "label": "Lightning Rock"
+        },
+        {
+          "code": "Q24079939",
+          "label": "Ramjet Anvil"
+        },
+        {
+          "code": "Q24081011",
+          "label": "Irresponsible Games"
+        },
+        {
+          "code": "Q24254673",
+          "label": "David Mccue"
+        },
+        {
+          "code": "Q23775654",
+          "label": "Wolf & Wood"
+        },
+        {
+          "code": "Q120970782",
+          "label": "Platinum Games"
+        },
+        {
+          "code": "Q119726894",
+          "label": "FAS3"
+        },
+        {
+          "code": "Q119458865",
+          "label": "Hovgaard Games"
+        },
+        {
+          "code": "Q119459628",
+          "label": "Sky Bear Games"
+        },
+        {
+          "code": "Q119487854",
+          "label": "Intrepid Studios"
+        },
+        {
+          "code": "Q119488063",
+          "label": "Envoidant Studios"
+        },
+        {
+          "code": "Q119691286",
+          "label": "Salix Games"
+        },
+        {
+          "code": "Q119742902",
+          "label": "Mopeful Games"
+        },
+        {
+          "code": "Q119791871",
+          "label": "Hungry Bear Games"
+        },
+        {
+          "code": "Q119841811",
+          "label": "CarX Technologies"
+        },
+        {
+          "code": "Q119846247",
+          "label": "Dongleware"
+        },
+        {
+          "code": "Q119847362",
+          "label": "Surprise! Productions"
+        },
+        {
+          "code": "Q119850523",
+          "label": "Boris Games"
+        },
+        {
+          "code": "Q119850957",
+          "label": "Pirate Games"
+        },
+        {
+          "code": "Q119851024",
+          "label": "JoWooD Vienna"
+        },
+        {
+          "code": "Q119879431",
+          "label": "Abylight"
+        },
+        {
+          "code": "Q120174076",
+          "label": "Team SNEED"
+        },
+        {
+          "code": "Q120178743",
+          "label": "Lucid Dreams Studio"
+        },
+        {
+          "code": "Q120197400",
+          "label": "Sumzap"
+        },
+        {
+          "code": "Q120197432",
+          "label": "Byking"
+        },
+        {
+          "code": "Q120378814",
+          "label": "BloodLine"
+        },
+        {
+          "code": "Q120670094",
+          "label": "Campfire Studio"
+        },
+        {
+          "code": "Q120687102",
+          "label": "Blindshot Studio"
+        },
+        {
+          "code": "Q120691761",
+          "label": "Halfie Studios"
+        },
+        {
+          "code": "Q120716304",
+          "label": "Anate Studio"
+        },
+        {
+          "code": "Q120717810",
+          "label": "HitherYon Games"
+        },
+        {
+          "code": "Q120732088",
+          "label": "Chicken Launcher"
+        },
+        {
+          "code": "Q120801358",
+          "label": "Ohsat Games"
+        },
+        {
+          "code": "Q120801401",
+          "label": "Yustas Games Studio"
+        },
+        {
+          "code": "Q120802271",
+          "label": "Good Gate Media"
+        },
+        {
+          "code": "Q120802591",
+          "label": "DreamStorm Studios"
+        },
+        {
+          "code": "Q120825056",
+          "label": "Bandai Namco Entertainment Romania"
+        },
+        {
+          "code": "Q120825179",
+          "label": "9Ratones"
+        },
+        {
+          "code": "Q120825317",
+          "label": "RainForest Games"
+        },
+        {
+          "code": "Q120826203",
+          "label": "Melonhead Games"
+        },
+        {
+          "code": "Q120826624",
+          "label": "Iced Lizard Games"
+        },
+        {
+          "code": "Q120913853",
+          "label": "Galdra Studios"
+        },
+        {
+          "code": "Q120913963",
+          "label": "First Step Cinematics"
+        },
+        {
+          "code": "Q120914647",
+          "label": "Ishtar Games"
+        },
+        {
+          "code": "Q120920458",
+          "label": "KR Games"
+        },
+        {
+          "code": "Q120926378",
+          "label": "Strudio Company"
+        },
+        {
+          "code": "Q120965482",
+          "label": "4 I Lab"
+        },
+        {
+          "code": "Q120969420",
+          "label": "FlexileStudio"
+        },
+        {
+          "code": "Q120970386",
+          "label": "Alawar Stargaze"
+        },
+        {
+          "code": "Q120970567",
+          "label": "Adept Studios GD"
+        },
+        {
+          "code": "Q120970586",
+          "label": "GameMixer"
+        },
+        {
+          "code": "Q119792038",
+          "label": "KeokeN Interactive"
+        },
+        {
+          "code": "Q120443326",
+          "label": "Us:track"
+        },
+        {
+          "code": "Q120582156",
+          "label": "Mediocre"
+        },
+        {
+          "code": "Q110068296",
+          "label": "Adria Games"
+        },
+        {
+          "code": "Q110068116",
+          "label": "Lockwood Publishing"
+        },
+        {
+          "code": "Q110069874",
+          "label": "Robot Teddy"
+        },
+        {
+          "code": "Q110089858",
+          "label": "Inflexion Games"
+        },
+        {
+          "code": "Q110096226",
+          "label": "Outerloop Games"
+        },
+        {
+          "code": "Q110068735",
+          "label": "Wide Right Interactive"
+        },
+        {
+          "code": "Q110087034",
+          "label": "Wishfully"
+        },
+        {
+          "code": "Q110097166",
+          "label": "Dramatic Labs"
+        },
+        {
+          "code": "Q110082665",
+          "label": "Vine"
+        },
+        {
+          "code": "Q110099040",
+          "label": "Bokeh Game Studio"
+        },
+        {
+          "code": "Q110159059",
+          "label": "Aeternum Game Studios"
+        },
+        {
+          "code": "Q110165653",
+          "label": "Stonewheat & Sons"
+        },
+        {
+          "code": "Q110189437",
+          "label": "Nellyvision"
+        },
+        {
+          "code": "Q110193156",
+          "label": "8-Bit Legit"
+        },
+        {
+          "code": "Q110193913",
+          "label": "HugePixel"
+        },
+        {
+          "code": "Q110114536",
+          "label": "Midnight Society"
+        },
+        {
+          "code": "Q110159554",
+          "label": "Xitilon"
+        },
+        {
+          "code": "Q110189455",
+          "label": "Lyrelark"
+        },
+        {
+          "code": "Q110193172",
+          "label": "Gradual Games"
+        },
+        {
+          "code": "Q110189518",
+          "label": "Hammer & Ravens"
+        },
+        {
+          "code": "Q110110658",
+          "label": "White Keyframe"
+        },
+        {
+          "code": "Q110126719",
+          "label": "Nupixo Games"
+        },
+        {
+          "code": "Q110137433",
+          "label": "No Matter Studios"
+        },
+        {
+          "code": "Q110159905",
+          "label": "JingCai Studio"
+        },
+        {
+          "code": "Q110193196",
+          "label": "The 6502 Collective"
+        },
+        {
+          "code": "Q110193479",
+          "label": "Wondernaut Studio"
+        },
+        {
+          "code": "Q110165712",
+          "label": "Big Heart Production"
+        },
+        {
+          "code": "Q110110645",
+          "label": "Sumo Nottingham"
+        },
+        {
+          "code": "Q110159637",
+          "label": "Grin Robot"
+        },
+        {
+          "code": "Q65464548",
+          "label": "Minakuchi Engineering Co., Ltd."
+        },
+        {
+          "code": "Q65464973",
+          "label": "MuuMuu"
+        },
+        {
+          "code": "Q65511045",
+          "label": "Abstraction Games"
+        },
+        {
+          "code": "Q65600691",
+          "label": "MadMan Theory Games"
+        },
+        {
+          "code": "Q65133729",
+          "label": "Sperasoft"
+        },
+        {
+          "code": "Q65643394",
+          "label": "xeen"
+        },
+        {
+          "code": "Q65195204",
+          "label": "North Kingdom"
+        },
+        {
+          "code": "Q65213764",
+          "label": "Project Aces"
+        },
+        {
+          "code": "Q65113867",
+          "label": "Milky Tea"
+        },
+        {
+          "code": "Q65117837",
+          "label": "Typhoon Studios"
+        },
+        {
+          "code": "Q65464998",
+          "label": "C.P. Brain"
+        },
+        {
+          "code": "Q65645591",
+          "label": "Bullets Co., Ltd."
+        },
+        {
+          "code": "Q65645607",
+          "label": "MCF Co., Ltd."
+        },
+        {
+          "code": "Q65770277",
+          "label": "Creative Reality"
+        },
+        {
+          "code": "Q65144337",
+          "label": "ThankCreate Studio"
+        },
+        {
+          "code": "Q65238059",
+          "label": "Oink Games"
+        },
+        {
+          "code": "Q65643406",
+          "label": "Japan Vistec"
+        },
+        {
+          "code": "Q65643873",
+          "label": "El Dia"
+        },
+        {
+          "code": "Q65124447",
+          "label": "PUBG Studios"
+        },
+        {
+          "code": "Q65157836",
+          "label": "Aquiris Game Studio"
+        },
+        {
+          "code": "Q65464929",
+          "label": "Aplus Co., Ltd."
+        },
+        {
+          "code": "Q65619023",
+          "label": "Superstar Catalyst Project"
+        },
+        {
+          "code": "Q65643467",
+          "label": "Beyond Interactive"
+        },
+        {
+          "code": "Q65464983",
+          "label": "Astec 21"
+        },
+        {
+          "code": "Q65503521",
+          "label": "Simply Silly Software"
+        },
+        {
+          "code": "Q65643523",
+          "label": "ocelot"
+        },
+        {
+          "code": "Q65643787",
+          "label": "Runforest, Inc."
+        },
+        {
+          "code": "Q65642876",
+          "label": "ORG Corporation"
+        },
+        {
+          "code": "Q65552978",
+          "label": "Putilin industries"
+        },
+        {
+          "code": "Q65643598",
+          "label": "Unico Inc."
+        },
+        {
+          "code": "Q65643676",
+          "label": "Mediamuse"
+        },
+        {
+          "code": "Q65643804",
+          "label": "5pb. Division #2"
+        },
+        {
+          "code": "Q110738696",
+          "label": "MuHa Games"
+        },
+        {
+          "code": "Q110748948",
+          "label": "Acram Digital"
+        },
+        {
+          "code": "Q110738393",
+          "label": "PowerSlash Studios"
+        },
+        {
+          "code": "Q110740712",
+          "label": "Sever Studio"
+        },
+        {
+          "code": "Q110712359",
+          "label": "40 Giants Entertainment"
+        },
+        {
+          "code": "Q110712323",
+          "label": "Rocket Vulture"
+        },
+        {
+          "code": "Q110738319",
+          "label": "Hydra Games"
+        },
+        {
+          "code": "Q110800962",
+          "label": "Funky Can Creative"
+        },
+        {
+          "code": "Q110812085",
+          "label": "BigBox VR"
+        },
+        {
+          "code": "Q110812308",
+          "label": "Sprakelsoft"
+        },
+        {
+          "code": "Q110738486",
+          "label": "Samustai"
+        },
+        {
+          "code": "Q110746115",
+          "label": "Digital Game Group"
+        },
+        {
+          "code": "Q110775441",
+          "label": "Mystery Egg Games"
+        },
+        {
+          "code": "Q110775975",
+          "label": "iMel"
+        },
+        {
+          "code": "Q110712441",
+          "label": "DP Games"
+        },
+        {
+          "code": "Q110712641",
+          "label": "Gemdrops"
+        },
+        {
+          "code": "Q110713939",
+          "label": "Quiet River"
+        },
+        {
+          "code": "Q110746130",
+          "label": "Red Ego Games"
+        },
+        {
+          "code": "Q110813859",
+          "label": "Clouded Leopard Entertainment"
+        },
+        {
+          "code": "Q110792929",
+          "label": "Gardens"
+        },
+        {
+          "code": "Q110712354",
+          "label": "1C Online Games"
+        },
+        {
+          "code": "Q110712723",
+          "label": "Nuke Nine"
+        },
+        {
+          "code": "Q110712668",
+          "label": "Volframe"
+        },
+        {
+          "code": "Q110713149",
+          "label": "Ackk Studios"
+        },
+        {
+          "code": "Q110726236",
+          "label": "Poncle"
+        },
+        {
+          "code": "Q110775356",
+          "label": "7 Raven Studios"
+        },
+        {
+          "code": "Q110738645",
+          "label": "RockGame"
+        },
+        {
+          "code": "Q110749387",
+          "label": "Pancake Games"
+        },
+        {
+          "code": "Q110793038",
+          "label": "Goblinz"
+        },
+        {
+          "code": "Q110812297",
+          "label": "Pixel Noire Games"
+        },
+        {
+          "code": "Q118111528",
+          "label": "HARAMI Studio"
+        },
+        {
+          "code": "Q118111726",
+          "label": "Bytten Studio"
+        },
+        {
+          "code": "Q118111908",
+          "label": "Gamella Studios"
+        },
+        {
+          "code": "Q118134690",
+          "label": "Strategiae"
+        },
+        {
+          "code": "Q118142409",
+          "label": "ColePowered Games"
+        },
+        {
+          "code": "Q118173596",
+          "label": "Quantum Lion Labs"
+        },
+        {
+          "code": "Q118176938",
+          "label": "The Whiz Kidz"
+        },
+        {
+          "code": "Q118215113",
+          "label": "Pin-Ball Games Ltd."
+        },
+        {
+          "code": "Q118233844",
+          "label": "Toppluva"
+        },
+        {
+          "code": "Q118252050",
+          "label": "Euphoric Brothers"
+        },
+        {
+          "code": "Q118302648",
+          "label": "Maximum Effect"
+        },
+        {
+          "code": "Q118369962",
+          "label": "Free Range Games"
+        },
+        {
+          "code": "Q118474214",
+          "label": "HexWorks"
+        },
+        {
+          "code": "Q118543998",
+          "label": "Tha Ltd."
+        },
+        {
+          "code": "Q118558676",
+          "label": "The Bergson's Games Studios"
+        },
+        {
+          "code": "Q118558729",
+          "label": "Heart Shaped Games"
+        },
+        {
+          "code": "Q118581370",
+          "label": "Isto Inc."
+        },
+        {
+          "code": "Q118581427",
+          "label": "Elf Games"
+        },
+        {
+          "code": "Q118590837",
+          "label": "Headware Games"
+        },
+        {
+          "code": "Q118592142",
+          "label": "Team JBMod"
+        },
+        {
+          "code": "Q118616705",
+          "label": "AstralSeal"
+        },
+        {
+          "code": "Q118607467",
+          "label": "FreeAnimals_Software"
+        },
+        {
+          "code": "Q118766708",
+          "label": "Eternal Alice Studio"
+        },
+        {
+          "code": "Q118780291",
+          "label": "Bikkuri Software"
+        },
+        {
+          "code": "Q118670609",
+          "label": "Cyberia Nova"
+        },
+        {
+          "code": "Q118813622",
+          "label": "Steelkrill Studio"
+        },
+        {
+          "code": "Q118868637",
+          "label": "Tayanna Studios"
+        },
+        {
+          "code": "Q118868719",
+          "label": "Game Swing"
+        },
+        {
+          "code": "Q118948250",
+          "label": "Tinysoft"
+        },
+        {
+          "code": "Q119150539",
+          "label": "Fein Games"
+        },
+        {
+          "code": "Q119395746",
+          "label": "Ember Trail"
+        },
+        {
+          "code": "Q119397045",
+          "label": "Pedestrian Entertainment"
+        },
+        {
+          "code": "Q119397748",
+          "label": "Microbird"
+        },
+        {
+          "code": "Q119409360",
+          "label": "Pentapeak Studios"
+        },
+        {
+          "code": "Q119409558",
+          "label": "Ashborne Games"
+        },
+        {
+          "code": "Q119440863",
+          "label": "Upstream Arcade"
+        },
+        {
+          "code": "Q119442260",
+          "label": "Alderon Games"
+        },
+        {
+          "code": "Q119442550",
+          "label": "Npixel"
+        },
+        {
+          "code": "Q119457065",
+          "label": "Moving Pieces Interactive"
+        },
+        {
+          "code": "Q118145852",
+          "label": "King of the Jungle"
+        },
+        {
+          "code": "Q3875762",
+          "label": "ngmoco"
+        },
+        {
+          "code": "Q3877250",
+          "label": "Nintendo Software Design & Development"
+        },
+        {
+          "code": "Q3961337",
+          "label": "Simulmondo"
+        },
+        {
+          "code": "Q3854011",
+          "label": "Stellar Stone"
+        },
+        {
+          "code": "Q3918074",
+          "label": "W!Games"
+        },
+        {
+          "code": "Q3982798",
+          "label": "Telecomsoft"
+        },
+        {
+          "code": "Q3877247",
+          "label": "Nintendo System Development"
+        },
+        {
+          "code": "Q3997974",
+          "label": "Trauma Studios"
+        },
+        {
+          "code": "Q3817132",
+          "label": "Krome Studios"
+        },
+        {
+          "code": "Q3960699",
+          "label": "Silver Style Entertainment"
+        },
+        {
+          "code": "Q3962810",
+          "label": "Slitherine Software UK Limited"
+        },
+        {
+          "code": "Q3978133",
+          "label": "SureAI"
+        },
+        {
+          "code": "Q110439635",
+          "label": "Han-Squirrel Studio"
+        },
+        {
+          "code": "Q110493215",
+          "label": "Sinister Design"
+        },
+        {
+          "code": "Q110494000",
+          "label": "Elecorn"
+        },
+        {
+          "code": "Q110499711",
+          "label": "Sonzai Games"
+        },
+        {
+          "code": "Q110549866",
+          "label": "Overhype Studios"
+        },
+        {
+          "code": "Q110493344",
+          "label": "Hemisphere Games"
+        },
+        {
+          "code": "Q110493903",
+          "label": "Fair Play Labs"
+        },
+        {
+          "code": "Q110499512",
+          "label": "One Gruel Studio"
+        },
+        {
+          "code": "Q110548335",
+          "label": "Utopos Games"
+        },
+        {
+          "code": "Q110493915",
+          "label": "Evolution Games"
+        },
+        {
+          "code": "Q110494551",
+          "label": "DolphinBarn"
+        },
+        {
+          "code": "Q110521291",
+          "label": "YouRun"
+        },
+        {
+          "code": "Q110431476",
+          "label": "Renegade Sector Games"
+        },
+        {
+          "code": "Q110493721",
+          "label": "Green Sauce Games"
+        },
+        {
+          "code": "Q110493869",
+          "label": "Fish Factory Games"
+        },
+        {
+          "code": "Q110494005",
+          "label": "Elder Games"
+        },
+        {
+          "code": "Q110494163",
+          "label": "Eat Create Sleep"
+        },
+        {
+          "code": "Q110499567",
+          "label": "Bolder Games"
+        },
+        {
+          "code": "Q110494476",
+          "label": "Dreadbit"
+        },
+        {
+          "code": "Q110443783",
+          "label": "Scarecrow Studio"
+        },
+        {
+          "code": "Q110476713",
+          "label": "Nekcom Games"
+        },
+        {
+          "code": "Q110493873",
+          "label": "Fire Hose Games"
+        },
+        {
+          "code": "Q110454010",
+          "label": "Hungry Couch Games"
+        },
+        {
+          "code": "Q110493928",
+          "label": "Eurogold"
+        },
+        {
+          "code": "Q110493968",
+          "label": "Enhance Games"
+        },
+        {
+          "code": "Q110515762",
+          "label": "magicdweedoo"
+        },
+        {
+          "code": "Q110560475",
+          "label": "SFS Studios"
+        },
+        {
+          "code": "Q110497803",
+          "label": "Costar Software"
+        },
+        {
+          "code": "Q110547984",
+          "label": "Mossmouth"
+        },
+        {
+          "code": "Q26689565",
+          "label": "Umbrella"
+        },
+        {
+          "code": "Q26822168",
+          "label": "Campo Santo"
+        },
+        {
+          "code": "Q25377211",
+          "label": "Shouei System"
+        },
+        {
+          "code": "Q25377676",
+          "label": "Team Meat"
+        },
+        {
+          "code": "Q26267413",
+          "label": "Big Red Button"
+        },
+        {
+          "code": "Q26791592",
+          "label": "SomaSim"
+        },
+        {
+          "code": "Q25377701",
+          "label": "Sakata SAS Co., Ltd."
+        },
+        {
+          "code": "Q25401249",
+          "label": "The Men Who Wear Many Hats"
+        },
+        {
+          "code": "Q25421421",
+          "label": "Coldwood Interactive"
+        },
+        {
+          "code": "Q26715541",
+          "label": "Dinosaur Polo Club"
+        },
+        {
+          "code": "Q26715626",
+          "label": "G2CREW"
+        },
+        {
+          "code": "Q25389031",
+          "label": "Pocket Studios"
+        },
+        {
+          "code": "Q25441778",
+          "label": "InLogic Software"
+        },
+        {
+          "code": "Q26689717",
+          "label": "Games From Outer Space"
+        },
+        {
+          "code": "Q26720075",
+          "label": "Wube Software"
+        },
+        {
+          "code": "Q25565647",
+          "label": "Pixelnest Studio"
+        },
+        {
+          "code": "Q25932560",
+          "label": "Killjoy Games"
+        },
+        {
+          "code": "Q26257641",
+          "label": "PassTech Games"
+        },
+        {
+          "code": "Q26715453",
+          "label": "Axolot Games"
+        },
+        {
+          "code": "Q25377881",
+          "label": "LTI Gray Matter"
+        },
+        {
+          "code": "Q26455487",
+          "label": "Shining Rock Software"
+        },
+        {
+          "code": "Q25104745",
+          "label": "Digital Happiness"
+        },
+        {
+          "code": "Q4033676",
+          "label": "Alawar Entertainment"
+        },
+        {
+          "code": "Q4033703",
+          "label": "Aliasworlds Entertainment"
+        },
+        {
+          "code": "Q4034912",
+          "label": "BattleGoat Studios"
+        },
+        {
+          "code": "Q4034645",
+          "label": "Awem"
+        },
+        {
+          "code": "Q4019629",
+          "label": "Whoopee Camp"
+        },
+        {
+          "code": "Q4033359",
+          "label": "Action Forms"
+        },
+        {
+          "code": "Q4033632",
+          "label": "Airtight Games"
+        },
+        {
+          "code": "Q4034625",
+          "label": "Autumn Moon Entertainment"
+        },
+        {
+          "code": "Q4019803",
+          "label": "Wildfire Games"
+        },
+        {
+          "code": "Q4033833",
+          "label": "AlternativaPlatform"
+        },
+        {
+          "code": "Q31288788",
+          "label": "Encore"
+        },
+        {
+          "code": "Q31287898",
+          "label": "Last Lotus"
+        },
+        {
+          "code": "Q31619583",
+          "label": "SMAC Games"
+        },
+        {
+          "code": "Q30895649",
+          "label": "Endnight Games"
+        },
+        {
+          "code": "Q30957005",
+          "label": "Cyber Light Game Studio"
+        },
+        {
+          "code": "Q31288527",
+          "label": "8th Floor Games"
+        },
+        {
+          "code": "Q31625870",
+          "label": "Expansive Worlds"
+        },
+        {
+          "code": "Q30892769",
+          "label": "Meridian4"
+        },
+        {
+          "code": "Q31280668",
+          "label": "Angry Mob Games"
+        },
+        {
+          "code": "Q31288337",
+          "label": "LearnDistrict"
+        },
+        {
+          "code": "Q31606161",
+          "label": "Antab Studio"
+        },
+        {
+          "code": "Q31610464",
+          "label": "SpinTop Games"
+        },
+        {
+          "code": "Q31614246",
+          "label": "The Gentlebros"
+        },
+        {
+          "code": "Q31617364",
+          "label": "Studio Wumpus"
+        },
+        {
+          "code": "Q31618055",
+          "label": "Strangely Interactive Ltd"
+        },
+        {
+          "code": "Q31276253",
+          "label": "Pipliz"
+        },
+        {
+          "code": "Q31286552",
+          "label": "JRad Games"
+        },
+        {
+          "code": "Q31617528",
+          "label": "4-Panel Footprint"
+        },
+        {
+          "code": "Q31628994",
+          "label": "Lince Works"
+        },
+        {
+          "code": "Q30925983",
+          "label": "Simon Creative"
+        },
+        {
+          "code": "Q31246483",
+          "label": "Liveplex"
+        },
+        {
+          "code": "Q31287807",
+          "label": "Sapphire Dragon Productions"
+        },
+        {
+          "code": "Q31607781",
+          "label": "Synapse Games"
+        },
+        {
+          "code": "Q31625367",
+          "label": "Matt Dabrowski"
+        },
+        {
+          "code": "Q31627033",
+          "label": "IronOak Games"
+        },
+        {
+          "code": "Q30915027",
+          "label": "Episode Interactive"
+        },
+        {
+          "code": "Q30936808",
+          "label": "Toylogic"
+        },
+        {
+          "code": "Q31288332",
+          "label": "The Team Who Must Not Be Named"
+        },
+        {
+          "code": "Q31605811",
+          "label": "Divine Games"
+        },
+        {
+          "code": "Q31626043",
+          "label": "Dire Wolf Digital"
+        },
+        {
+          "code": "Q31283791",
+          "label": "Ertal Games"
+        },
+        {
+          "code": "Q31285228",
+          "label": "OhNoo Studio"
+        },
+        {
+          "code": "Q31177231",
+          "label": "Family Production"
+        },
+        {
+          "code": "Q28416421",
+          "label": "Golden Disc Electronic"
+        },
+        {
+          "code": "Q28686397",
+          "label": "miHoYo"
+        },
+        {
+          "code": "Q28721400",
+          "label": "10tons Entertainment"
+        },
+        {
+          "code": "Q28222801",
+          "label": "Survios"
+        },
+        {
+          "code": "Q28410092",
+          "label": "Beijing Wiz Online CO., Ltd"
+        },
+        {
+          "code": "Q28173854",
+          "label": "Compulsion Games"
+        },
+        {
+          "code": "Q28223113",
+          "label": "Free Lives"
+        },
+        {
+          "code": "Q28406776",
+          "label": "Soedesco"
+        },
+        {
+          "code": "Q28407898",
+          "label": "Arcane Kids"
+        },
+        {
+          "code": "Q28666112",
+          "label": "Saturn-plus"
+        },
+        {
+          "code": "Q28721432",
+          "label": "Secret Exit"
+        },
+        {
+          "code": "Q28407799",
+          "label": "Gamsole"
+        },
+        {
+          "code": "Q122335358",
+          "label": "Sunna Entertainment"
+        },
+        {
+          "code": "Q122337810",
+          "label": "Aabs Inc."
+        },
+        {
+          "code": "Q122344054",
+          "label": "Studio Pork"
+        },
+        {
+          "code": "Q122362748",
+          "label": "Joey Drew Studios"
+        },
+        {
+          "code": "Q122363528",
+          "label": "Rising Moon Games"
+        },
+        {
+          "code": "Q122363547",
+          "label": "Odencat"
+        },
+        {
+          "code": "Q122366871",
+          "label": "Asobox"
+        },
+        {
+          "code": "Q122382429",
+          "label": "Vast Fame"
+        },
+        {
+          "code": "Q122397527",
+          "label": "Eirtep"
+        },
+        {
+          "code": "Q122417710",
+          "label": "Sintax Technology Co., Ltd"
+        },
+        {
+          "code": "Q122426061",
+          "label": "Farlight Games Industry"
+        },
+        {
+          "code": "Q122435088",
+          "label": "Game Start LLC"
+        },
+        {
+          "code": "Q122437872",
+          "label": "FobTi interactive"
+        },
+        {
+          "code": "Q122441844",
+          "label": "OrionGames"
+        },
+        {
+          "code": "Q122453747",
+          "label": "Thorium Entertainment"
+        },
+        {
+          "code": "Q122453765",
+          "label": "Kluge Interactive"
+        },
+        {
+          "code": "Q122454027",
+          "label": "Ufo Cat Games"
+        },
+        {
+          "code": "Q122454041",
+          "label": "Chupacabra Game Studios"
+        },
+        {
+          "code": "Q122458038",
+          "label": "Ariel Jurkowski Games"
+        },
+        {
+          "code": "Q122459150",
+          "label": "Indie Games Studio"
+        },
+        {
+          "code": "Q122459306",
+          "label": "Vblank Entertainment"
+        },
+        {
+          "code": "Q122497365",
+          "label": "Rundisc"
+        },
+        {
+          "code": "Q122500069",
+          "label": "The Deep End Games"
+        },
+        {
+          "code": "Q122503163",
+          "label": "Kids With Sticks"
+        },
+        {
+          "code": "Q122640529",
+          "label": "OutOfTheBit"
+        },
+        {
+          "code": "Q122663691",
+          "label": "Epiphany Games"
+        },
+        {
+          "code": "Q122663758",
+          "label": "Brinemedia"
+        },
+        {
+          "code": "Q122663972",
+          "label": "Petums"
+        },
+        {
+          "code": "Q122664106",
+          "label": "9Finger Games"
+        },
+        {
+          "code": "Q122670324",
+          "label": "Longterm Games"
+        },
+        {
+          "code": "Q122670566",
+          "label": "Enjoy Studio"
+        },
+        {
+          "code": "Q122672900",
+          "label": "Lunar Pixel"
+        },
+        {
+          "code": "Q122704030",
+          "label": "Cherrypick Games"
+        },
+        {
+          "code": "Q122704144",
+          "label": "Hungry Sky"
+        },
+        {
+          "code": "Q122708534",
+          "label": "Freegamer"
+        },
+        {
+          "code": "Q122710406",
+          "label": "Iocaine Studios"
+        },
+        {
+          "code": "Q122732266",
+          "label": "Red Spot Sylphina"
+        },
+        {
+          "code": "Q122733099",
+          "label": "Sega Technical Institute Burbank"
+        },
+        {
+          "code": "Q122737028",
+          "label": "MobileWizardry"
+        },
+        {
+          "code": "Q122737159",
+          "label": "Mobile 1UP"
+        },
+        {
+          "code": "Q122746126",
+          "label": "Hello Penguin Team"
+        },
+        {
+          "code": "Q122749963",
+          "label": "YeTa Games"
+        },
+        {
+          "code": "Q122755271",
+          "label": "Unwound Games"
+        },
+        {
+          "code": "Q122755268",
+          "label": "Aerovery Lab"
+        },
+        {
+          "code": "Q122761662",
+          "label": "Sand Castles Studio"
+        },
+        {
+          "code": "Q122766590",
+          "label": "Recreate Games"
+        },
+        {
+          "code": "Q122829124",
+          "label": "Gravity Game Arise"
+        },
+        {
+          "code": "Q122360633",
+          "label": "Wirion"
+        },
+        {
+          "code": "Q122338679",
+          "label": "Magic Cube"
+        },
+        {
+          "code": "Q24255996",
+          "label": "Mandragora"
+        },
+        {
+          "code": "Q24255745",
+          "label": "BlankMediaGames"
+        },
+        {
+          "code": "Q24255583",
+          "label": "Shugasu UG"
+        },
+        {
+          "code": "Q24255586",
+          "label": "Thylacine Studios"
+        },
+        {
+          "code": "Q24255588",
+          "label": "Viswanath Atlu"
+        },
+        {
+          "code": "Q24255601",
+          "label": "UnexEvo"
+        },
+        {
+          "code": "Q24255928",
+          "label": "Code Club AB"
+        },
+        {
+          "code": "Q24255989",
+          "label": "Dogenzaka Lab"
+        },
+        {
+          "code": "Q24256009",
+          "label": "Tokyo RPG Factory"
+        },
+        {
+          "code": "Q24255645",
+          "label": "Snowbird Games"
+        },
+        {
+          "code": "Q24255920",
+          "label": "Arvydas Žemaitis"
+        },
+        {
+          "code": "Q24255981",
+          "label": "Sorath"
+        },
+        {
+          "code": "Q24256541",
+          "label": "Crazy Moo Games"
+        },
+        {
+          "code": "Q24256604",
+          "label": "Specialbit"
+        },
+        {
+          "code": "Q24255742",
+          "label": "Texel Raptor"
+        },
+        {
+          "code": "Q24255750",
+          "label": "Star Gem Inc."
+        },
+        {
+          "code": "Q24256452",
+          "label": "Qooc Software"
+        },
+        {
+          "code": "Q24255747",
+          "label": "Modulaatio Games"
+        },
+        {
+          "code": "Q24255604",
+          "label": "Big Fat Simulations Inc."
+        },
+        {
+          "code": "Q24255590",
+          "label": "Reentry Games"
+        },
+        {
+          "code": "Q24255763",
+          "label": "Panoramik Inc"
+        },
+        {
+          "code": "Q24255773",
+          "label": "MinMax Games Ltd."
+        },
+        {
+          "code": "Q24255833",
+          "label": "Hammerfall Publishing"
+        },
+        {
+          "code": "Q24255849",
+          "label": "Dekovir"
+        },
+        {
+          "code": "Q24255790",
+          "label": "Raptor Claw Games"
+        },
+        {
+          "code": "Q24255835",
+          "label": "Landon Podbielski"
+        },
+        {
+          "code": "Q24255955",
+          "label": "Nexus Game Studios"
+        },
+        {
+          "code": "Q24256112",
+          "label": "Ole Lange"
+        },
+        {
+          "code": "Q24256448",
+          "label": "DnS Development"
+        },
+        {
+          "code": "Q24256491",
+          "label": "exosyphen studios"
+        },
+        {
+          "code": "Q24256455",
+          "label": "Turtle Cream"
+        },
+        {
+          "code": "Q24256586",
+          "label": "Petit Depotto"
+        },
+        {
+          "code": "Q24255845",
+          "label": "Jundroo"
+        },
+        {
+          "code": "Q24255846",
+          "label": "Payload Studios"
+        },
+        {
+          "code": "Q24256223",
+          "label": "Transhuman Design"
+        },
+        {
+          "code": "Q24346102",
+          "label": "Urban Games"
+        },
+        {
+          "code": "Q24255596",
+          "label": "Playrise Digital Ltd."
+        },
+        {
+          "code": "Q24255643",
+          "label": "ICE Entertainment"
+        },
+        {
+          "code": "Q24256588",
+          "label": "Priority Interrupt"
+        },
+        {
+          "code": "Q24256175",
+          "label": "Deck13 Hamburg"
+        },
+        {
+          "code": "Q24256203",
+          "label": "Fly System"
+        },
+        {
+          "code": "Q3759468",
+          "label": "General Computer Corporation"
+        },
+        {
+          "code": "Q3761761",
+          "label": "Syn Sophia"
+        },
+        {
+          "code": "Q3815456",
+          "label": "Backflip Studios"
+        },
+        {
+          "code": "Q3781101",
+          "label": "Imagineer"
+        },
+        {
+          "code": "Q3775043",
+          "label": "GameHouse"
+        },
+        {
+          "code": "Q3775891",
+          "label": "feelplus"
+        },
+        {
+          "code": "Q3772556",
+          "label": "Natsume Atari"
+        },
+        {
+          "code": "Q27630583",
+          "label": "Umbrella"
+        },
+        {
+          "code": "Q27017122",
+          "label": "Compile Maru"
+        },
+        {
+          "code": "Q28162866",
+          "label": "Snowman"
+        },
+        {
+          "code": "Q27928474",
+          "label": "Cardboard Computer"
+        },
+        {
+          "code": "Q28154317",
+          "label": "Bandai Entertainment Company"
+        },
+        {
+          "code": "Q26904753",
+          "label": "3 Sprockets"
+        },
+        {
+          "code": "Q28129037",
+          "label": "Amazon Games"
+        },
+        {
+          "code": "Q26842891",
+          "label": "UNIANA"
+        },
+        {
+          "code": "Q26966356",
+          "label": "Variable State"
+        },
+        {
+          "code": "Q27665087",
+          "label": "D-Pad Studio"
+        },
+        {
+          "code": "Q27739768",
+          "label": "CyberAlliance"
+        },
+        {
+          "code": "Q27094432",
+          "label": "Digital Homicide Studios"
+        },
+        {
+          "code": "Q26964782",
+          "label": "Kobojo"
+        },
+        {
+          "code": "Q27017110",
+          "label": "Ruby Party"
+        },
+        {
+          "code": "Q27044867",
+          "label": "Ocelot Society"
+        },
+        {
+          "code": "Q27303837",
+          "label": "Cubical Drift"
+        },
+        {
+          "code": "Q27703660",
+          "label": "Odnako Games"
+        },
+        {
+          "code": "Q28004624",
+          "label": "Iceflake Studios"
+        },
+        {
+          "code": "Q110013763",
+          "label": "Skunkape"
+        },
+        {
+          "code": "Q110058652",
+          "label": "Glaive Games"
+        },
+        {
+          "code": "Q110013577",
+          "label": "Stormling Studios"
+        },
+        {
+          "code": "Q110037684",
+          "label": "D6 Team"
+        },
+        {
+          "code": "Q110059023",
+          "label": "Roomah Games"
+        },
+        {
+          "code": "Q109996504",
+          "label": "Guará Studios"
+        },
+        {
+          "code": "Q109996611",
+          "label": "BUG-Studio"
+        },
+        {
+          "code": "Q110013831",
+          "label": "Skunkape Interactive"
+        },
+        {
+          "code": "Q110039140",
+          "label": "Round 2 Games"
+        },
+        {
+          "code": "Q110011692",
+          "label": "Strange Scaffold"
+        },
+        {
+          "code": "Q110015165",
+          "label": "Delphinium Interactive"
+        },
+        {
+          "code": "Q110036044",
+          "label": "Duck team"
+        },
+        {
+          "code": "Q110051784",
+          "label": "Valkyrie Entertainment"
+        },
+        {
+          "code": "Q109996875",
+          "label": "Scythe Dev Team"
+        },
+        {
+          "code": "Q110037519",
+          "label": "Drageus Games"
+        },
+        {
+          "code": "Q110012204",
+          "label": "Monokel"
+        },
+        {
+          "code": "Q110037739",
+          "label": "npckc"
+        },
+        {
+          "code": "Q110060982",
+          "label": "Gunstone Studios"
+        },
+        {
+          "code": "Q110061023",
+          "label": "Wonderful Lasers"
+        },
+        {
+          "code": "Q110064872",
+          "label": "Embark Studios"
+        },
+        {
+          "code": "Q110015978",
+          "label": "Vivid Games"
+        },
+        {
+          "code": "Q110033917",
+          "label": "Fatbot Games"
+        },
+        {
+          "code": "Q110038933",
+          "label": "Asylum Square"
+        },
+        {
+          "code": "Q110038772",
+          "label": "Rejected Games"
+        },
+        {
+          "code": "Q110059537",
+          "label": "Super PowerUp Games"
+        },
+        {
+          "code": "Q124300428",
+          "label": "Digital Dreams"
+        },
+        {
+          "code": "Q124130946",
+          "label": "Gro Play"
+        },
+        {
+          "code": "Q124149672",
+          "label": "PDW:HOTAPEN"
+        },
+        {
+          "code": "Q124152427",
+          "label": "Abu Insdustries"
+        },
+        {
+          "code": "Q124153283",
+          "label": "Nomadroid"
+        },
+        {
+          "code": "Q124155125",
+          "label": "Wildboy Studios"
+        },
+        {
+          "code": "Q124155433",
+          "label": "Lucid Labs"
+        },
+        {
+          "code": "Q124162733",
+          "label": "HyperBeard"
+        },
+        {
+          "code": "Q124165685",
+          "label": "Mindsai Productions"
+        },
+        {
+          "code": "Q124167355",
+          "label": "Flow Entertainment"
+        },
+        {
+          "code": "Q124178820",
+          "label": "Skyborne Games"
+        },
+        {
+          "code": "Q124186395",
+          "label": "Schwarz Games"
+        },
+        {
+          "code": "Q124246206",
+          "label": "One O One Games"
+        },
+        {
+          "code": "Q124246335",
+          "label": "Tiny Games"
+        },
+        {
+          "code": "Q124246790",
+          "label": "Quartomundo"
+        },
+        {
+          "code": "Q124248042",
+          "label": "314 Arts"
+        },
+        {
+          "code": "Q124248256",
+          "label": "Frogsong Studios"
+        },
+        {
+          "code": "Q124248299",
+          "label": "Nightbloomer Studio"
+        },
+        {
+          "code": "Q124249072",
+          "label": "Video Games Deluxe"
+        },
+        {
+          "code": "Q124251582",
+          "label": "Yash Future Tech Solutions"
+        },
+        {
+          "code": "Q124251938",
+          "label": "Starsoft Entertainment"
+        },
+        {
+          "code": "Q124255980",
+          "label": "Sunscorched Studios"
+        },
+        {
+          "code": "Q124285064",
+          "label": "Envision Entertainment"
+        },
+        {
+          "code": "Q124289582",
+          "label": "Rotu Entertainment"
+        },
+        {
+          "code": "Q124289694",
+          "label": "Pirates Of The Digital Sea"
+        },
+        {
+          "code": "Q124294446",
+          "label": "Queasy Games"
+        },
+        {
+          "code": "Q124299875",
+          "label": "Emberheart Games"
+        },
+        {
+          "code": "Q124299878",
+          "label": "Vermillion Digital"
+        },
+        {
+          "code": "Q124299906",
+          "label": "Channel 3 Entertainment"
+        },
+        {
+          "code": "Q124299936",
+          "label": "Space Fox Games"
+        },
+        {
+          "code": "Q124300214",
+          "label": "Cold Symmetry"
+        },
+        {
+          "code": "Q124300221",
+          "label": "Pine Scented Software"
+        },
+        {
+          "code": "Q124300418",
+          "label": "Algomedia Studio"
+        },
+        {
+          "code": "Q124300419",
+          "label": "Alpha Helix"
+        },
+        {
+          "code": "Q124300417",
+          "label": "ABC Department"
+        },
+        {
+          "code": "Q124300423",
+          "label": "Bidule 4 AG"
+        },
+        {
+          "code": "Q124300420",
+          "label": "Anachronia"
+        },
+        {
+          "code": "Q124300426",
+          "label": "Bright Software"
+        },
+        {
+          "code": "Q124300427",
+          "label": "Cultimedia"
+        },
+        {
+          "code": "Q124300424",
+          "label": "Black Pencil Entertainment"
+        },
+        {
+          "code": "Q124300425",
+          "label": "Blue Line Studios"
+        },
+        {
+          "code": "Q124300430",
+          "label": "Evolution Trading AG"
+        },
+        {
+          "code": "Q124300431",
+          "label": "Falcomedia"
+        },
+        {
+          "code": "Q124300429",
+          "label": "Epsitec SA"
+        },
+        {
+          "code": "Q124300434",
+          "label": "la1n"
+        },
+        {
+          "code": "Q124300432",
+          "label": "Handmade Game Production"
+        },
+        {
+          "code": "Q124300433",
+          "label": "Kimey Fun Media"
+        },
+        {
+          "code": "Q124300435",
+          "label": "Modern Arts"
+        },
+        {
+          "code": "Q124300438",
+          "label": "Pfiat"
+        },
+        {
+          "code": "Q124300436",
+          "label": "Nightingale Productions"
+        },
+        {
+          "code": "Q124300442",
+          "label": "Swiss Computer Arts"
+        },
+        {
+          "code": "Q124300437",
+          "label": "Optobyte"
+        },
+        {
+          "code": "Q124300441",
+          "label": "Sunrise Swiss"
+        },
+        {
+          "code": "Q124300440",
+          "label": "Profi Game Production"
+        },
+        {
+          "code": "Q124300439",
+          "label": "Prestige"
+        },
+        {
+          "code": "Q124300422",
+          "label": "Arizona"
+        },
+        {
+          "code": "Q124300443",
+          "label": "The Game Factory"
+        },
+        {
+          "code": "Q4045077",
+          "label": "NaturalMotion"
+        },
+        {
+          "code": "Q4045349",
+          "label": "Nikita Online"
+        },
+        {
+          "code": "Q4048134",
+          "label": "Reflexive Entertainment"
+        },
+        {
+          "code": "Q4043608",
+          "label": "Magic Wand Productions"
+        },
+        {
+          "code": "Q4047152",
+          "label": "Point of View, Inc."
+        },
+        {
+          "code": "Q4044298",
+          "label": "MindArk"
+        },
+        {
+          "code": "Q4047081",
+          "label": "Playrix"
+        },
+        {
+          "code": "Q4042801",
+          "label": "Lesta Games"
+        },
+        {
+          "code": "Q4044195",
+          "label": "Micro Forté"
+        },
+        {
+          "code": "Q4047460",
+          "label": "Prope"
+        },
+        {
+          "code": "Q4807758",
+          "label": "Aspect"
+        },
+        {
+          "code": "Q4813366",
+          "label": "Athena"
+        },
+        {
+          "code": "Q4828168",
+          "label": "Aventurine SA"
+        },
+        {
+          "code": "Q4826391",
+          "label": "Automata UK"
+        },
+        {
+          "code": "Q4827813",
+          "label": "Avatar Reality"
+        },
+        {
+          "code": "Q4834382",
+          "label": "B2B Games"
+        },
+        {
+          "code": "Q4817166",
+          "label": "Atod"
+        },
+        {
+          "code": "Q4817250",
+          "label": "Atomic Antelope"
+        },
+        {
+          "code": "Q4812065",
+          "label": "Asymmetric Publications"
+        },
+        {
+          "code": "Q4817300",
+          "label": "Atomic Planet Entertainment"
+        },
+        {
+          "code": "Q4817281",
+          "label": "Atomic Games"
+        },
+        {
+          "code": "Q4826137",
+          "label": "New Star Games"
+        },
+        {
+          "code": "Q4817298",
+          "label": "Atomic Motion"
+        },
+        {
+          "code": "Q4819912",
+          "label": "Audiokinetic"
+        },
+        {
+          "code": "Q4831131",
+          "label": "Ayeah Games"
+        },
+        {
+          "code": "Q4806327",
+          "label": "AsiaSoft"
+        },
+        {
+          "code": "Q28763140",
+          "label": "Joyland"
+        },
+        {
+          "code": "Q29159298",
+          "label": "Ghost Town Games"
+        },
+        {
+          "code": "Q29578079",
+          "label": "Mindware Corp."
+        },
+        {
+          "code": "Q29997031",
+          "label": "Goldhawk Interactive"
+        },
+        {
+          "code": "Q30041006",
+          "label": "TheMeatly Games"
+        },
+        {
+          "code": "Q29832258",
+          "label": "Three Fields Entertainment"
+        },
+        {
+          "code": "Q30086425",
+          "label": "Optimum Resource"
+        },
+        {
+          "code": "Q28721618",
+          "label": "Everywear Games"
+        },
+        {
+          "code": "Q29964544",
+          "label": "Tindalos Interactive"
+        },
+        {
+          "code": "Q30032973",
+          "label": "X-bow Software"
+        },
+        {
+          "code": "Q28721454",
+          "label": "Wargaming Helsinki"
+        },
+        {
+          "code": "Q28803110",
+          "label": "Roll7"
+        },
+        {
+          "code": "Q29919441",
+          "label": "Williams Electronics Games"
+        },
+        {
+          "code": "Q28872982",
+          "label": "Independent Arts Software"
+        },
+        {
+          "code": "Q28924488",
+          "label": "Tamatem"
+        },
+        {
+          "code": "Q29227659",
+          "label": "Ndemic Creations"
+        },
+        {
+          "code": "Q29888180",
+          "label": "Ubisoft Berlin"
+        },
+        {
+          "code": "Q30105931",
+          "label": "Red Hook Studios"
+        },
+        {
+          "code": "Q29326164",
+          "label": "Team Cherry"
+        },
+        {
+          "code": "Q29578855",
+          "label": "Logic Artists"
+        },
+        {
+          "code": "Q29782891",
+          "label": "Industrial Game Studios"
+        },
+        {
+          "code": "Q29888207",
+          "label": "Ubisoft Philippines"
+        },
+        {
+          "code": "Q29883069",
+          "label": "Oxford Softworks"
+        },
+        {
+          "code": "Q86756163",
+          "label": "Playgendary"
+        },
+        {
+          "code": "Q87419925",
+          "label": "Mega Crit"
+        },
+        {
+          "code": "Q89292991",
+          "label": "Fiction Factory Games"
+        },
+        {
+          "code": "Q90701136",
+          "label": "Recloak"
+        },
+        {
+          "code": "Q90405658",
+          "label": "Rival Games"
+        },
+        {
+          "code": "Q88008773",
+          "label": "Studio Koba"
+        },
+        {
+          "code": "Q88327173",
+          "label": "Game Mechanic Studios"
+        },
+        {
+          "code": "Q87352350",
+          "label": "Lizardcube"
+        },
+        {
+          "code": "Q89100104",
+          "label": "Forever Entertainment"
+        },
+        {
+          "code": "Q90396348",
+          "label": "Meteorise"
+        },
+        {
+          "code": "Q91013199",
+          "label": "Mane6"
+        },
+        {
+          "code": "Q86745042",
+          "label": "ensemble"
+        },
+        {
+          "code": "Q88896323",
+          "label": "WARP"
+        },
+        {
+          "code": "Q88955269",
+          "label": "fyto"
+        },
+        {
+          "code": "Q90770757",
+          "label": "Turtle Juice"
+        },
+        {
+          "code": "Q91013231",
+          "label": "Studio Seufz"
+        },
+        {
+          "code": "Q87516565",
+          "label": "Backbone Emeryville"
+        },
+        {
+          "code": "Q88768172",
+          "label": "Snowhound Games"
+        },
+        {
+          "code": "Q88894180",
+          "label": "KagariSoft"
+        },
+        {
+          "code": "Q89949604",
+          "label": "Peltast Software"
+        },
+        {
+          "code": "Q90566255",
+          "label": "Honey Parade Games"
+        },
+        {
+          "code": "Q91038266",
+          "label": "PlayStation Mobile, Inc."
+        },
+        {
+          "code": "Q87753541",
+          "label": "Tobuscus Game Studios"
+        },
+        {
+          "code": "Q88090338",
+          "label": "Lab Zero Games"
+        },
+        {
+          "code": "Q90573897",
+          "label": "ElectricPuke"
+        },
+        {
+          "code": "Q90906892",
+          "label": "Ludoïd"
+        },
+        {
+          "code": "Q73398072",
+          "label": "Strange Creatures Studio LLC"
+        },
+        {
+          "code": "Q75049650",
+          "label": "Twofaced Games"
+        },
+        {
+          "code": "Q71727327",
+          "label": "Neko Work H"
+        },
+        {
+          "code": "Q72876021",
+          "label": "Trese Brothers"
+        },
+        {
+          "code": "Q74391138",
+          "label": "Nonsense Arts"
+        },
+        {
+          "code": "Q74491941",
+          "label": "Graybeard Games"
+        },
+        {
+          "code": "Q74892870",
+          "label": "MayoNinja Games"
+        },
+        {
+          "code": "Q70266232",
+          "label": "KO_OP"
+        },
+        {
+          "code": "Q71857341",
+          "label": "Hand Made Software"
+        },
+        {
+          "code": "Q71916378",
+          "label": "QUByte Interactive"
+        },
+        {
+          "code": "Q72621230",
+          "label": "Prospect Games"
+        },
+        {
+          "code": "Q72871685",
+          "label": "GemMedia"
+        },
+        {
+          "code": "Q71581863",
+          "label": "Big Bad Wolf"
+        },
+        {
+          "code": "Q73086777",
+          "label": "Windy Hill"
+        },
+        {
+          "code": "Q70274956",
+          "label": "Buckethead Entertainment"
+        },
+        {
+          "code": "Q70417972",
+          "label": "bluecurse"
+        },
+        {
+          "code": "Q71271358",
+          "label": "Long Hat House"
+        },
+        {
+          "code": "Q72871768",
+          "label": "Unicorn Multimedia Corporation"
+        },
+        {
+          "code": "Q75074915",
+          "label": "SILK P.O.D."
+        },
+        {
+          "code": "Q71005615",
+          "label": "Sly"
+        },
+        {
+          "code": "Q70600754",
+          "label": "Illumix"
+        },
+        {
+          "code": "Q71338225",
+          "label": "Tainted Games"
+        },
+        {
+          "code": "Q74618797",
+          "label": "Hexenhaus"
+        },
+        {
+          "code": "Q70890142",
+          "label": "Iconic Gaming Studio"
+        },
+        {
+          "code": "Q72975717",
+          "label": "Maranyo Games"
+        },
+        {
+          "code": "Q74602803",
+          "label": "Abel Inc."
+        },
+        {
+          "code": "Q74604762",
+          "label": "Bimboosoft Co., Ltd."
+        },
+        {
+          "code": "Q69891912",
+          "label": "GreenupGames"
+        },
+        {
+          "code": "Q70258963",
+          "label": "Arbitrary Metric"
+        },
+        {
+          "code": "Q71919083",
+          "label": "BITSTAIN"
+        },
+        {
+          "code": "Q72385678",
+          "label": "Cosmigo"
+        },
+        {
+          "code": "Q73409061",
+          "label": "Chaos Minds"
+        },
+        {
+          "code": "Q70584772",
+          "label": "Edenic Era LLC"
+        },
+        {
+          "code": "Q72327814",
+          "label": "Chilla's Art"
+        },
+        {
+          "code": "Q74453500",
+          "label": "Procedural Arts"
+        },
+        {
+          "code": "Q69881242",
+          "label": "No Reply Games"
+        },
+        {
+          "code": "Q69881752",
+          "label": "ViNovella"
+        },
+        {
+          "code": "Q71959446",
+          "label": "Incredible Simulations, Inc."
+        },
+        {
+          "code": "Q72772310",
+          "label": "Silly Galah Games"
+        },
+        {
+          "code": "Q109906281",
+          "label": "Syrox Developments"
+        },
+        {
+          "code": "Q109929910",
+          "label": "Balancing Monkey Games"
+        },
+        {
+          "code": "Q109974563",
+          "label": "SleepTeam"
+        },
+        {
+          "code": "Q109942582",
+          "label": "Grave Danger Games"
+        },
+        {
+          "code": "Q109906711",
+          "label": "Kaneda Games"
+        },
+        {
+          "code": "Q109923535",
+          "label": "Retro Forge Games"
+        },
+        {
+          "code": "Q109979371",
+          "label": "WildSphere"
+        },
+        {
+          "code": "Q109986228",
+          "label": "Crazysoft"
+        },
+        {
+          "code": "Q109928309",
+          "label": "Konfa Games"
+        },
+        {
+          "code": "Q109928554",
+          "label": "Gameplay First"
+        },
+        {
+          "code": "Q109930238",
+          "label": "Gibier Games"
+        },
+        {
+          "code": "Q109942498",
+          "label": "Marionette Games"
+        },
+        {
+          "code": "Q109969389",
+          "label": "IV Productions"
+        },
+        {
+          "code": "Q109908775",
+          "label": "Round 8 Studio"
+        },
+        {
+          "code": "Q109913383",
+          "label": "Forust"
+        },
+        {
+          "code": "Q109949399",
+          "label": "Brave At Night"
+        },
+        {
+          "code": "Q109969323",
+          "label": "DigiArt Interactive"
+        },
+        {
+          "code": "Q109906187",
+          "label": "Pretty Fly Games"
+        },
+        {
+          "code": "Q109928792",
+          "label": "Voxler"
+        },
+        {
+          "code": "Q109929481",
+          "label": "Jutsu Games"
+        },
+        {
+          "code": "Q109932630",
+          "label": "BreakFirst"
+        },
+        {
+          "code": "Q109971788",
+          "label": "TriBit Studio"
+        },
+        {
+          "code": "Q109978189",
+          "label": "Chibig"
+        },
+        {
+          "code": "Q109923630",
+          "label": "Mob Entertainment"
+        },
+        {
+          "code": "Q109928766",
+          "label": "Ravenscourt"
+        },
+        {
+          "code": "Q109913867",
+          "label": "Paranoid Interactive"
+        },
+        {
+          "code": "Q109969261",
+          "label": "Porcelain Fortress"
+        },
+        {
+          "code": "Q109977798",
+          "label": "Poor Cat"
+        },
+        {
+          "code": "Q109949625",
+          "label": "The Outer Zone"
+        },
+        {
+          "code": "Q109942429",
+          "label": "Prison Games"
+        },
+        {
+          "code": "Q109942629",
+          "label": "Buddy System"
+        },
+        {
+          "code": "Q110194597",
+          "label": "FM Studio"
+        },
+        {
+          "code": "Q110247746",
+          "label": "Higgs Games"
+        },
+        {
+          "code": "Q110247832",
+          "label": "Ravegan"
+        },
+        {
+          "code": "Q110400653",
+          "label": "Half-Face Games"
+        },
+        {
+          "code": "Q110194050",
+          "label": "Mental Drink"
+        },
+        {
+          "code": "Q110209484",
+          "label": "Glasscannon Studio"
+        },
+        {
+          "code": "Q110221352",
+          "label": "Claytechworks"
+        },
+        {
+          "code": "Q110247043",
+          "label": "Infinite State Games"
+        },
+        {
+          "code": "Q110247483",
+          "label": "Viridino Studios"
+        },
+        {
+          "code": "Q110400604",
+          "label": "FMV Interactive"
+        },
+        {
+          "code": "Q110400639",
+          "label": "Silen Games"
+        },
+        {
+          "code": "Q110247352",
+          "label": "Playbae"
+        },
+        {
+          "code": "Q110249759",
+          "label": "North Battle"
+        },
+        {
+          "code": "Q110307537",
+          "label": "Clout Games"
+        },
+        {
+          "code": "Q110400563",
+          "label": "naptime.games"
+        },
+        {
+          "code": "Q110217530",
+          "label": "Gotcha Gotcha Games"
+        },
+        {
+          "code": "Q110231625",
+          "label": "Morteshka"
+        },
+        {
+          "code": "Q110246359",
+          "label": "DigiTales Interactive"
+        },
+        {
+          "code": "Q110362875",
+          "label": "PlayAround"
+        },
+        {
+          "code": "Q110226407",
+          "label": "Qichenzhai"
+        },
+        {
+          "code": "Q110196689",
+          "label": "Game Nacional"
+        },
+        {
+          "code": "Q110209308",
+          "label": "Graphium Studio"
+        },
+        {
+          "code": "Q110247790",
+          "label": "CFK"
+        },
+        {
+          "code": "Q4052309",
+          "label": "Ubisoft Casablanca"
+        },
+        {
+          "code": "Q4048789",
+          "label": "SIMS Co., Ltd."
+        },
+        {
+          "code": "Q4048944",
+          "label": "Safari Software"
+        },
+        {
+          "code": "Q4051528",
+          "label": "Titan Studios"
+        },
+        {
+          "code": "Q4051487",
+          "label": "Tigon Studios"
+        },
+        {
+          "code": "Q4052310",
+          "label": "Ubisoft Chengdu"
+        },
+        {
+          "code": "Q4049035",
+          "label": "Sand Grain Studios"
+        },
+        {
+          "code": "Q4051069",
+          "label": "The Farm 51"
+        },
+        {
+          "code": "Q4051736",
+          "label": "Triangle Service"
+        },
+        {
+          "code": "Q4050746",
+          "label": "Targem Games"
+        },
+        {
+          "code": "Q4051095",
+          "label": "The Game Creators"
+        },
+        {
+          "code": "Q4052312",
+          "label": "Ubisoft Singapore"
+        },
+        {
+          "code": "Q67540406",
+          "label": "Dusky Hallows Studio"
+        },
+        {
+          "code": "Q67773676",
+          "label": "Reperio Studios"
+        },
+        {
+          "code": "Q67777208",
+          "label": "Viewport Games"
+        },
+        {
+          "code": "Q68088835",
+          "label": "Popcannibal"
+        },
+        {
+          "code": "Q69427151",
+          "label": "Mobius Digital"
+        },
+        {
+          "code": "Q69789116",
+          "label": "Crealude"
+        },
+        {
+          "code": "Q67391348",
+          "label": "Philly Games"
+        },
+        {
+          "code": "Q67413292",
+          "label": "IfThen Software LLC"
+        },
+        {
+          "code": "Q68826371",
+          "label": "Perverteer Games"
+        },
+        {
+          "code": "Q67391562",
+          "label": "DrPinkCake"
+        },
+        {
+          "code": "Q69403582",
+          "label": "Ambition"
+        },
+        {
+          "code": "Q68094551",
+          "label": "Return To Adventure Mountain, LLC"
+        },
+        {
+          "code": "Q68209981",
+          "label": "Moi Rai Games"
+        },
+        {
+          "code": "Q68574562",
+          "label": "Creepy Jar"
+        },
+        {
+          "code": "Q68190735",
+          "label": "K Bros Games"
+        },
+        {
+          "code": "Q68194615",
+          "label": "MrKnobb"
+        },
+        {
+          "code": "Q68794596",
+          "label": "Code Headquarters LLC"
+        },
+        {
+          "code": "Q69329890",
+          "label": "System Era Softworks"
+        },
+        {
+          "code": "Q69352476",
+          "label": "COVER Corporation"
+        },
+        {
+          "code": "Q67334701",
+          "label": "Skadoo Toons"
+        },
+        {
+          "code": "Q67530734",
+          "label": "Volcanic Games"
+        },
+        {
+          "code": "Q67599983",
+          "label": "Anima Project"
+        },
+        {
+          "code": "Q68338390",
+          "label": "Affray Studios"
+        },
+        {
+          "code": "Q69356631",
+          "label": "Vénus Noire"
+        },
+        {
+          "code": "Q67186598",
+          "label": "Roblox Corporation"
+        },
+        {
+          "code": "Q68038445",
+          "label": "IronOak Studios"
+        },
+        {
+          "code": "Q68924102",
+          "label": "HopesGaming"
+        },
+        {
+          "code": "Q5299627",
+          "label": "DoubleBear Productions"
+        },
+        {
+          "code": "Q5300149",
+          "label": "Doublesix"
+        },
+        {
+          "code": "Q5367665",
+          "label": "Elsinore Multimedia"
+        },
+        {
+          "code": "Q5374707",
+          "label": "Empty Clip Studios"
+        },
+        {
+          "code": "Q5323072",
+          "label": "eGames"
+        },
+        {
+          "code": "Q5306251",
+          "label": "DreamRift"
+        },
+        {
+          "code": "Q5329176",
+          "label": "East Point Software"
+        },
+        {
+          "code": "Q5307712",
+          "label": "Drinkbox Studios"
+        },
+        {
+          "code": "Q5324626",
+          "label": "EV Interactive"
+        },
+        {
+          "code": "Q5337654",
+          "label": "Edge Games"
+        },
+        {
+          "code": "Q5357113",
+          "label": "Panther Software"
+        },
+        {
+          "code": "Q5357296",
+          "label": "Yuzusoft"
+        },
+        {
+          "code": "Q5282731",
+          "label": "Disruptor Beam"
+        },
+        {
+          "code": "Q5348820",
+          "label": "Eidos Montreal"
+        },
+        {
+          "code": "Q5359622",
+          "label": "Quin Rose"
+        },
+        {
+          "code": "Q5319115",
+          "label": "Dynamo Games"
+        },
+        {
+          "code": "Q5364684",
+          "label": "Nitro chiral"
+        },
+        {
+          "code": "Q4786865",
+          "label": "Archimage"
+        },
+        {
+          "code": "Q4797388",
+          "label": "Artech Digital Entertainment"
+        },
+        {
+          "code": "Q4801840",
+          "label": "Artworx"
+        },
+        {
+          "code": "Q4765083",
+          "label": "Animation F/X"
+        },
+        {
+          "code": "Q4796743",
+          "label": "Art Co., Ltd"
+        },
+        {
+          "code": "Q4806100",
+          "label": "11 bit studios"
+        },
+        {
+          "code": "Q4765236",
+          "label": "Anino Games"
+        },
+        {
+          "code": "Q4779421",
+          "label": "Apex Computer Productions"
+        },
+        {
+          "code": "Q4801348",
+          "label": "Artix Entertainment"
+        },
+        {
+          "code": "Q4796618",
+          "label": "Arsys Software"
+        },
+        {
+          "code": "Q4802306",
+          "label": "Arush Entertainment"
+        },
+        {
+          "code": "Q4802754",
+          "label": "Arzest"
+        },
+        {
+          "code": "Q4752680",
+          "label": "Anchor Inc."
+        },
+        {
+          "code": "Q4785091",
+          "label": "Arcade Zone"
+        },
+        {
+          "code": "Q66049441",
+          "label": "Allied's"
+        },
+        {
+          "code": "Q67046041",
+          "label": "Naraven Games"
+        },
+        {
+          "code": "Q65924763",
+          "label": "Factor 5 GmbH"
+        },
+        {
+          "code": "Q66456981",
+          "label": "TookiPalooki"
+        },
+        {
+          "code": "Q66498879",
+          "label": "Black Dragon Publishing"
+        },
+        {
+          "code": "Q65923256",
+          "label": "Midjiwan"
+        },
+        {
+          "code": "Q66503729",
+          "label": "NEKO WORKs"
+        },
+        {
+          "code": "Q67050943",
+          "label": "AppSir"
+        },
+        {
+          "code": "Q67161782",
+          "label": "Motion Miracles"
+        },
+        {
+          "code": "Q66834424",
+          "label": "Nacon"
+        },
+        {
+          "code": "Q66222577",
+          "label": "Lag Studios"
+        },
+        {
+          "code": "Q66314463",
+          "label": "Albino Moose Games"
+        },
+        {
+          "code": "Q66371215",
+          "label": "The Quinnspiracy"
+        },
+        {
+          "code": "Q66439798",
+          "label": "Dark Gaia"
+        },
+        {
+          "code": "Q66498864",
+          "label": "Rotobee"
+        },
+        {
+          "code": "Q66956879",
+          "label": "Le Cartel"
+        },
+        {
+          "code": "Q66084414",
+          "label": "Finish Line Games"
+        },
+        {
+          "code": "Q66457828",
+          "label": "Yangyang Mobile"
+        },
+        {
+          "code": "Q66762381",
+          "label": "NAT Games"
+        },
+        {
+          "code": "Q66912875",
+          "label": "Metronomik"
+        },
+        {
+          "code": "Q67080396",
+          "label": "Stuck In Attic"
+        },
+        {
+          "code": "Q65786132",
+          "label": "Redfire Software"
+        },
+        {
+          "code": "Q66966728",
+          "label": "Panache Digital Games"
+        },
+        {
+          "code": "Q67047555",
+          "label": "Backwoods Entertainment"
+        },
+        {
+          "code": "Q67152079",
+          "label": "Infinite Fall"
+        },
+        {
+          "code": "Q65803772",
+          "label": "Critical Bliss"
+        },
+        {
+          "code": "Q66003935",
+          "label": "Grendel Games"
+        },
+        {
+          "code": "Q66771314",
+          "label": "PagodaWest Games"
+        },
+        {
+          "code": "Q66771380",
+          "label": "Headcannon"
+        },
+        {
+          "code": "Q66777838",
+          "label": "Seriously"
+        },
+        {
+          "code": "Q109887226",
+          "label": "Café Shiba"
+        },
+        {
+          "code": "Q109900156",
+          "label": "Maple Powered Games"
+        },
+        {
+          "code": "Q109768960",
+          "label": "Cyberwave"
+        },
+        {
+          "code": "Q109703890",
+          "label": "Smart Tale"
+        },
+        {
+          "code": "Q109735668",
+          "label": "Hangzhou zhexin IT Co.,Ltd"
+        },
+        {
+          "code": "Q109742547",
+          "label": "Palm Pioneer"
+        },
+        {
+          "code": "Q109796949",
+          "label": "Sony Computer Entertainment Korea"
+        },
+        {
+          "code": "Q109853221",
+          "label": "Windybeard"
+        },
+        {
+          "code": "Q109906139",
+          "label": "Sunlight Games"
+        },
+        {
+          "code": "Q109789481",
+          "label": "Journey Bound Games"
+        },
+        {
+          "code": "Q109827580",
+          "label": "HappySNS"
+        },
+        {
+          "code": "Q109852676",
+          "label": "Alawar Premium"
+        },
+        {
+          "code": "Q109794495",
+          "label": "Con Artist Games"
+        },
+        {
+          "code": "Q109849945",
+          "label": "Possibility Space"
+        },
+        {
+          "code": "Q109858531",
+          "label": "Chameleon Games"
+        },
+        {
+          "code": "Q109860175",
+          "label": "Exbleative"
+        },
+        {
+          "code": "Q109703627",
+          "label": "it Matters Games"
+        },
+        {
+          "code": "Q109715904",
+          "label": "Yume Creations"
+        },
+        {
+          "code": "Q109779653",
+          "label": "GLEE MR.GLEE TECH"
+        },
+        {
+          "code": "Q109828151",
+          "label": "Yellow Dot"
+        },
+        {
+          "code": "Q109828990",
+          "label": "Tinimations"
+        },
+        {
+          "code": "Q109887249",
+          "label": "Pixelbite"
+        },
+        {
+          "code": "Q109888220",
+          "label": "Laughing Machines"
+        },
+        {
+          "code": "Q109744729",
+          "label": "Full Circle"
+        },
+        {
+          "code": "Q109714029",
+          "label": "Jinke"
+        },
+        {
+          "code": "Q109707716",
+          "label": "Undercoders"
+        },
+        {
+          "code": "Q109860113",
+          "label": "EndlessFluff Games"
+        },
+        {
+          "code": "Q109703775",
+          "label": "Black Sheep Studio"
+        },
+        {
+          "code": "Q109809360",
+          "label": "Kind Cat Games"
+        },
+        {
+          "code": "Q109888129",
+          "label": "Big Boat Interactive"
+        },
+        {
+          "code": "Q94658604",
+          "label": "Giant Monkey Robot"
+        },
+        {
+          "code": "Q96390725",
+          "label": "Lolapps"
+        },
+        {
+          "code": "Q96741285",
+          "label": "Warzone 2100 Project"
+        },
+        {
+          "code": "Q95128161",
+          "label": "Petite Games"
+        },
+        {
+          "code": "Q96107088",
+          "label": "Class-X Games"
+        },
+        {
+          "code": "Q96379956",
+          "label": "Grey Alien"
+        },
+        {
+          "code": "Q95765937",
+          "label": "Tribe Studios"
+        },
+        {
+          "code": "Q96045983",
+          "label": "Relentless Game Studios"
+        },
+        {
+          "code": "Q96243717",
+          "label": "Robotality"
+        },
+        {
+          "code": "Q94652401",
+          "label": "Dalcom Soft"
+        },
+        {
+          "code": "Q95579468",
+          "label": "Luxee"
+        },
+        {
+          "code": "Q96278593",
+          "label": "Toge Productions"
+        },
+        {
+          "code": "Q96341300",
+          "label": "DoubleMoose Games"
+        },
+        {
+          "code": "Q96354890",
+          "label": "AtomicTorch Studio"
+        },
+        {
+          "code": "Q96754759",
+          "label": "Jankenteam"
+        },
+        {
+          "code": "Q95996836",
+          "label": "Yeda Games"
+        },
+        {
+          "code": "Q96651578",
+          "label": "Lightbulb Crew"
+        },
+        {
+          "code": "Q94988332",
+          "label": "Kotobaasobi"
+        },
+        {
+          "code": "Q94999785",
+          "label": "Coly"
+        },
+        {
+          "code": "Q95421298",
+          "label": "The Initiative"
+        },
+        {
+          "code": "Q95691020",
+          "label": "Betagames Group"
+        },
+        {
+          "code": "Q96177138",
+          "label": "Hi-Bit Studios"
+        },
+        {
+          "code": "Q96251413",
+          "label": "Corvostudio"
+        },
+        {
+          "code": "Q96371606",
+          "label": "Airship Syndicate"
+        },
+        {
+          "code": "Q96375821",
+          "label": "DECA Games"
+        },
+        {
+          "code": "Q96612282",
+          "label": "Nomad Games"
+        },
+        {
+          "code": "Q96644113",
+          "label": "Anic"
+        },
+        {
+          "code": "Q96044404",
+          "label": "Bugbyte"
+        },
+        {
+          "code": "Q96238190",
+          "label": "Neko Climax Studios"
+        },
+        {
+          "code": "Q96612086",
+          "label": "Liquid Games"
+        },
+        {
+          "code": "Q110572715",
+          "label": "Northplay"
+        },
+        {
+          "code": "Q110621943",
+          "label": "Origamihero Games"
+        },
+        {
+          "code": "Q110637170",
+          "label": "Guimaraf Studio"
+        },
+        {
+          "code": "Q110664249",
+          "label": "DQ Team"
+        },
+        {
+          "code": "Q110573194",
+          "label": "Pipetka Games"
+        },
+        {
+          "code": "Q110610007",
+          "label": "Gleamer Studio"
+        },
+        {
+          "code": "Q110628151",
+          "label": "ArticNet"
+        },
+        {
+          "code": "Q110645200",
+          "label": "Plitka Games"
+        },
+        {
+          "code": "Q110678177",
+          "label": "TLR Games"
+        },
+        {
+          "code": "Q110664214",
+          "label": "New Tales"
+        },
+        {
+          "code": "Q110589774",
+          "label": "Mighty Polygon"
+        },
+        {
+          "code": "Q110628445",
+          "label": "Creative Hand"
+        },
+        {
+          "code": "Q110653872",
+          "label": "P2 Entertainment"
+        },
+        {
+          "code": "Q110628422",
+          "label": "Silesia Games"
+        },
+        {
+          "code": "Q110651522",
+          "label": "Soleau Software"
+        },
+        {
+          "code": "Q110663398",
+          "label": "Artless Games"
+        },
+        {
+          "code": "Q110572331",
+          "label": "IndieRevo"
+        },
+        {
+          "code": "Q110573294",
+          "label": "Wizard Games"
+        },
+        {
+          "code": "Q110628308",
+          "label": "Drakkar Dev"
+        },
+        {
+          "code": "Q110637158",
+          "label": "Nibb Games"
+        },
+        {
+          "code": "Q110637367",
+          "label": "Leoful"
+        },
+        {
+          "code": "Q110670425",
+          "label": "Luden.io"
+        },
+        {
+          "code": "Q110690228",
+          "label": "Sibilant Interactive"
+        },
+        {
+          "code": "Q110645087",
+          "label": "2Awesome Studio"
+        },
+        {
+          "code": "Q110645094",
+          "label": "Cross Game Studio"
+        },
+        {
+          "code": "Q110664237",
+          "label": "2xMilk"
+        },
+        {
+          "code": "Q110571305",
+          "label": "Firi Games"
+        },
+        {
+          "code": "Q110573154",
+          "label": "Dev4Play"
+        },
+        {
+          "code": "Q110637274",
+          "label": "Repixel8"
+        },
+        {
+          "code": "Q110681058",
+          "label": "Turning Wheel LLC"
+        },
+        {
+          "code": "Q30597522",
+          "label": "Atooi"
+        },
+        {
+          "code": "Q30225692",
+          "label": "Hinterland Studio"
+        },
+        {
+          "code": "Q30149054",
+          "label": "Ankama Games"
+        },
+        {
+          "code": "Q30111892",
+          "label": "Iron Tower Studios"
+        },
+        {
+          "code": "Q30588185",
+          "label": "Bethesda Game Studios Dallas"
+        },
+        {
+          "code": "Q30639520",
+          "label": "Mango Protocol"
+        },
+        {
+          "code": "Q30247167",
+          "label": "Forgotten Empires"
+        },
+        {
+          "code": "Q30753174",
+          "label": "Discord Inc."
+        },
+        {
+          "code": "Q30223365",
+          "label": "Studio FOW"
+        },
+        {
+          "code": "Q30645414",
+          "label": "Snapshot Games"
+        },
+        {
+          "code": "Q4949049",
+          "label": "Bottle Rocket"
+        },
+        {
+          "code": "Q5050312",
+          "label": "Castle Thorn Software"
+        },
+        {
+          "code": "Q5072155",
+          "label": "Changyou"
+        },
+        {
+          "code": "Q5038922",
+          "label": "Career Soft"
+        },
+        {
+          "code": "Q5046774",
+          "label": "Carry Lab"
+        },
+        {
+          "code": "Q4974880",
+          "label": "Brooklyn Multimedia"
+        },
+        {
+          "code": "Q5020461",
+          "label": "California Dreams"
+        },
+        {
+          "code": "Q5031102",
+          "label": "Canalside Studios"
+        },
+        {
+          "code": "Q5065045",
+          "label": "Certain Affinity"
+        },
+        {
+          "code": "Q5038014",
+          "label": "Carbonated Games"
+        },
+        {
+          "code": "Q5037667",
+          "label": "Caramel Box"
+        },
+        {
+          "code": "Q5049616",
+          "label": "Castaway Entertainment"
+        },
+        {
+          "code": "Q5050990",
+          "label": "CatLab Interactive"
+        },
+        {
+          "code": "Q4967488",
+          "label": "Bright Star Technology"
+        },
+        {
+          "code": "Q5010013",
+          "label": "Idigicon Limited"
+        },
+        {
+          "code": "Q5015653",
+          "label": "Cable Software"
+        },
+        {
+          "code": "Q5013911",
+          "label": "CRL Group"
+        },
+        {
+          "code": "Q5042600",
+          "label": "TT Fusion"
+        },
+        {
+          "code": "Q5068045",
+          "label": "Chair Entertainment"
+        },
+        {
+          "code": "Q4949090",
+          "label": "Bottlerocket Entertainment"
+        },
+        {
+          "code": "Q4631829",
+          "label": "24 Caret Games"
+        },
+        {
+          "code": "Q4736447",
+          "label": "Alternative Games"
+        },
+        {
+          "code": "Q4700283",
+          "label": "Akaoni Studio"
+        },
+        {
+          "code": "Q4733343",
+          "label": "Allumer"
+        },
+        {
+          "code": "Q4736479",
+          "label": "Alternative Software"
+        },
+        {
+          "code": "Q4638890",
+          "label": "4D Rulers"
+        },
+        {
+          "code": "Q4673224",
+          "label": "Aces Studio"
+        },
+        {
+          "code": "Q4746762",
+          "label": "Project Siren"
+        },
+        {
+          "code": "Q4673616",
+          "label": "Acheron Design"
+        },
+        {
+          "code": "Q4734957",
+          "label": "AlphaSim"
+        },
+        {
+          "code": "Q4644252",
+          "label": "8-4"
+        },
+        {
+          "code": "Q4693572",
+          "label": "Agora Games"
+        },
+        {
+          "code": "Q4633251",
+          "label": "2XL Games"
+        },
+        {
+          "code": "Q4635982",
+          "label": "38 Studios"
+        },
+        {
+          "code": "Q4696605",
+          "label": "Aicom"
+        },
+        {
+          "code": "Q4726537",
+          "label": "Alientrap"
+        },
+        {
+          "code": "Q4639141",
+          "label": "4mm Games"
+        },
+        {
+          "code": "Q5611874",
+          "label": "Grubby Hands Limited"
+        },
+        {
+          "code": "Q5575439",
+          "label": "Shanda"
+        },
+        {
+          "code": "Q5574456",
+          "label": "Gnosis Games"
+        },
+        {
+          "code": "Q5582926",
+          "label": "Good Science Studio"
+        },
+        {
+          "code": "Q5647891",
+          "label": "Hangar 13"
+        },
+        {
+          "code": "Q5577387",
+          "label": "Gogii Games"
+        },
+        {
+          "code": "Q5586477",
+          "label": "Gorilla Systems"
+        },
+        {
+          "code": "Q5608149",
+          "label": "Grey Dog Software"
+        },
+        {
+          "code": "Q5646973",
+          "label": "HanbitSoft"
+        },
+        {
+          "code": "Q5647718",
+          "label": "HandyGames"
+        },
+        {
+          "code": "Q5573015",
+          "label": "GlyphX"
+        },
+        {
+          "code": "Q5615731",
+          "label": "Guild Software"
+        },
+        {
+          "code": "Q5609440",
+          "label": "Grinding Gear Games"
+        },
+        {
+          "code": "Q85668419",
+          "label": "MonkeyMoon"
+        },
+        {
+          "code": "Q85672318",
+          "label": "La Belle Games"
+        },
+        {
+          "code": "Q85747898",
+          "label": "Blue Wizard Digital"
+        },
+        {
+          "code": "Q85782658",
+          "label": "Luminous Productions"
+        },
+        {
+          "code": "Q85805488",
+          "label": "LCG Entertainment, Inc."
+        },
+        {
+          "code": "Q85813685",
+          "label": "WB Games San Francisco"
+        },
+        {
+          "code": "Q86661244",
+          "label": "Thing Trunk"
+        },
+        {
+          "code": "Q85633843",
+          "label": "BlackMuffin Studio"
+        },
+        {
+          "code": "Q85676628",
+          "label": "Sad Puppy"
+        },
+        {
+          "code": "Q85850231",
+          "label": "Auroch Digital"
+        },
+        {
+          "code": "Q86734975",
+          "label": "Access"
+        },
+        {
+          "code": "Q84618611",
+          "label": "Fan Visual"
+        },
+        {
+          "code": "Q85671146",
+          "label": "Magic Design Studios"
+        },
+        {
+          "code": "Q85531151",
+          "label": "Ilex Games"
+        },
+        {
+          "code": "Q85678252",
+          "label": "Oh Bibi"
+        },
+        {
+          "code": "Q85774833",
+          "label": "Kolibri Games"
+        },
+        {
+          "code": "Q85784621",
+          "label": "Meadows Games"
+        },
+        {
+          "code": "Q85795686",
+          "label": "Rainbite"
+        },
+        {
+          "code": "Q85868075",
+          "label": "WFS"
+        },
+        {
+          "code": "Q84493878",
+          "label": "Funomena"
+        },
+        {
+          "code": "Q86743193",
+          "label": "Brownies"
+        },
+        {
+          "code": "Q85607259",
+          "label": "Nexters"
+        },
+        {
+          "code": "Q85670471",
+          "label": "Alt Shift"
+        },
+        {
+          "code": "Q85742752",
+          "label": "Archetype Entertainment"
+        },
+        {
+          "code": "Q86690447",
+          "label": "KillHouse Games"
+        },
+        {
+          "code": "Q85517867",
+          "label": "ZoG forum team"
+        },
+        {
+          "code": "Q85670150",
+          "label": "Un pas fragile Team"
+        },
+        {
+          "code": "Q85805395",
+          "label": "Team Arcana"
+        },
+        {
+          "code": "Q4037769",
+          "label": "EA Bright Light"
+        },
+        {
+          "code": "Q4038563",
+          "label": "Fun Labs"
+        },
+        {
+          "code": "Q4039000",
+          "label": "Freeverse"
+        },
+        {
+          "code": "Q4041384",
+          "label": "Infinity Plus Two"
+        },
+        {
+          "code": "Q4042343",
+          "label": "KranX Productions"
+        },
+        {
+          "code": "Q4037990",
+          "label": "Elemental Games"
+        },
+        {
+          "code": "Q4040380",
+          "label": "Hammerware"
+        },
+        {
+          "code": "Q4040948",
+          "label": "I-Jet Media"
+        },
+        {
+          "code": "Q4042038",
+          "label": "Kaga Create"
+        },
+        {
+          "code": "Q4041742",
+          "label": "JV Games"
+        },
+        {
+          "code": "Q4039252",
+          "label": "Gamos"
+        },
+        {
+          "code": "Q4042609",
+          "label": "Larian Studios"
+        },
+        {
+          "code": "Q32904761",
+          "label": "Drool"
+        },
+        {
+          "code": "Q32860651",
+          "label": "Counterplay Games Inc."
+        },
+        {
+          "code": "Q32950935",
+          "label": "Yingpei Games"
+        },
+        {
+          "code": "Q32984827",
+          "label": "Frogmind"
+        },
+        {
+          "code": "Q32860616",
+          "label": "Stoic"
+        },
+        {
+          "code": "Q32860620",
+          "label": "Pixelbomb Games"
+        },
+        {
+          "code": "Q32860745",
+          "label": "Zillion Whales"
+        },
+        {
+          "code": "Q32904813",
+          "label": "Camel 101"
+        },
+        {
+          "code": "Q32904771",
+          "label": "Loiste Interactive"
+        },
+        {
+          "code": "Q32904821",
+          "label": "Nerial"
+        },
+        {
+          "code": "Q32955296",
+          "label": "Source Studio Ltd."
+        },
+        {
+          "code": "Q33008540",
+          "label": "Kurisu no Patto"
+        },
+        {
+          "code": "Q32860761",
+          "label": "Broken Rules"
+        },
+        {
+          "code": "Q32860744",
+          "label": "Waygetter Electronics"
+        },
+        {
+          "code": "Q32860749",
+          "label": "Terrible Toybox"
+        },
+        {
+          "code": "Q32860788",
+          "label": "Loren Lemcke"
+        },
+        {
+          "code": "Q32904743",
+          "label": "Pantera Entertainment"
+        },
+        {
+          "code": "Q32860647",
+          "label": "Misfits Attic"
+        },
+        {
+          "code": "Q32860656",
+          "label": "Drizzly Bear"
+        },
+        {
+          "code": "Q32860755",
+          "label": "Juggernaut Games"
+        },
+        {
+          "code": "Q32860753",
+          "label": "Pixel Titans"
+        },
+        {
+          "code": "Q32860775",
+          "label": "Eastshade Studios"
+        },
+        {
+          "code": "Q32904861",
+          "label": "Bits & Beasts"
+        },
+        {
+          "code": "Q32952178",
+          "label": "Tomkorp Computer Solutions Inc."
+        },
+        {
+          "code": "Q33005237",
+          "label": "Kumobius"
+        },
+        {
+          "code": "Q32860757",
+          "label": "Borealys Games"
+        },
+        {
+          "code": "Q32904814",
+          "label": "Art in Heart"
+        },
+        {
+          "code": "Q32904801",
+          "label": "Weappy Studio"
+        },
+        {
+          "code": "Q32904841",
+          "label": "Sassybot"
+        },
+        {
+          "code": "Q32904869",
+          "label": "Mindillusion"
+        },
+        {
+          "code": "Q32956292",
+          "label": "Octane Games"
+        },
+        {
+          "code": "Q32860748",
+          "label": "Driven Arts"
+        },
+        {
+          "code": "Q32955629",
+          "label": "WaterMelon"
+        },
+        {
+          "code": "Q32860618",
+          "label": "House House"
+        },
+        {
+          "code": "Q32860746",
+          "label": "Analgesic Productions"
+        },
+        {
+          "code": "Q32860731",
+          "label": "Giant Margarita"
+        },
+        {
+          "code": "Q32922682",
+          "label": "The Binary Mill"
+        },
+        {
+          "code": "Q32860777",
+          "label": "Nik Nak Studios"
+        },
+        {
+          "code": "Q32900502",
+          "label": "Wispfire"
+        },
+        {
+          "code": "Q32904874",
+          "label": "Swordtales"
+        },
+        {
+          "code": "Q32021960",
+          "label": "Thekla"
+        },
+        {
+          "code": "Q32860600",
+          "label": "Antagonist"
+        },
+        {
+          "code": "Q32038645",
+          "label": "Berzerk Studio"
+        },
+        {
+          "code": "Q32059975",
+          "label": "Aesir Interactive"
+        },
+        {
+          "code": "Q32060798",
+          "label": "Screeps"
+        },
+        {
+          "code": "Q32096370",
+          "label": "Samurai Punk"
+        },
+        {
+          "code": "Q32860574",
+          "label": "Osmotic Studios"
+        },
+        {
+          "code": "Q32037808",
+          "label": "Sukeban Games"
+        },
+        {
+          "code": "Q32039439",
+          "label": "Ntronium Games"
+        },
+        {
+          "code": "Q32059928",
+          "label": "Mechanical Butterfly Studios"
+        },
+        {
+          "code": "Q32059991",
+          "label": "Baroque Decay"
+        },
+        {
+          "code": "Q32094873",
+          "label": "Stormcloud Games"
+        },
+        {
+          "code": "Q32313041",
+          "label": "Caustic Creative"
+        },
+        {
+          "code": "Q32411635",
+          "label": "StarSystemStudios™"
+        },
+        {
+          "code": "Q32003426",
+          "label": "SOCKO! Entertainment"
+        },
+        {
+          "code": "Q31990228",
+          "label": "Urbanscan"
+        },
+        {
+          "code": "Q32003874",
+          "label": "Kronosaur Productions"
+        },
+        {
+          "code": "Q32020784",
+          "label": "sparsevector"
+        },
+        {
+          "code": "Q32096228",
+          "label": "Flying Helmet Games"
+        },
+        {
+          "code": "Q32410981",
+          "label": "Mothership Entertainment LLC"
+        },
+        {
+          "code": "Q32414970",
+          "label": "Brilliant Game Studios"
+        },
+        {
+          "code": "Q31999943",
+          "label": "Burst Studios"
+        },
+        {
+          "code": "Q32016413",
+          "label": "Shining Pixel Studios"
+        },
+        {
+          "code": "Q32020188",
+          "label": "ROCKFISH Games"
+        },
+        {
+          "code": "Q32060794",
+          "label": "Awaceb"
+        },
+        {
+          "code": "Q32060815",
+          "label": "Boxelware"
+        },
+        {
+          "code": "Q32313788",
+          "label": "Fantahorn Studio"
+        },
+        {
+          "code": "Q32414714",
+          "label": "Barrel Roll Games"
+        },
+        {
+          "code": "Q32415351",
+          "label": "Rupeck Games"
+        },
+        {
+          "code": "Q31984956",
+          "label": "Over the Top Games"
+        },
+        {
+          "code": "Q32025644",
+          "label": "Entrada Interactive LLC"
+        },
+        {
+          "code": "Q32039810",
+          "label": "Paperash studio"
+        },
+        {
+          "code": "Q32059956",
+          "label": "Rainbow Games"
+        },
+        {
+          "code": "Q32095024",
+          "label": "Split Polygon"
+        },
+        {
+          "code": "Q32096292",
+          "label": "JetCat Games"
+        },
+        {
+          "code": "Q32405336",
+          "label": "Miniboss"
+        },
+        {
+          "code": "Q32860566",
+          "label": "Team Fractal Alligator"
+        },
+        {
+          "code": "Q32059724",
+          "label": "Digital Cybercherries"
+        },
+        {
+          "code": "Q32094697",
+          "label": "Tim Conkling"
+        },
+        {
+          "code": "Q32860615",
+          "label": "Butterscotch Shenanigans"
+        },
+        {
+          "code": "Q32039346",
+          "label": "Zero Point Software"
+        },
+        {
+          "code": "Q32410014",
+          "label": "Kite Games"
+        },
+        {
+          "code": "Q32568590",
+          "label": "Hindarium"
+        },
+        {
+          "code": "Q24877463",
+          "label": "Onoma"
+        },
+        {
+          "code": "Q24707091",
+          "label": "Finji"
+        },
+        {
+          "code": "Q24836290",
+          "label": "Heluo Studio"
+        },
+        {
+          "code": "Q24908541",
+          "label": "704Games"
+        },
+        {
+          "code": "Q25024981",
+          "label": "CodeCombat"
+        },
+        {
+          "code": "Q24664854",
+          "label": "Sloclap"
+        },
+        {
+          "code": "Q24698820",
+          "label": "genDESIGN"
+        },
+        {
+          "code": "Q24869515",
+          "label": "Ape, Inc."
+        },
+        {
+          "code": "Q24867783",
+          "label": "Frill"
+        },
+        {
+          "code": "Q24695424",
+          "label": "Rain Games"
+        },
+        {
+          "code": "Q24909573",
+          "label": "Modoka"
+        },
+        {
+          "code": "Q24993540",
+          "label": "Antimatter Games"
+        },
+        {
+          "code": "Q24863123",
+          "label": "Madosoft"
+        },
+        {
+          "code": "Q24944835",
+          "label": "Morning Star Multimedia"
+        },
+        {
+          "code": "Q24840496",
+          "label": "Phoenix Media"
+        },
+        {
+          "code": "Q24702411",
+          "label": "Chart Top Design"
+        },
+        {
+          "code": "Q5132327",
+          "label": "Clever Trick"
+        },
+        {
+          "code": "Q5133643",
+          "label": "Climax Studios"
+        },
+        {
+          "code": "Q5140125",
+          "label": "Coded Illusions"
+        },
+        {
+          "code": "Q5160278",
+          "label": "Confounding Factor"
+        },
+        {
+          "code": "Q5167141",
+          "label": "Cooking Mama Limited"
+        },
+        {
+          "code": "Q5180559",
+          "label": "Crafts & Meister"
+        },
+        {
+          "code": "Q5165725",
+          "label": "Contrail"
+        },
+        {
+          "code": "Q5141434",
+          "label": "Cohort Studios"
+        },
+        {
+          "code": "Q5121432",
+          "label": "Circle Studio"
+        },
+        {
+          "code": "Q5139702",
+          "label": "Cocktail Soft"
+        },
+        {
+          "code": "Q5140142",
+          "label": "Codeminion"
+        },
+        {
+          "code": "Q5180324",
+          "label": "Crack dot Com"
+        },
+        {
+          "code": "Q5099356",
+          "label": "Chimera Entertainment"
+        },
+        {
+          "code": "Q5161811",
+          "label": "Melsoft Games"
+        },
+        {
+          "code": "Q5119226",
+          "label": "Ciberbit"
+        },
+        {
+          "code": "Q5163431",
+          "label": "Conspiracy Entertainment"
+        },
+        {
+          "code": "Q5179292",
+          "label": "Covert Operations Ltd"
+        },
+        {
+          "code": "Q5170290",
+          "label": "Coreplay"
+        },
+        {
+          "code": "Q5174029",
+          "label": "Cosmi Corporation"
+        },
+        {
+          "code": "Q4052639",
+          "label": "Venom Games"
+        },
+        {
+          "code": "Q4053599",
+          "label": "Zoetrope Interactive"
+        },
+        {
+          "code": "Q4052799",
+          "label": "Vortex Software"
+        },
+        {
+          "code": "Q4053573",
+          "label": "ZeptoLab"
+        },
+        {
+          "code": "Q4053329",
+          "label": "XPEC Entertainment"
+        },
+        {
+          "code": "Q4120690",
+          "label": "Hothead Games"
+        },
+        {
+          "code": "Q4120720",
+          "label": "Kuma Reality Games"
+        },
+        {
+          "code": "Q4117953",
+          "label": "EA Salt Lake"
+        },
+        {
+          "code": "Q4131576",
+          "label": "TT Games"
+        },
+        {
+          "code": "Q4052313",
+          "label": "Ubisoft Tiwak"
+        },
+        {
+          "code": "Q31633758",
+          "label": "WeirdBeard"
+        },
+        {
+          "code": "Q31641433",
+          "label": "Other Ocean Interactive"
+        },
+        {
+          "code": "Q31641880",
+          "label": "Sluggerfly"
+        },
+        {
+          "code": "Q31633667",
+          "label": "cloudcade"
+        },
+        {
+          "code": "Q31679001",
+          "label": "Geeta Games"
+        },
+        {
+          "code": "Q31744264",
+          "label": "Fully Bugged"
+        },
+        {
+          "code": "Q31967389",
+          "label": "PixelFade Inc"
+        },
+        {
+          "code": "Q31981980",
+          "label": "Sillysoft Games"
+        },
+        {
+          "code": "Q31636564",
+          "label": "Eight Points"
+        },
+        {
+          "code": "Q31638773",
+          "label": "LuGus Studios"
+        },
+        {
+          "code": "Q31670671",
+          "label": "Little Cat Feet"
+        },
+        {
+          "code": "Q31743430",
+          "label": "Hellscape Games"
+        },
+        {
+          "code": "Q31727687",
+          "label": "Three Phase Interactive Pty Ltd"
+        },
+        {
+          "code": "Q31738507",
+          "label": "Section Studios"
+        },
+        {
+          "code": "Q31980732",
+          "label": "SRF Games"
+        },
+        {
+          "code": "Q31632128",
+          "label": "Conatus Creative Inc."
+        },
+        {
+          "code": "Q31634701",
+          "label": "Elias Viglione"
+        },
+        {
+          "code": "Q31638165",
+          "label": "Everglow Interactive Inc."
+        },
+        {
+          "code": "Q31666674",
+          "label": "Mastfire Studios"
+        },
+        {
+          "code": "Q31678377",
+          "label": "CreativeForge Games"
+        },
+        {
+          "code": "Q31631075",
+          "label": "SmashGames"
+        },
+        {
+          "code": "Q31636160",
+          "label": "Fntastic"
+        },
+        {
+          "code": "Q31648743",
+          "label": "FlipSwitch Games"
+        },
+        {
+          "code": "Q31649058",
+          "label": "Milkstone Studios"
+        },
+        {
+          "code": "Q31666739",
+          "label": "Blind Squirrel Entertainment"
+        },
+        {
+          "code": "Q31726214",
+          "label": "A Sharp, LLC"
+        },
+        {
+          "code": "Q31744155",
+          "label": "G-OLD"
+        },
+        {
+          "code": "Q31969681",
+          "label": "ALICE IN DISSONANCE"
+        },
+        {
+          "code": "Q31969870",
+          "label": "Stray Fawn Studio"
+        },
+        {
+          "code": "Q31678473",
+          "label": "Silk Games"
+        },
+        {
+          "code": "Q31630015",
+          "label": "Stunlock Studios"
+        },
+        {
+          "code": "Q31649157",
+          "label": "Stegersaurus Software Inc."
+        },
+        {
+          "code": "Q31663580",
+          "label": "Red Candle Games"
+        },
+        {
+          "code": "Q31726546",
+          "label": "Broken Window Studios"
+        },
+        {
+          "code": "Q96970547",
+          "label": "Brave Bunny"
+        },
+        {
+          "code": "Q97061185",
+          "label": "Global Star Software"
+        },
+        {
+          "code": "Q97358217",
+          "label": "Soma Games"
+        },
+        {
+          "code": "Q97325212",
+          "label": "Coconut Island Games"
+        },
+        {
+          "code": "Q97172770",
+          "label": "World's Edge"
+        },
+        {
+          "code": "Q96771607",
+          "label": "The Game Band"
+        },
+        {
+          "code": "Q97097184",
+          "label": "3Division Entertainment"
+        },
+        {
+          "code": "Q97400272",
+          "label": "Gravity-i"
+        },
+        {
+          "code": "Q97348394",
+          "label": "Cotton Game"
+        },
+        {
+          "code": "Q97216565",
+          "label": "Gato Studio"
+        },
+        {
+          "code": "Q97230493",
+          "label": "SmartJoy"
+        },
+        {
+          "code": "Q97058830",
+          "label": "Pajama Llama Games"
+        },
+        {
+          "code": "Q97064697",
+          "label": "Pony Town Team"
+        },
+        {
+          "code": "Q97094228",
+          "label": "Freehold Games"
+        },
+        {
+          "code": "Q97183834",
+          "label": "Mega Cat Studios"
+        },
+        {
+          "code": "Q97400302",
+          "label": "Vimukti Technologies"
+        },
+        {
+          "code": "Q97460968",
+          "label": "Broken Arms Games"
+        },
+        {
+          "code": "Q97462693",
+          "label": "Nuclearvision Entertainment"
+        },
+        {
+          "code": "Q96774959",
+          "label": "Studio Élan"
+        },
+        {
+          "code": "Q97105238",
+          "label": "Wild Arts"
+        },
+        {
+          "code": "Q97337479",
+          "label": "Superhot Team"
+        },
+        {
+          "code": "Q97341465",
+          "label": "Red Stage Entertainment"
+        },
+        {
+          "code": "Q96761477",
+          "label": "Forgotten Hope Devs"
+        },
+        {
+          "code": "Q96782095",
+          "label": "Koalabs"
+        },
+        {
+          "code": "Q97300197",
+          "label": "NExT Studios"
+        },
+        {
+          "code": "Q97301884",
+          "label": "Guard Crush Games"
+        },
+        {
+          "code": "Q5969518",
+          "label": "ICE Software"
+        },
+        {
+          "code": "Q5972831",
+          "label": "iNiS"
+        },
+        {
+          "code": "Q5974149",
+          "label": "ISOTX"
+        },
+        {
+          "code": "Q6037149",
+          "label": "Inscape"
+        },
+        {
+          "code": "Q5950872",
+          "label": "Hutsell Computer War Games"
+        },
+        {
+          "code": "Q5994396",
+          "label": "IguanaBee"
+        },
+        {
+          "code": "Q6000619",
+          "label": "Illwinter Game Design"
+        },
+        {
+          "code": "Q6027756",
+          "label": "Industrial Toys"
+        },
+        {
+          "code": "Q6038702",
+          "label": "InstantAction"
+        },
+        {
+          "code": "Q5942495",
+          "label": "HuneX"
+        },
+        {
+          "code": "Q6107672",
+          "label": "JAM Productions"
+        },
+        {
+          "code": "Q5959087",
+          "label": "Hypnotix"
+        },
+        {
+          "code": "Q5972861",
+          "label": "IOMO"
+        },
+        {
+          "code": "Q6086454",
+          "label": "Isotope 244"
+        },
+        {
+          "code": "Q6002406",
+          "label": "ImaginEngine"
+        },
+        {
+          "code": "Q6004863",
+          "label": "Immersion Games"
+        },
+        {
+          "code": "Q6030727",
+          "label": "Information Global Service"
+        },
+        {
+          "code": "Q6083391",
+          "label": "Positech Games"
+        },
+        {
+          "code": "Q6028784",
+          "label": "Infamous Adventures"
+        },
+        {
+          "code": "Q6072534",
+          "label": "Iron Galaxy Studios"
+        },
+        {
+          "code": "Q111745438",
+          "label": "Asteroid Lab"
+        },
+        {
+          "code": "Q111754908",
+          "label": "Lab42"
+        },
+        {
+          "code": "Q111769138",
+          "label": "Lapovich Team"
+        },
+        {
+          "code": "Q111812469",
+          "label": "Portable Moose"
+        },
+        {
+          "code": "Q111812586",
+          "label": "Sky Machine Studios"
+        },
+        {
+          "code": "Q111820901",
+          "label": "Hashbane"
+        },
+        {
+          "code": "Q111893481",
+          "label": "Implausible Industries"
+        },
+        {
+          "code": "Q111659025",
+          "label": "Inputwish"
+        },
+        {
+          "code": "Q111693993",
+          "label": "PSR Outdoors"
+        },
+        {
+          "code": "Q111755756",
+          "label": "Three Legged Egg"
+        },
+        {
+          "code": "Q111782403",
+          "label": "The Nuttery Entertainment"
+        },
+        {
+          "code": "Q111821179",
+          "label": "Luminawesome Games"
+        },
+        {
+          "code": "Q111844933",
+          "label": "LAB132"
+        },
+        {
+          "code": "Q111854516",
+          "label": "Naisu"
+        },
+        {
+          "code": "Q111907295",
+          "label": "Revulo Games"
+        },
+        {
+          "code": "Q111743152",
+          "label": "Team Xonotic"
+        },
+        {
+          "code": "Q111845224",
+          "label": "AY Games"
+        },
+        {
+          "code": "Q111893468",
+          "label": "Sengi Games"
+        },
+        {
+          "code": "Q111659042",
+          "label": "Pixalon"
+        },
+        {
+          "code": "Q111743296",
+          "label": "Warsow team"
+        },
+        {
+          "code": "Q111845320",
+          "label": "Zerouno Games"
+        },
+        {
+          "code": "Q111907780",
+          "label": "Orube Game Studio"
+        },
+        {
+          "code": "Q111659050",
+          "label": "Plastic Reality Technologies"
+        },
+        {
+          "code": "Q111695372",
+          "label": "Rembrosoft"
+        },
+        {
+          "code": "Q111828591",
+          "label": "SP-time"
+        },
+        {
+          "code": "Q111854927",
+          "label": "Cloud M1"
+        },
+        {
+          "code": "Q111893265",
+          "label": "Storybird Studio"
+        },
+        {
+          "code": "Q111906629",
+          "label": "Wired Dreams Studios"
+        },
+        {
+          "code": "Q111661846",
+          "label": "Sprovieri Games"
+        },
+        {
+          "code": "Q111662872",
+          "label": "Sunwolf Entertainment"
+        },
+        {
+          "code": "Q111663299",
+          "label": "ABX Games Studio"
+        },
+        {
+          "code": "Q111906680",
+          "label": "Leikir Studio"
+        },
+        {
+          "code": "Q111693853",
+          "label": "Sabec Limited"
+        },
+        {
+          "code": "Q111721291",
+          "label": "Ogre Pixel"
+        },
+        {
+          "code": "Q111662882",
+          "label": "Cloisters Interactive"
+        },
+        {
+          "code": "Q111663525",
+          "label": "Radiangames"
+        },
+        {
+          "code": "Q111680657",
+          "label": "Nine Rocks Games"
+        },
+        {
+          "code": "Q111731992",
+          "label": "VectorStorm"
+        },
+        {
+          "code": "Q111782508",
+          "label": "Caipirinha Games"
+        },
+        {
+          "code": "Q111906689",
+          "label": "Metasepia Games"
+        },
+        {
+          "code": "Q111743178",
+          "label": "Turbo Pixel Studios"
+        },
+        {
+          "code": "Q111782064",
+          "label": "Dead Drop Studios"
+        },
+        {
+          "code": "Q111904372",
+          "label": "MegaPixel Studio"
+        },
+        {
+          "code": "Q111729690",
+          "label": "Spiral Circus"
+        },
+        {
+          "code": "Q110939110",
+          "label": "Nape Games"
+        },
+        {
+          "code": "Q110941257",
+          "label": "DAMAGE STATE"
+        },
+        {
+          "code": "Q110821432",
+          "label": "Flying Islands Team"
+        },
+        {
+          "code": "Q110828465",
+          "label": "6E6E6E"
+        },
+        {
+          "code": "Q110865130",
+          "label": "Xform Games"
+        },
+        {
+          "code": "Q110904630",
+          "label": "Valiant Game Studio"
+        },
+        {
+          "code": "Q110914363",
+          "label": "Square Root Studios"
+        },
+        {
+          "code": "Q110829829",
+          "label": "Hook Games"
+        },
+        {
+          "code": "Q110834793",
+          "label": "RandomSpin Games"
+        },
+        {
+          "code": "Q110834876",
+          "label": "Kistler Studios"
+        },
+        {
+          "code": "Q110865397",
+          "label": "EggNut"
+        },
+        {
+          "code": "Q110835023",
+          "label": "Pocket Piñata Interactive"
+        },
+        {
+          "code": "Q110864797",
+          "label": "Keybol Games"
+        },
+        {
+          "code": "Q110904797",
+          "label": "The Pixel Hunt"
+        },
+        {
+          "code": "Q110904949",
+          "label": "Meringue Interactive"
+        },
+        {
+          "code": "Q110970315",
+          "label": "Glob Games Studio"
+        },
+        {
+          "code": "Q110974481",
+          "label": "Abyte Entertainment"
+        },
+        {
+          "code": "Q110834768",
+          "label": "Cavyhouse"
+        },
+        {
+          "code": "Q110856547",
+          "label": "Door 407"
+        },
+        {
+          "code": "Q110866913",
+          "label": "SAT-BOX"
+        },
+        {
+          "code": "Q110868239",
+          "label": "5am Games"
+        },
+        {
+          "code": "Q110939267",
+          "label": "WhaleFood Games"
+        },
+        {
+          "code": "Q110817261",
+          "label": "Pipe studio"
+        },
+        {
+          "code": "Q110865864",
+          "label": "Hermes Interactive"
+        },
+        {
+          "code": "Q110866833",
+          "label": "Gamedia"
+        },
+        {
+          "code": "Q110867119",
+          "label": "STP WORKS"
+        },
+        {
+          "code": "Q110899036",
+          "label": "Tripod Studio"
+        },
+        {
+          "code": "Q110904598",
+          "label": "Pugware"
+        },
+        {
+          "code": "Q110920875",
+          "label": "historia"
+        },
+        {
+          "code": "Q110904904",
+          "label": "Iko"
+        },
+        {
+          "code": "Q110971082",
+          "label": "Fireart Games"
+        },
+        {
+          "code": "Q110972512",
+          "label": "Paradox Tinto"
+        },
+        {
+          "code": "Q110894842",
+          "label": "Hakama"
+        },
+        {
+          "code": "Q33436982",
+          "label": "Crackshell"
+        },
+        {
+          "code": "Q33438053",
+          "label": "Berserk Games"
+        },
+        {
+          "code": "Q33438677",
+          "label": "FreakZone Games"
+        },
+        {
+          "code": "Q33439073",
+          "label": "Phoenix Online Studios"
+        },
+        {
+          "code": "Q33326497",
+          "label": "3909"
+        },
+        {
+          "code": "Q33255668",
+          "label": "Destructive Creations"
+        },
+        {
+          "code": "Q33277867",
+          "label": "Nimbly Games"
+        },
+        {
+          "code": "Q33278279",
+          "label": "Mando productions"
+        },
+        {
+          "code": "Q33326306",
+          "label": "XII Games"
+        },
+        {
+          "code": "Q33327493",
+          "label": "Dead Mage"
+        },
+        {
+          "code": "Q33436427",
+          "label": "MoaCube"
+        },
+        {
+          "code": "Q33437793",
+          "label": "Steel Crate Games"
+        },
+        {
+          "code": "Q33252998",
+          "label": "Stroboskop"
+        },
+        {
+          "code": "Q33278403",
+          "label": "Zaratustra Productions"
+        },
+        {
+          "code": "Q33326051",
+          "label": "Noah System"
+        },
+        {
+          "code": "Q33326238",
+          "label": "EXOR Studios"
+        },
+        {
+          "code": "Q33436162",
+          "label": "QCF Design"
+        },
+        {
+          "code": "Q33440274",
+          "label": "Krillbite Studio"
+        },
+        {
+          "code": "Q33326196",
+          "label": "Final Form Games"
+        },
+        {
+          "code": "Q33326652",
+          "label": "Archive Entertainment"
+        },
+        {
+          "code": "Q33327484",
+          "label": "Smartly Dressed Games"
+        },
+        {
+          "code": "Q33436117",
+          "label": "Bit Planet Games, LLC"
+        },
+        {
+          "code": "Q33438888",
+          "label": "Blue Bottle Games"
+        },
+        {
+          "code": "Q33327402",
+          "label": "Senscape"
+        },
+        {
+          "code": "Q33438243",
+          "label": "Scientifically Proven"
+        },
+        {
+          "code": "Q33438646",
+          "label": "Eyebrow Interactive"
+        },
+        {
+          "code": "Q33438925",
+          "label": "Owl Cave"
+        },
+        {
+          "code": "Q33440368",
+          "label": "YOTSUBANE"
+        },
+        {
+          "code": "Q33278173",
+          "label": "Data Realms"
+        },
+        {
+          "code": "Q33327580",
+          "label": "Robot Loves Kitty"
+        },
+        {
+          "code": "Q33327330",
+          "label": "Schine, GmbH"
+        },
+        {
+          "code": "Q33438294",
+          "label": "SoftWarWare"
+        },
+        {
+          "code": "Q33440256",
+          "label": "Netcore Games"
+        },
+        {
+          "code": "Q33440556",
+          "label": "Zombie Panic Team"
+        },
+        {
+          "code": "Q33438189",
+          "label": "No Goblin"
+        },
+        {
+          "code": "Q33438728",
+          "label": "Black Pants Studio"
+        },
+        {
+          "code": "Q123850824",
+          "label": "The Dust"
+        },
+        {
+          "code": "Q123757734",
+          "label": "Illuvium"
+        },
+        {
+          "code": "Q123423826",
+          "label": "Yingpei games"
+        },
+        {
+          "code": "Q123423928",
+          "label": "Hero Game Studios"
+        },
+        {
+          "code": "Q123423937",
+          "label": "SuperInc."
+        },
+        {
+          "code": "Q123436226",
+          "label": "novamicus"
+        },
+        {
+          "code": "Q123438637",
+          "label": "Astrosnout"
+        },
+        {
+          "code": "Q123438717",
+          "label": "Digital Melody"
+        },
+        {
+          "code": "Q123463721",
+          "label": "Happy Juice Games"
+        },
+        {
+          "code": "Q123466459",
+          "label": "Beard Envy"
+        },
+        {
+          "code": "Q123471724",
+          "label": "Ammobox Studios"
+        },
+        {
+          "code": "Q123472046",
+          "label": "Circle Five Studios"
+        },
+        {
+          "code": "Q123472052",
+          "label": "Pub Games"
+        },
+        {
+          "code": "Q123472104",
+          "label": "800 North and Digital Ranch"
+        },
+        {
+          "code": "Q123472123",
+          "label": "Triternion"
+        },
+        {
+          "code": "Q123474616",
+          "label": "Hatinh Interactive"
+        },
+        {
+          "code": "Q123500016",
+          "label": "Dopamine Software"
+        },
+        {
+          "code": "Q123523209",
+          "label": "'am^up"
+        },
+        {
+          "code": "Q123527767",
+          "label": "Kid Onion Studio"
+        },
+        {
+          "code": "Q123558603",
+          "label": "PlayFTW"
+        },
+        {
+          "code": "Q123558802",
+          "label": "HitsNapp"
+        },
+        {
+          "code": "Q123559294",
+          "label": "Gamytech"
+        },
+        {
+          "code": "Q123561827",
+          "label": "Best Arabic Games"
+        },
+        {
+          "code": "Q123575695",
+          "label": "Lunheim Studios"
+        },
+        {
+          "code": "Q123581682",
+          "label": "Graviteam"
+        },
+        {
+          "code": "Q123585617",
+          "label": "Kit9 Studio"
+        },
+        {
+          "code": "Q123597861",
+          "label": "Neutronized"
+        },
+        {
+          "code": "Q123608436",
+          "label": "FourbitFriday"
+        },
+        {
+          "code": "Q123631798",
+          "label": "Komi Games Inc."
+        },
+        {
+          "code": "Q123656776",
+          "label": "Robust Games"
+        },
+        {
+          "code": "Q123661594",
+          "label": "Miga Games"
+        },
+        {
+          "code": "Q123678778",
+          "label": "Invincibles Studio"
+        },
+        {
+          "code": "Q123701356",
+          "label": "Studio Wheel"
+        },
+        {
+          "code": "Q123734788",
+          "label": "Yojoyco"
+        },
+        {
+          "code": "Q123739725",
+          "label": "Simula Games"
+        },
+        {
+          "code": "Q123741615",
+          "label": "Amazing Games"
+        },
+        {
+          "code": "Q123777034",
+          "label": "Eremite Games"
+        },
+        {
+          "code": "Q123915725",
+          "label": "SparkyTailGames"
+        },
+        {
+          "code": "Q123979602",
+          "label": "Immersive Games"
+        },
+        {
+          "code": "Q123989287",
+          "label": "Lizardry"
+        },
+        {
+          "code": "Q123995894",
+          "label": "A&F Software"
+        },
+        {
+          "code": "Q124005205",
+          "label": "Thirdverse"
+        },
+        {
+          "code": "Q124005821",
+          "label": "GameCrafterTeam"
+        },
+        {
+          "code": "Q124005823",
+          "label": "GameTomo"
+        },
+        {
+          "code": "Q124014057",
+          "label": "Echo Project"
+        },
+        {
+          "code": "Q124023511",
+          "label": "Elektrogames"
+        },
+        {
+          "code": "Q124045643",
+          "label": "Retro Army Limited"
+        },
+        {
+          "code": "Q124052584",
+          "label": "Unlimited Fly Games"
+        },
+        {
+          "code": "Q124056756",
+          "label": "StickyLock"
+        },
+        {
+          "code": "Q124060293",
+          "label": "Nyctophile Studios"
+        },
+        {
+          "code": "Q124130651",
+          "label": "Gulag Games"
+        },
+        {
+          "code": "Q124130660",
+          "label": "Kavkaz Sila Games"
+        },
+        {
+          "code": "Q124130667",
+          "label": "Regime X"
+        },
+        {
+          "code": "Q123474676",
+          "label": "Mischief"
+        },
+        {
+          "code": "Q123555173",
+          "label": "Live Wire"
+        },
+        {
+          "code": "Q4861844",
+          "label": "Barnhouse Effect"
+        },
+        {
+          "code": "Q4877287",
+          "label": "Beatshapers"
+        },
+        {
+          "code": "Q4894091",
+          "label": "Racjin"
+        },
+        {
+          "code": "Q4873091",
+          "label": "Bethesda Game Studios Austin"
+        },
+        {
+          "code": "Q4873135",
+          "label": "Battlefront.com"
+        },
+        {
+          "code": "Q4899973",
+          "label": "Beyond Games"
+        },
+        {
+          "code": "Q4890858",
+          "label": "Last Day of Work"
+        },
+        {
+          "code": "Q4892118",
+          "label": "Berkeley Systems"
+        },
+        {
+          "code": "Q4837535",
+          "label": "Babaroga"
+        },
+        {
+          "code": "Q4879926",
+          "label": "Beep Industries"
+        },
+        {
+          "code": "Q4873488",
+          "label": "Bauhaus Entertainment"
+        },
+        {
+          "code": "Q4876206",
+          "label": "Beamdog"
+        },
+        {
+          "code": "Q4844241",
+          "label": "Playlogic Entertainment"
+        },
+        {
+          "code": "Q4867458",
+          "label": "Basilisk Games"
+        },
+        {
+          "code": "Q4891719",
+          "label": "Bergsala Lightweight"
+        },
+        {
+          "code": "Q4893510",
+          "label": "Torus Games"
+        },
+        {
+          "code": "Q5514680",
+          "label": "GTE Interactive Media"
+        },
+        {
+          "code": "Q5516969",
+          "label": "GAIA Co."
+        },
+        {
+          "code": "Q5565886",
+          "label": "Givro"
+        },
+        {
+          "code": "Q5521793",
+          "label": "Gaps"
+        },
+        {
+          "code": "Q5531890",
+          "label": "General Entertainment"
+        },
+        {
+          "code": "Q5557341",
+          "label": "Ghostfire Games"
+        },
+        {
+          "code": "Q5519857",
+          "label": "Game Insight"
+        },
+        {
+          "code": "Q5515610",
+          "label": "Gabriel Entertainment"
+        },
+        {
+          "code": "Q5520034",
+          "label": "Gamenauts"
+        },
+        {
+          "code": "Q5520055",
+          "label": "Gamerizon"
+        },
+        {
+          "code": "Q5520107",
+          "label": "Games by Apollo"
+        },
+        {
+          "code": "Q5520130",
+          "label": "Gameshastra"
+        },
+        {
+          "code": "Q5533812",
+          "label": "Genuine Games"
+        },
+        {
+          "code": "Q5520409",
+          "label": "Gamtec"
+        },
+        {
+          "code": "Q5533267",
+          "label": "Genius Factor Games"
+        },
+        {
+          "code": "Q5519849",
+          "label": "Game Doctors"
+        },
+        {
+          "code": "Q7540260",
+          "label": "Slick Entertainment"
+        },
+        {
+          "code": "Q7547814",
+          "label": "Sniper Studios"
+        },
+        {
+          "code": "Q7582037",
+          "label": "Square One Studios"
+        },
+        {
+          "code": "Q7601065",
+          "label": "Star Vault"
+        },
+        {
+          "code": "Q7546644",
+          "label": "Smule"
+        },
+        {
+          "code": "Q7554405",
+          "label": "Soft-World International"
+        },
+        {
+          "code": "Q7565315",
+          "label": "Southend Interactive"
+        },
+        {
+          "code": "Q7577242",
+          "label": "Spil Games"
+        },
+        {
+          "code": "Q7538144",
+          "label": "Skyworks Interactive"
+        },
+        {
+          "code": "Q7554119",
+          "label": "Softkinetic"
+        },
+        {
+          "code": "Q7562512",
+          "label": "Loot Interactive, LLC"
+        },
+        {
+          "code": "Q7575852",
+          "label": "Spellborn International"
+        },
+        {
+          "code": "Q7577190",
+          "label": "Spike Chunsoft"
+        },
+        {
+          "code": "Q7547237",
+          "label": "SnapDragon Games"
+        },
+        {
+          "code": "Q7543950",
+          "label": "WildWorks"
+        },
+        {
+          "code": "Q7549915",
+          "label": "Sobee"
+        },
+        {
+          "code": "Q93671545",
+          "label": "Green Panda Games"
+        },
+        {
+          "code": "Q94649502",
+          "label": "ProjectMoon"
+        },
+        {
+          "code": "Q91125606",
+          "label": "Bloom Digital Media"
+        },
+        {
+          "code": "Q93500114",
+          "label": "Cold Beam Games"
+        },
+        {
+          "code": "Q91189296",
+          "label": "Mooneye Studios"
+        },
+        {
+          "code": "Q92009942",
+          "label": "Ratalaika Games"
+        },
+        {
+          "code": "Q92309919",
+          "label": "Stegosoft Games"
+        },
+        {
+          "code": "Q93671484",
+          "label": "Blue Mammoth Games"
+        },
+        {
+          "code": "Q91336645",
+          "label": "Redbeet Interactive"
+        },
+        {
+          "code": "Q92314272",
+          "label": "Anuken"
+        },
+        {
+          "code": "Q93671170",
+          "label": "1492 Studio"
+        },
+        {
+          "code": "Q93780169",
+          "label": "Systemic Reaction"
+        },
+        {
+          "code": "Q91620371",
+          "label": "Maddy Makes Games"
+        },
+        {
+          "code": "Q93723103",
+          "label": "Out of the Blue"
+        },
+        {
+          "code": "Q93499667",
+          "label": "Ebb Software"
+        },
+        {
+          "code": "Q93778796",
+          "label": "Neon Giant"
+        },
+        {
+          "code": "Q91624939",
+          "label": "Extremely OK Games"
+        },
+        {
+          "code": "Q93363404",
+          "label": "Relentless Studios"
+        },
+        {
+          "code": "Q93497501",
+          "label": "FYQD-Studio"
+        },
+        {
+          "code": "Q91167708",
+          "label": "Isojumper"
+        },
+        {
+          "code": "Q5769598",
+          "label": "Hired Gun"
+        },
+        {
+          "code": "Q5663878",
+          "label": "Alcachofa Soft"
+        },
+        {
+          "code": "Q5748611",
+          "label": "HexaDrive"
+        },
+        {
+          "code": "Q5909783",
+          "label": "Hot B"
+        },
+        {
+          "code": "Q5696520",
+          "label": "Hect"
+        },
+        {
+          "code": "Q5750244",
+          "label": "Hi-Rez Studios"
+        },
+        {
+          "code": "Q5792546",
+          "label": "Nimble Giant Entertainment"
+        },
+        {
+          "code": "Q5694471",
+          "label": "Heatwave Interactive"
+        },
+        {
+          "code": "Q5706052",
+          "label": "Heliotrope Studios"
+        },
+        {
+          "code": "Q5871728",
+          "label": "Hitcents"
+        },
+        {
+          "code": "Q5706964",
+          "label": "Hellbent Games"
+        },
+        {
+          "code": "Q5658652",
+          "label": "Harlequin Games"
+        },
+        {
+          "code": "Q5764967",
+          "label": "Himalaya Studios"
+        },
+        {
+          "code": "Q5652776",
+          "label": "Happy Happening"
+        },
+        {
+          "code": "Q5653765",
+          "label": "APF Electronics, Inc."
+        },
+        {
+          "code": "Q5748250",
+          "label": "Heuristic Park"
+        },
+        {
+          "code": "Q5909605",
+          "label": "HotGen"
+        },
+        {
+          "code": "Q111328660",
+          "label": "Happy Broccoli Games"
+        },
+        {
+          "code": "Q111442512",
+          "label": "Codebrew Games"
+        },
+        {
+          "code": "Q111517237",
+          "label": "I Got Games"
+        },
+        {
+          "code": "Q111588147",
+          "label": "Ambiera"
+        },
+        {
+          "code": "Q111598096",
+          "label": "Boogygames Studios"
+        },
+        {
+          "code": "Q111643845",
+          "label": "Amfich"
+        },
+        {
+          "code": "Q111311417",
+          "label": "Tortuga Team"
+        },
+        {
+          "code": "Q111342143",
+          "label": "34BigThings"
+        },
+        {
+          "code": "Q111508987",
+          "label": "Quarlellle"
+        },
+        {
+          "code": "Q111569867",
+          "label": "QuickBobber"
+        },
+        {
+          "code": "Q111579632",
+          "label": "LGT SIA"
+        },
+        {
+          "code": "Q111603660",
+          "label": "Avalon Digital"
+        },
+        {
+          "code": "Q111658994",
+          "label": "Falanxia"
+        },
+        {
+          "code": "Q111306616",
+          "label": "Isometricorp Games"
+        },
+        {
+          "code": "Q111539106",
+          "label": "Stray Bombay"
+        },
+        {
+          "code": "Q111599899",
+          "label": "LVGameDev"
+        },
+        {
+          "code": "Q111650902",
+          "label": "Cute Hannah's Games"
+        },
+        {
+          "code": "Q111307715",
+          "label": "Einzelartig Games"
+        },
+        {
+          "code": "Q111371047",
+          "label": "Santa Goat"
+        },
+        {
+          "code": "Q111377139",
+          "label": "Digital Tentacle"
+        },
+        {
+          "code": "Q111445136",
+          "label": "Shueisha Games"
+        },
+        {
+          "code": "Q111509866",
+          "label": "Bippinbits"
+        },
+        {
+          "code": "Q111658973",
+          "label": "Disney Mobile Games Studio"
+        },
+        {
+          "code": "Q111340786",
+          "label": "Axyos Games"
+        },
+        {
+          "code": "Q111450467",
+          "label": "Geography of Robots"
+        },
+        {
+          "code": "Q111457986",
+          "label": "Nukearts"
+        },
+        {
+          "code": "Q111525607",
+          "label": "Stegalosaurus Game Development"
+        },
+        {
+          "code": "Q111540630",
+          "label": "William at Oxford"
+        },
+        {
+          "code": "Q111541340",
+          "label": "Tessera Studios"
+        },
+        {
+          "code": "Q111648401",
+          "label": "Rosa Special Studio"
+        },
+        {
+          "code": "Q111649825",
+          "label": "Peaksel"
+        },
+        {
+          "code": "Q111653134",
+          "label": "Scarecrow Arts"
+        },
+        {
+          "code": "Q111307735",
+          "label": "Woblyware"
+        },
+        {
+          "code": "Q111369570",
+          "label": "Enigmatic Machines"
+        },
+        {
+          "code": "Q111465147",
+          "label": "Ransom Interactive"
+        },
+        {
+          "code": "Q111642798",
+          "label": "Piece Of Voxel"
+        },
+        {
+          "code": "Q111371055",
+          "label": "Miju Games"
+        },
+        {
+          "code": "Q111383269",
+          "label": "Turquoise Revival Games"
+        },
+        {
+          "code": "Q111525281",
+          "label": "Hosted Games"
+        },
+        {
+          "code": "Q111546120",
+          "label": "Wolfs Moon Studios"
+        },
+        {
+          "code": "Q111320713",
+          "label": "New Bridge Games"
+        },
+        {
+          "code": "Q111516144",
+          "label": "Bandai Namco Amusement"
+        },
+        {
+          "code": "Q111551109",
+          "label": "Boom Games"
+        },
+        {
+          "code": "Q7079654",
+          "label": "Offset Software"
+        },
+        {
+          "code": "Q7112051",
+          "label": "Outerra"
+        },
+        {
+          "code": "Q7113718",
+          "label": "Overkill Software"
+        },
+        {
+          "code": "Q7061841",
+          "label": "Nosotek"
+        },
+        {
+          "code": "Q7065431",
+          "label": "Now Production"
+        },
+        {
+          "code": "Q7067700",
+          "label": "NuFX"
+        },
+        {
+          "code": "Q7099623",
+          "label": "Orange Games"
+        },
+        {
+          "code": "Q7112063",
+          "label": "Outfit7"
+        },
+        {
+          "code": "Q7112876",
+          "label": "Outrage Games"
+        },
+        {
+          "code": "Q7064530",
+          "label": "Novel, Inc."
+        },
+        {
+          "code": "Q7090143",
+          "label": "OMGPop"
+        },
+        {
+          "code": "Q7100061",
+          "label": "Orbital Media"
+        },
+        {
+          "code": "Q7114879",
+          "label": "Owlchemy Labs"
+        },
+        {
+          "code": "Q7620131",
+          "label": "Storm Impact"
+        },
+        {
+          "code": "Q7622701",
+          "label": "Streamline Studios"
+        },
+        {
+          "code": "Q7620780",
+          "label": "Straandlooper"
+        },
+        {
+          "code": "Q7622597",
+          "label": "Straylight Studios"
+        },
+        {
+          "code": "Q7628162",
+          "label": "Studio Alex"
+        },
+        {
+          "code": "Q7628183",
+          "label": "Studio Gigante"
+        },
+        {
+          "code": "Q7642083",
+          "label": "SuperVillain Studios"
+        },
+        {
+          "code": "Q7644163",
+          "label": "Supersonic Software"
+        },
+        {
+          "code": "Q7634814",
+          "label": "Sugar Games"
+        },
+        {
+          "code": "Q7643396",
+          "label": "Supergiant Games"
+        },
+        {
+          "code": "Q7663606",
+          "label": "SystemSoft Alpha"
+        },
+        {
+          "code": "Q7663678",
+          "label": "System Sacom"
+        },
+        {
+          "code": "Q7630841",
+          "label": "Subatomic Studios"
+        },
+        {
+          "code": "Q7621384",
+          "label": "Strange Flavour"
+        },
+        {
+          "code": "Q7643992",
+          "label": "Supermono studios"
+        },
+        {
+          "code": "Q7623531",
+          "label": "Streum On Studio"
+        },
+        {
+          "code": "Q7641092",
+          "label": "Sunrise Interactive"
+        },
+        {
+          "code": "Q7644148",
+          "label": "Supersoft"
+        },
+        {
+          "code": "Q7622536",
+          "label": "Strawdog Studios"
+        },
+        {
+          "code": "Q7662724",
+          "label": "Synthetic Dimensions"
+        },
+        {
+          "code": "Q6778266",
+          "label": "Marvelous Entertainment"
+        },
+        {
+          "code": "Q6824407",
+          "label": "Metro3D"
+        },
+        {
+          "code": "Q6808967",
+          "label": "megazebra"
+        },
+        {
+          "code": "Q6839448",
+          "label": "Microdeal"
+        },
+        {
+          "code": "Q6843265",
+          "label": "Midway Austin"
+        },
+        {
+          "code": "Q6730810",
+          "label": "Magic Pixel Games"
+        },
+        {
+          "code": "Q6782763",
+          "label": "Nippon Computer Systems"
+        },
+        {
+          "code": "Q6805537",
+          "label": "Media Rings"
+        },
+        {
+          "code": "Q6839113",
+          "label": "MicroIllusions"
+        },
+        {
+          "code": "Q6727177",
+          "label": "Madfinger Games"
+        },
+        {
+          "code": "Q6751258",
+          "label": "Manomio"
+        },
+        {
+          "code": "Q6750574",
+          "label": "EA Seattle"
+        },
+        {
+          "code": "Q6843314",
+          "label": "Midway Studios – Los Angeles"
+        },
+        {
+          "code": "Q6843315",
+          "label": "Midway Studios – Newcastle"
+        },
+        {
+          "code": "Q126371686",
+          "label": "Ravinia"
+        },
+        {
+          "code": "Q126208235",
+          "label": "20:20"
+        },
+        {
+          "code": "Q126085569",
+          "label": "Nitrolic Games"
+        },
+        {
+          "code": "Q126085597",
+          "label": "Createasaurus"
+        },
+        {
+          "code": "Q126094842",
+          "label": "Tower Five"
+        },
+        {
+          "code": "Q126098750",
+          "label": "Playduction"
+        },
+        {
+          "code": "Q126155636",
+          "label": "GreenT"
+        },
+        {
+          "code": "Q126156543",
+          "label": "Hooligapps"
+        },
+        {
+          "code": "Q126160237",
+          "label": "Oxygene Media"
+        },
+        {
+          "code": "Q126168120",
+          "label": "Sparks Games"
+        },
+        {
+          "code": "Q126192224",
+          "label": "Momentum Labs Limited."
+        },
+        {
+          "code": "Q126194456",
+          "label": "Supadoge"
+        },
+        {
+          "code": "Q126194522",
+          "label": "Wheelmaker Studios"
+        },
+        {
+          "code": "Q126194809",
+          "label": "Homeschool Studios"
+        },
+        {
+          "code": "Q126198191",
+          "label": "F1 Licenceware"
+        },
+        {
+          "code": "Q126209297",
+          "label": "Funfia"
+        },
+        {
+          "code": "Q126209335",
+          "label": "3X Entertainment Limited"
+        },
+        {
+          "code": "Q126209423",
+          "label": "Funky_Forest"
+        },
+        {
+          "code": "Q126209941",
+          "label": "WolfTeamVN"
+        },
+        {
+          "code": "Q126279718",
+          "label": "Pon Pon Games"
+        },
+        {
+          "code": "Q126285446",
+          "label": "CCCP Games"
+        },
+        {
+          "code": "Q126324975",
+          "label": "Office Koukan"
+        },
+        {
+          "code": "Q126367101",
+          "label": "MonsterBox"
+        },
+        {
+          "code": "Q126372277",
+          "label": "Xiness"
+        },
+        {
+          "code": "Q126373655",
+          "label": "C Prompt Games"
+        },
+        {
+          "code": "Q126387618",
+          "label": "Cyber Rhino Studios"
+        },
+        {
+          "code": "Q126414201",
+          "label": "zerobyteorbit"
+        },
+        {
+          "code": "Q126441744",
+          "label": "Midnight Works"
+        },
+        {
+          "code": "Q126453632",
+          "label": "Yellow Brick Games"
+        },
+        {
+          "code": "Q126456578",
+          "label": "S-GAME"
+        },
+        {
+          "code": "Q126486797",
+          "label": "GAMETOTOP.CC"
+        },
+        {
+          "code": "Q126487134",
+          "label": "Soroka Games"
+        },
+        {
+          "code": "Q126487283",
+          "label": "Big Way"
+        },
+        {
+          "code": "Q126487835",
+          "label": "Terarin Games"
+        },
+        {
+          "code": "Q126488130",
+          "label": "HuCang"
+        },
+        {
+          "code": "Q126500936",
+          "label": "Billion Gaming Studio"
+        },
+        {
+          "code": "Q126563420",
+          "label": "Turbo Suslic EEE"
+        },
+        {
+          "code": "Q126563928",
+          "label": "Genius Studio Japan Inc."
+        },
+        {
+          "code": "Q126595349",
+          "label": "Twin Eagles Group"
+        },
+        {
+          "code": "Q126596480",
+          "label": "Astrosaurus Games"
+        },
+        {
+          "code": "Q126616148",
+          "label": "Quazar Studio"
+        },
+        {
+          "code": "Q126617158",
+          "label": "Bear Box Media"
+        },
+        {
+          "code": "Q126678227",
+          "label": "Ninja Pig Studios"
+        },
+        {
+          "code": "Q126687620",
+          "label": "Maestro Interactive Games"
+        },
+        {
+          "code": "Q126719665",
+          "label": "GenITeam LLC"
+        },
+        {
+          "code": "Q126720778",
+          "label": "ZNK Games"
+        },
+        {
+          "code": "Q126727419",
+          "label": "Playmeow Games"
+        },
+        {
+          "code": "Q126733240",
+          "label": "LumiNet Kft."
+        },
+        {
+          "code": "Q126811476",
+          "label": "Chaos Theory Games"
+        },
+        {
+          "code": "Q126888496",
+          "label": "Gentle Troll Entertainment"
+        },
+        {
+          "code": "Q126890393",
+          "label": "Apskeppet"
+        },
+        {
+          "code": "Q126942354",
+          "label": "Koei Tecmo Singapore"
+        },
+        {
+          "code": "Q126951810",
+          "label": "CatBellUnion"
+        },
+        {
+          "code": "Q126957608",
+          "label": "Cross Field Inc."
+        },
+        {
+          "code": "Q126962658",
+          "label": "Carbon Fire"
+        },
+        {
+          "code": "Q127162941",
+          "label": "kurenaibook"
+        },
+        {
+          "code": "Q127248971",
+          "label": "Alkterios Games"
+        },
+        {
+          "code": "Q127278010",
+          "label": "RetroStyle Games"
+        },
+        {
+          "code": "Q127278499",
+          "label": "Because Because Games"
+        },
+        {
+          "code": "Q127325376",
+          "label": "Krewe Studios"
+        },
+        {
+          "code": "Q127391441",
+          "label": "Tic Toc Games"
+        },
+        {
+          "code": "Q127416660",
+          "label": "Fast Travel Games"
+        },
+        {
+          "code": "Q127416733",
+          "label": "Virtual Air Guitar Company"
+        },
+        {
+          "code": "Q127424409",
+          "label": "Feral Cat Den"
+        },
+        {
+          "code": "Q127424476",
+          "label": "Endless Shirafu"
+        },
+        {
+          "code": "Q127424490",
+          "label": "Tianyu Studio Software"
+        },
+        {
+          "code": "Q126112065",
+          "label": "Rosetta"
+        },
+        {
+          "code": "Q126368056",
+          "label": "Laplacian"
+        },
+        {
+          "code": "Q77265397",
+          "label": "Screaming Villains"
+        },
+        {
+          "code": "Q84365321",
+          "label": "Nexile"
+        },
+        {
+          "code": "Q79285917",
+          "label": "Intelligent cat"
+        },
+        {
+          "code": "Q79870585",
+          "label": "Crystice Softworks"
+        },
+        {
+          "code": "Q81063275",
+          "label": "Beat Games"
+        },
+        {
+          "code": "Q83022860",
+          "label": "Daou Infosys"
+        },
+        {
+          "code": "Q83199637",
+          "label": "Team Antitribu"
+        },
+        {
+          "code": "Q83740889",
+          "label": "Red Nettle Studio"
+        },
+        {
+          "code": "Q76359404",
+          "label": "Pixel Error"
+        },
+        {
+          "code": "Q79402333",
+          "label": "Sharkmob"
+        },
+        {
+          "code": "Q75496169",
+          "label": "Sparse Game Development"
+        },
+        {
+          "code": "Q77369313",
+          "label": "Stumbling Cat"
+        },
+        {
+          "code": "Q77418206",
+          "label": "Skipmore"
+        },
+        {
+          "code": "Q77711263",
+          "label": "VOID Interactive"
+        },
+        {
+          "code": "Q77741856",
+          "label": "Y/CJ/Y"
+        },
+        {
+          "code": "Q79354446",
+          "label": "Trilum Studios"
+        },
+        {
+          "code": "Q80116485",
+          "label": "Landka"
+        },
+        {
+          "code": "Q82792413",
+          "label": "Tuxedo Labs"
+        },
+        {
+          "code": "Q84322247",
+          "label": "elle-murakami"
+        },
+        {
+          "code": "Q79954040",
+          "label": "Storm in a Teacup"
+        },
+        {
+          "code": "Q76887630",
+          "label": "Actual Humans"
+        },
+        {
+          "code": "Q77654046",
+          "label": "Universally Speaking Ltd."
+        },
+        {
+          "code": "Q77739480",
+          "label": "Soverance Studios"
+        },
+        {
+          "code": "Q77886066",
+          "label": "SimulaM"
+        },
+        {
+          "code": "Q78093922",
+          "label": "KainHauld"
+        },
+        {
+          "code": "Q75672726",
+          "label": "Devil Kitty Games"
+        },
+        {
+          "code": "Q76349217",
+          "label": "Placeholder Gameworks"
+        },
+        {
+          "code": "Q77985915",
+          "label": "Parsec Productions"
+        },
+        {
+          "code": "Q78502663",
+          "label": "Programmers-3, Inc."
+        },
+        {
+          "code": "Q79402321",
+          "label": "Divinity Studios"
+        },
+        {
+          "code": "Q76212327",
+          "label": "Pine Street Codeworks"
+        },
+        {
+          "code": "Q75834278",
+          "label": "Twisted Tree Games"
+        },
+        {
+          "code": "Q76529733",
+          "label": "Tea & Cake Games"
+        },
+        {
+          "code": "Q111016910",
+          "label": "Kodots Games"
+        },
+        {
+          "code": "Q111128210",
+          "label": "Abrakam"
+        },
+        {
+          "code": "Q111149290",
+          "label": "Cleversan Games"
+        },
+        {
+          "code": "Q111268167",
+          "label": "CodeParade"
+        },
+        {
+          "code": "Q111188621",
+          "label": "Lienzo"
+        },
+        {
+          "code": "Q111129009",
+          "label": "Tinymoon"
+        },
+        {
+          "code": "Q111248845",
+          "label": "Playwing"
+        },
+        {
+          "code": "Q111255230",
+          "label": "Crisp App Studio"
+        },
+        {
+          "code": "Q110978930",
+          "label": "TPP Studio"
+        },
+        {
+          "code": "Q111053350",
+          "label": "Firepunchd"
+        },
+        {
+          "code": "Q111132835",
+          "label": "Blazing Griffin"
+        },
+        {
+          "code": "Q111133256",
+          "label": "Triple.B.Titles"
+        },
+        {
+          "code": "Q111163149",
+          "label": "Silverware Games"
+        },
+        {
+          "code": "Q111023638",
+          "label": "Spiral Game Studios"
+        },
+        {
+          "code": "Q111127316",
+          "label": "Blazing Planet Studio"
+        },
+        {
+          "code": "Q111249753",
+          "label": "DeepWell Digital Therapeutics"
+        },
+        {
+          "code": "Q111260293",
+          "label": "ThinkOfGames"
+        },
+        {
+          "code": "Q111271406",
+          "label": "Skywall Studios"
+        },
+        {
+          "code": "Q111273676",
+          "label": "BitBull"
+        },
+        {
+          "code": "Q111017679",
+          "label": "Noobz from Poland"
+        },
+        {
+          "code": "Q111267804",
+          "label": "Cozy Bee Games"
+        },
+        {
+          "code": "Q111271835",
+          "label": "MyDearest"
+        },
+        {
+          "code": "Q111033892",
+          "label": "B&W Studios"
+        },
+        {
+          "code": "Q111132753",
+          "label": "Mighty Kingdom"
+        },
+        {
+          "code": "Q111152464",
+          "label": "Glee-Cheese Studio"
+        },
+        {
+          "code": "Q111179100",
+          "label": "GirlGames"
+        },
+        {
+          "code": "Q111305529",
+          "label": "Rocket Panda Games"
+        },
+        {
+          "code": "Q111183849",
+          "label": "Loki"
+        },
+        {
+          "code": "Q111273535",
+          "label": "1P2P Studio"
+        },
+        {
+          "code": "Q111305623",
+          "label": "Pippin Games"
+        },
+        {
+          "code": "Q111242126",
+          "label": "FMC"
+        },
+        {
+          "code": "Q111242520",
+          "label": "Soleil"
+        },
+        {
+          "code": "Q110990764",
+          "label": "PINIX"
+        },
+        {
+          "code": "Q111187025",
+          "label": "Project Helius"
+        },
+        {
+          "code": "Q5412689",
+          "label": "European Integration Studio"
+        },
+        {
+          "code": "Q5473011",
+          "label": "Fortyfive"
+        },
+        {
+          "code": "Q5509410",
+          "label": "Funtactix"
+        },
+        {
+          "code": "Q5451391",
+          "label": "Fire Maple Games"
+        },
+        {
+          "code": "Q5451759",
+          "label": "Firebrand Games"
+        },
+        {
+          "code": "Q5454636",
+          "label": "Fish in a Bottle"
+        },
+        {
+          "code": "Q5505786",
+          "label": "Front Fareast Industrial"
+        },
+        {
+          "code": "Q5449303",
+          "label": "FinBlade"
+        },
+        {
+          "code": "Q5453814",
+          "label": "First Star Software"
+        },
+        {
+          "code": "Q5506283",
+          "label": "Frozen Codebase"
+        },
+        {
+          "code": "Q5437526",
+          "label": "Fathammer"
+        },
+        {
+          "code": "Q5437954",
+          "label": "Fatshark"
+        },
+        {
+          "code": "Q5441909",
+          "label": "Feline Fuelled Games"
+        },
+        {
+          "code": "Q5499833",
+          "label": "Free Fall Associates"
+        },
+        {
+          "code": "Q5502917",
+          "label": "FreshGames"
+        },
+        {
+          "code": "Q5382500",
+          "label": "Epicenter Studios"
+        },
+        {
+          "code": "Q5420255",
+          "label": "Exient Entertainment"
+        },
+        {
+          "code": "Q5505524",
+          "label": "From The Bench Digital Entertainment"
+        },
+        {
+          "code": "Q5377810",
+          "label": "Engineering Animation"
+        },
+        {
+          "code": "Q5420341",
+          "label": "Exis Interactive"
+        },
+        {
+          "code": "Q5475149",
+          "label": "Four Door Lemon"
+        },
+        {
+          "code": "Q5501698",
+          "label": "French-Bread"
+        },
+        {
+          "code": "Q131465111",
+          "label": "Bullhead"
+        },
+        {
+          "code": "Q131451546",
+          "label": "XFLAG"
+        },
+        {
+          "code": "Q131467247",
+          "label": "Rumblesushi"
+        },
+        {
+          "code": "Q131369789",
+          "label": "PiXEL"
+        },
+        {
+          "code": "Q131382606",
+          "label": "Octeto Studios"
+        },
+        {
+          "code": "Q131386471",
+          "label": "Byterunners"
+        },
+        {
+          "code": "Q131388415",
+          "label": "3R Games"
+        },
+        {
+          "code": "Q131392479",
+          "label": "Infold Games"
+        },
+        {
+          "code": "Q131405441",
+          "label": "Studio Halftone Dot"
+        },
+        {
+          "code": "Q131405883",
+          "label": "Hentopia"
+        },
+        {
+          "code": "Q131406244",
+          "label": "Maker製造機"
+        },
+        {
+          "code": "Q131406249",
+          "label": "Mango Party News"
+        },
+        {
+          "code": "Q131406308",
+          "label": "SiGMAGURO"
+        },
+        {
+          "code": "Q131406825",
+          "label": "Modern Microware"
+        },
+        {
+          "code": "Q131411246",
+          "label": "Darkwinter Software"
+        },
+        {
+          "code": "Q131436457",
+          "label": "Oh Baby Games"
+        },
+        {
+          "code": "Q131437009",
+          "label": "Freeciv Team"
+        },
+        {
+          "code": "Q131438694",
+          "label": "TreesPlease Games"
+        },
+        {
+          "code": "Q131447669",
+          "label": "Fairy Mount Games"
+        },
+        {
+          "code": "Q131449401",
+          "label": "Sikalosoft"
+        },
+        {
+          "code": "Q131462995",
+          "label": "Leenzee"
+        },
+        {
+          "code": "Q131471282",
+          "label": "Monster and Monster"
+        },
+        {
+          "code": "Q131521233",
+          "label": "Femdom Wife Game"
+        },
+        {
+          "code": "Q131544540",
+          "label": "SaliaCoel"
+        },
+        {
+          "code": "Q131564196",
+          "label": "Rubberbrain"
+        },
+        {
+          "code": "Q131574490",
+          "label": "Morphcat Games"
+        },
+        {
+          "code": "Q131606373",
+          "label": "Amistech Games"
+        },
+        {
+          "code": "Q131607303",
+          "label": "Other Tales Interactive"
+        },
+        {
+          "code": "Q131619845",
+          "label": "À la mode games"
+        },
+        {
+          "code": "Q131630200",
+          "label": "PleasurePixels"
+        },
+        {
+          "code": "Q131697947",
+          "label": "THQ Montreal"
+        },
+        {
+          "code": "Q131704206",
+          "label": "念念而忘(Indelible Studio)"
+        },
+        {
+          "code": "Q131721146",
+          "label": "Bandai Namco Studios Vancouver"
+        },
+        {
+          "code": "Q131732881",
+          "label": "Kotake Create"
+        },
+        {
+          "code": "Q131824769",
+          "label": "Trashmasters"
+        },
+        {
+          "code": "Q131827283",
+          "label": "Red Pipe Studios"
+        },
+        {
+          "code": "Q131863916",
+          "label": "Hidden Variable Studios"
+        },
+        {
+          "code": "Q131912089",
+          "label": "Ubisoft Mainz"
+        },
+        {
+          "code": "Q131924377",
+          "label": "BattleBrew Productions"
+        },
+        {
+          "code": "Q131935444",
+          "label": "Hyperspace Cowgirls"
+        },
+        {
+          "code": "Q131823559",
+          "label": "AIHASTO"
+        },
+        {
+          "code": "Q131940377",
+          "label": "East Technology Corp."
+        },
+        {
+          "code": "Q131980577",
+          "label": "Tamarin Studios"
+        },
+        {
+          "code": "Q131983907",
+          "label": "CrazyFoot Gamestudio B.V."
+        },
+        {
+          "code": "Q131986115",
+          "label": "Sandfall Interactive"
+        },
+        {
+          "code": "Q132042013",
+          "label": "GameFactory"
+        },
+        {
+          "code": "Q132146206",
+          "label": "Bureau 81"
+        },
+        {
+          "code": "Q132146469",
+          "label": "Realcast"
+        },
+        {
+          "code": "Q132156291",
+          "label": "Playbrains"
+        },
+        {
+          "code": "Q132195943",
+          "label": "Everbyte"
+        },
+        {
+          "code": "Q124662494",
+          "label": "Sporty Peppers"
+        },
+        {
+          "code": "Q124669538",
+          "label": "Touch of Magic"
+        },
+        {
+          "code": "Q124986163",
+          "label": "Northern Lights Entertainment"
+        },
+        {
+          "code": "Q124300444",
+          "label": "The Second Future"
+        },
+        {
+          "code": "Q124300445",
+          "label": "Think!Ware Development"
+        },
+        {
+          "code": "Q124302374",
+          "label": "Smallthing Studios"
+        },
+        {
+          "code": "Q124303820",
+          "label": "GameChanger Studio"
+        },
+        {
+          "code": "Q124303826",
+          "label": "Deadpan Games"
+        },
+        {
+          "code": "Q124304157",
+          "label": "Mintrocket"
+        },
+        {
+          "code": "Q124304303",
+          "label": "Michel Rho"
+        },
+        {
+          "code": "Q124358653",
+          "label": "Sungrand Studios"
+        },
+        {
+          "code": "Q124391223",
+          "label": "Bow3 Games"
+        },
+        {
+          "code": "Q124394520",
+          "label": "Cyclone Zero"
+        },
+        {
+          "code": "Q124408797",
+          "label": "Downsideup Games"
+        },
+        {
+          "code": "Q124413123",
+          "label": "8sec"
+        },
+        {
+          "code": "Q124435687",
+          "label": "Lustration Team"
+        },
+        {
+          "code": "Q124463686",
+          "label": "Lucky Kat Studios"
+        },
+        {
+          "code": "Q124476962",
+          "label": "realfun studio"
+        },
+        {
+          "code": "Q124520009",
+          "label": "Gammera Nest"
+        },
+        {
+          "code": "Q124540986",
+          "label": "Supra Games"
+        },
+        {
+          "code": "Q124542445",
+          "label": "StudioBando"
+        },
+        {
+          "code": "Q124550695",
+          "label": "Max Inferno"
+        },
+        {
+          "code": "Q124562300",
+          "label": "Brightrock Games"
+        },
+        {
+          "code": "Q124614788",
+          "label": "Nightrider Software"
+        },
+        {
+          "code": "Q124614974",
+          "label": "Mentrox Goldline"
+        },
+        {
+          "code": "Q124615418",
+          "label": "Pantheon Software"
+        },
+        {
+          "code": "Q124662596",
+          "label": "Fireplace Games"
+        },
+        {
+          "code": "Q124666295",
+          "label": "HexyArts"
+        },
+        {
+          "code": "Q124668370",
+          "label": "SofterCode"
+        },
+        {
+          "code": "Q124688873",
+          "label": "Serious Sim"
+        },
+        {
+          "code": "Q124706029",
+          "label": "Nacon Studio Milan"
+        },
+        {
+          "code": "Q124707701",
+          "label": "Kodii Systems"
+        },
+        {
+          "code": "Q124717390",
+          "label": "Big Head Games"
+        },
+        {
+          "code": "Q124749583",
+          "label": "3583 Bytes"
+        },
+        {
+          "code": "Q124790089",
+          "label": "Un Je Ne Sais Quoi"
+        },
+        {
+          "code": "Q124818511",
+          "label": "Studio 397"
+        },
+        {
+          "code": "Q124830497",
+          "label": "Goca Games"
+        },
+        {
+          "code": "Q124831033",
+          "label": "Sketchbook Games"
+        },
+        {
+          "code": "Q124989109",
+          "label": "PORTANIS"
+        },
+        {
+          "code": "Q124999689",
+          "label": "Mad Mike Production"
+        },
+        {
+          "code": "Q125000371",
+          "label": "fap girls"
+        },
+        {
+          "code": "Q125117497",
+          "label": "Bonte Avond"
+        },
+        {
+          "code": "Q125134585",
+          "label": "Zodiac Interactive"
+        },
+        {
+          "code": "Q125282805",
+          "label": "Demihumans"
+        },
+        {
+          "code": "Q124373275",
+          "label": "Stardust"
+        },
+        {
+          "code": "Q124681194",
+          "label": "Acronym"
+        },
+        {
+          "code": "Q124309817",
+          "label": "Drifter"
+        },
+        {
+          "code": "Q124998413",
+          "label": "MOM"
+        },
+        {
+          "code": "Q124726356",
+          "label": "indie game developer"
+        },
+        {
+          "code": "Q33198629",
+          "label": "Mode 7"
+        },
+        {
+          "code": "Q33198776",
+          "label": "Spooky Squid Games Inc."
+        },
+        {
+          "code": "Q33245968",
+          "label": "Haruneko Entertainment"
+        },
+        {
+          "code": "Q33247388",
+          "label": "Prism Studios"
+        },
+        {
+          "code": "Q33247668",
+          "label": "Royal Troupe"
+        },
+        {
+          "code": "Q33248139",
+          "label": "Cellar Door Games"
+        },
+        {
+          "code": "Q33248337",
+          "label": "BeautiFun Games"
+        },
+        {
+          "code": "Q33252636",
+          "label": "Lostwood"
+        },
+        {
+          "code": "Q33252883",
+          "label": "Indomitus Games"
+        },
+        {
+          "code": "Q33252900",
+          "label": "Ludeon Studios"
+        },
+        {
+          "code": "Q33198768",
+          "label": "Blind Mind Studios"
+        },
+        {
+          "code": "Q33198804",
+          "label": "Untame"
+        },
+        {
+          "code": "Q33247617",
+          "label": "Aterdux Entertainment"
+        },
+        {
+          "code": "Q33248034",
+          "label": "Big Sandwich Games"
+        },
+        {
+          "code": "Q33248046",
+          "label": "Eden Industries"
+        },
+        {
+          "code": "Q33252890",
+          "label": "Santa Ragione"
+        },
+        {
+          "code": "Q33198825",
+          "label": "MiniVisions"
+        },
+        {
+          "code": "Q33246120",
+          "label": "Terrible Posture Games"
+        },
+        {
+          "code": "Q33198714",
+          "label": "Black Market Games"
+        },
+        {
+          "code": "Q33198746",
+          "label": "Ivy Games"
+        },
+        {
+          "code": "Q33245901",
+          "label": "Vogelsap"
+        },
+        {
+          "code": "Q33245983",
+          "label": "the whale husband"
+        },
+        {
+          "code": "Q33248319",
+          "label": "JoyMasher"
+        },
+        {
+          "code": "Q33252651",
+          "label": "Wild Games Studio"
+        },
+        {
+          "code": "Q33252873",
+          "label": "Puny Human"
+        },
+        {
+          "code": "Q33252906",
+          "label": "Metalhead Software Inc."
+        },
+        {
+          "code": "Q33198519",
+          "label": "Playsaurus"
+        },
+        {
+          "code": "Q33198731",
+          "label": "Moonpod"
+        },
+        {
+          "code": "Q33248039",
+          "label": "Krystian Majewski"
+        },
+        {
+          "code": "Q33248058",
+          "label": "Team Psykskallar"
+        },
+        {
+          "code": "Q33248278",
+          "label": "Suspicious Developments"
+        },
+        {
+          "code": "Q33248026",
+          "label": "8monkey Labs"
+        },
+        {
+          "code": "Q33248159",
+          "label": "Messhof"
+        },
+        {
+          "code": "Q33252807",
+          "label": "Incandescent Imaging"
+        },
+        {
+          "code": "Q33252867",
+          "label": "League of Geeks"
+        },
+        {
+          "code": "Q33198526",
+          "label": "IMGN.PRO"
+        },
+        {
+          "code": "Q33247613",
+          "label": "Numantian Games"
+        },
+        {
+          "code": "Q33247583",
+          "label": "Whalenought Studios"
+        },
+        {
+          "code": "Q33252564",
+          "label": "MagicalTimeBean"
+        },
+        {
+          "code": "Q33252897",
+          "label": "Minor Key Games"
+        },
+        {
+          "code": "Q7365709",
+          "label": "Ronimo Games"
+        },
+        {
+          "code": "Q7418926",
+          "label": "Sanritsu Denki"
+        },
+        {
+          "code": "Q7424694",
+          "label": "Saru Brunei"
+        },
+        {
+          "code": "Q7416412",
+          "label": "Sandlot"
+        },
+        {
+          "code": "Q7444033",
+          "label": "Secret Lab"
+        },
+        {
+          "code": "Q7446140",
+          "label": "SegaSoft"
+        },
+        {
+          "code": "Q7379839",
+          "label": "Runecraft"
+        },
+        {
+          "code": "Q7419411",
+          "label": "Santa Cruz Games"
+        },
+        {
+          "code": "Q7427715",
+          "label": "Savage Entertainment"
+        },
+        {
+          "code": "Q7355138",
+          "label": "Rocket Science Games"
+        },
+        {
+          "code": "Q7377918",
+          "label": "Rockstar Dundee"
+        },
+        {
+          "code": "Q7416415",
+          "label": "Sandlot Games"
+        },
+        {
+          "code": "Q7420737",
+          "label": "Sanuk Games"
+        },
+        {
+          "code": "Q7430638",
+          "label": "Scavenger, Inc."
+        },
+        {
+          "code": "Q7444025",
+          "label": "Secret Identity Studios"
+        },
+        {
+          "code": "Q7355080",
+          "label": "RocketOwl Inc."
+        },
+        {
+          "code": "Q7415719",
+          "label": "Sanctuary Woods"
+        },
+        {
+          "code": "Q7439465",
+          "label": "Sculptured Software"
+        },
+        {
+          "code": "Q5198876",
+          "label": "Cyclone Studios"
+        },
+        {
+          "code": "Q5265081",
+          "label": "Destan Entertainment"
+        },
+        {
+          "code": "Q5275848",
+          "label": "Digital Eel"
+        },
+        {
+          "code": "Q5183635",
+          "label": "Creature Labs"
+        },
+        {
+          "code": "Q5189157",
+          "label": "CrowdStar"
+        },
+        {
+          "code": "Q5191169",
+          "label": "Crystal Computing"
+        },
+        {
+          "code": "Q5200430",
+          "label": "Cypronia"
+        },
+        {
+          "code": "Q5202466",
+          "label": "Céidot Game Studios"
+        },
+        {
+          "code": "Q5275953",
+          "label": "Digital Praise"
+        },
+        {
+          "code": "Q5223216",
+          "label": "Dark Energy Digital"
+        },
+        {
+          "code": "Q5256334",
+          "label": "Demonware"
+        },
+        {
+          "code": "Q5281433",
+          "label": "Dischan Media"
+        },
+        {
+          "code": "Q5182605",
+          "label": "Crate Entertainment"
+        },
+        {
+          "code": "Q5265583",
+          "label": "Detalion"
+        },
+        {
+          "code": "Q5275905",
+          "label": "Digital Leisure"
+        },
+        {
+          "code": "Q5227155",
+          "label": "Data Design Interactive"
+        },
+        {
+          "code": "Q5183310",
+          "label": "Crea-Tech"
+        },
+        {
+          "code": "Q5243118",
+          "label": "Daydream Software"
+        },
+        {
+          "code": "Q5245591",
+          "label": "Deadline Games"
+        },
+        {
+          "code": "Q5275800",
+          "label": "Digital Capital Corporation"
+        },
+        {
+          "code": "Q7169533",
+          "label": "Perpetual Entertainment"
+        },
+        {
+          "code": "Q7203501",
+          "label": "Playnormous"
+        },
+        {
+          "code": "Q7225751",
+          "label": "Pollux Gamelabs"
+        },
+        {
+          "code": "Q7170779",
+          "label": "Persuasive Games"
+        },
+        {
+          "code": "Q7180503",
+          "label": "Phantagram"
+        },
+        {
+          "code": "Q7231501",
+          "label": "Portalarium"
+        },
+        {
+          "code": "Q7250166",
+          "label": "Proper Games"
+        },
+        {
+          "code": "Q7193705",
+          "label": "Pikpok"
+        },
+        {
+          "code": "Q7203173",
+          "label": "Playaround"
+        },
+        {
+          "code": "Q7227174",
+          "label": "PomPom Games"
+        },
+        {
+          "code": "Q7203541",
+          "label": "Playstos Entertainment"
+        },
+        {
+          "code": "Q7199695",
+          "label": "PixelJAM Games"
+        },
+        {
+          "code": "Q7227120",
+          "label": "Polytron Corporation"
+        },
+        {
+          "code": "Q7236699",
+          "label": "Powerful Robot Games"
+        },
+        {
+          "code": "Q7202313",
+          "label": "Platine Dispositif"
+        },
+        {
+          "code": "Q7261488",
+          "label": "Purple software"
+        },
+        {
+          "code": "Q7196883",
+          "label": "Pionesoft"
+        },
+        {
+          "code": "Q7197726",
+          "label": "Piranha Games"
+        },
+        {
+          "code": "Q7202946",
+          "label": "PlayNation"
+        },
+        {
+          "code": "Q7226426",
+          "label": "Polygon Magic"
+        },
+        {
+          "code": "Q7259502",
+          "label": "PULLTOP"
+        },
+        {
+          "code": "Q126039026",
+          "label": "mana"
+        },
+        {
+          "code": "Q125758534",
+          "label": "Gbanga"
+        },
+        {
+          "code": "Q125285981",
+          "label": "Utopian World of Sandwiches"
+        },
+        {
+          "code": "Q125316648",
+          "label": "Yazar Media Group"
+        },
+        {
+          "code": "Q125373841",
+          "label": "McPeppergames"
+        },
+        {
+          "code": "Q125374173",
+          "label": "nuGAME"
+        },
+        {
+          "code": "Q125405475",
+          "label": "Arc Games"
+        },
+        {
+          "code": "Q125423181",
+          "label": "Henchmen Studio"
+        },
+        {
+          "code": "Q125400731",
+          "label": "Astrum Entertainment"
+        },
+        {
+          "code": "Q125450618",
+          "label": "Blobfish Games"
+        },
+        {
+          "code": "Q125465472",
+          "label": "Two Tiny Dice"
+        },
+        {
+          "code": "Q125491200",
+          "label": "ManaVoid Entertainment"
+        },
+        {
+          "code": "Q125491291",
+          "label": "BadRez Games"
+        },
+        {
+          "code": "Q125503022",
+          "label": "Hilltop Studios"
+        },
+        {
+          "code": "Q125503027",
+          "label": "Sand Door Studio"
+        },
+        {
+          "code": "Q125503032",
+          "label": "Team Caravan"
+        },
+        {
+          "code": "Q125503065",
+          "label": "LocalThunk"
+        },
+        {
+          "code": "Q125506816",
+          "label": "Broken Arrow Games"
+        },
+        {
+          "code": "Q125507104",
+          "label": "Erect Society"
+        },
+        {
+          "code": "Q125525875",
+          "label": "Dream Dale"
+        },
+        {
+          "code": "Q125526294",
+          "label": "Retro64"
+        },
+        {
+          "code": "Q125526375",
+          "label": "Puzzle Lab"
+        },
+        {
+          "code": "Q125575057",
+          "label": "Crystal Squid"
+        },
+        {
+          "code": "Q125575907",
+          "label": "Splashworks"
+        },
+        {
+          "code": "Q125589206",
+          "label": "Toybox Games"
+        },
+        {
+          "code": "Q125589435",
+          "label": "Novel Games"
+        },
+        {
+          "code": "Q125620291",
+          "label": "Hortor Games"
+        },
+        {
+          "code": "Q125637106",
+          "label": "Simrail S.A."
+        },
+        {
+          "code": "Q125660356",
+          "label": "Symbolic Software"
+        },
+        {
+          "code": "Q125701888",
+          "label": "RCMADIAX LLC"
+        },
+        {
+          "code": "Q125703364",
+          "label": "OXiAB Game Studio"
+        },
+        {
+          "code": "Q125715143",
+          "label": "Tepui Products"
+        },
+        {
+          "code": "Q125717298",
+          "label": "Bawu Team"
+        },
+        {
+          "code": "Q125748299",
+          "label": "Dakko Dakko"
+        },
+        {
+          "code": "Q125754293",
+          "label": "Nostatic Software"
+        },
+        {
+          "code": "Q125760818",
+          "label": "Towerfag"
+        },
+        {
+          "code": "Q125769152",
+          "label": "Visual Impact"
+        },
+        {
+          "code": "Q125808647",
+          "label": "Grenaa Games"
+        },
+        {
+          "code": "Q125815940",
+          "label": "Extra Nice"
+        },
+        {
+          "code": "Q125825112",
+          "label": "Prison Lab"
+        },
+        {
+          "code": "Q125825310",
+          "label": "Kraisoft Entertainment"
+        },
+        {
+          "code": "Q125834417",
+          "label": "Cytherean Adventures"
+        },
+        {
+          "code": "Q125843247",
+          "label": "Lekker spelen"
+        },
+        {
+          "code": "Q125864349",
+          "label": "E-Regular Games"
+        },
+        {
+          "code": "Q125868804",
+          "label": "Raptisoft"
+        },
+        {
+          "code": "Q125872987",
+          "label": "Mizo Games"
+        },
+        {
+          "code": "Q125876202",
+          "label": "threeW Games"
+        },
+        {
+          "code": "Q125879163",
+          "label": "Arawella Corporation"
+        },
+        {
+          "code": "Q125929683",
+          "label": "Thornbury Software"
+        },
+        {
+          "code": "Q125950497",
+          "label": "Dezvolt Games"
+        },
+        {
+          "code": "Q125955813",
+          "label": "Mythic Moon Studios"
+        },
+        {
+          "code": "Q125956364",
+          "label": "Antidote Entertainment"
+        },
+        {
+          "code": "Q125986388",
+          "label": "Digital DNA Games"
+        },
+        {
+          "code": "Q126000321",
+          "label": "Akies Games"
+        },
+        {
+          "code": "Q126009460",
+          "label": "ZiMAD"
+        },
+        {
+          "code": "Q126010408",
+          "label": "Sirius Publishing"
+        },
+        {
+          "code": "Q126010565",
+          "label": "IBM Multimedia Studio"
+        },
+        {
+          "code": "Q126071379",
+          "label": "Blinkmoon Games"
+        },
+        {
+          "code": "Q7976899",
+          "label": "Wayward Design"
+        },
+        {
+          "code": "Q8024279",
+          "label": "Windmill"
+        },
+        {
+          "code": "Q8025512",
+          "label": "Winkysoft"
+        },
+        {
+          "code": "Q7941917",
+          "label": "Vortex Game Studios"
+        },
+        {
+          "code": "Q8000452",
+          "label": "WildTangent"
+        },
+        {
+          "code": "Q7959294",
+          "label": "Wadjet Eye Games"
+        },
+        {
+          "code": "Q7936168",
+          "label": "Vision Park"
+        },
+        {
+          "code": "Q7939990",
+          "label": "Volatile Games"
+        },
+        {
+          "code": "Q7969414",
+          "label": "Warhorse Studios"
+        },
+        {
+          "code": "Q7937557",
+          "label": "Vivarium Inc."
+        },
+        {
+          "code": "Q7967797",
+          "label": "Wangame Studios"
+        },
+        {
+          "code": "Q8027404",
+          "label": "WisdomTools Enterprises"
+        },
+        {
+          "code": "Q7939006",
+          "label": "Vlambeer"
+        },
+        {
+          "code": "Q7959833",
+          "label": "Wahoo Studios"
+        },
+        {
+          "code": "Q7998311",
+          "label": "Wicked Witch Software"
+        },
+        {
+          "code": "Q33108658",
+          "label": "Red Wasp Design Ltd"
+        },
+        {
+          "code": "Q33111384",
+          "label": "PolyKnight Games"
+        },
+        {
+          "code": "Q33111877",
+          "label": "Hawken Entertainment, Inc."
+        },
+        {
+          "code": "Q33198462",
+          "label": "Abbey Games"
+        },
+        {
+          "code": "Q33111972",
+          "label": "The Indie Stone"
+        },
+        {
+          "code": "Q33112006",
+          "label": "Xaviant"
+        },
+        {
+          "code": "Q33189192",
+          "label": "Badland Studio"
+        },
+        {
+          "code": "Q33189130",
+          "label": "Tomoaki Sugeno"
+        },
+        {
+          "code": "Q33198509",
+          "label": "Anisoptera Games"
+        },
+        {
+          "code": "Q33198490",
+          "label": "GalaxyTrail"
+        },
+        {
+          "code": "Q33104592",
+          "label": "Nekomura Games"
+        },
+        {
+          "code": "Q33108667",
+          "label": "Subsoap"
+        },
+        {
+          "code": "Q33111975",
+          "label": "Konstantin Koshutin"
+        },
+        {
+          "code": "Q33198339",
+          "label": "Hermitworks Entertainment"
+        },
+        {
+          "code": "Q33198469",
+          "label": "Freejam"
+        },
+        {
+          "code": "Q33104575",
+          "label": "Crocodile Entertainment"
+        },
+        {
+          "code": "Q33108530",
+          "label": "Sandstorm Productions"
+        },
+        {
+          "code": "Q33111933",
+          "label": "Hopoo Games, LLC"
+        },
+        {
+          "code": "Q33111989",
+          "label": "Coilworks"
+        },
+        {
+          "code": "Q33188643",
+          "label": "RichMakeGame"
+        },
+        {
+          "code": "Q33198455",
+          "label": "Numinous Games"
+        },
+        {
+          "code": "Q33111996",
+          "label": "Zachtronics"
+        },
+        {
+          "code": "Q33108661",
+          "label": "JoyBits"
+        },
+        {
+          "code": "Q33111339",
+          "label": "Digital Continue"
+        },
+        {
+          "code": "Q33189088",
+          "label": "Crystal Empire Games"
+        },
+        {
+          "code": "Q33198159",
+          "label": "The Irregular Corporation"
+        },
+        {
+          "code": "Q33198438",
+          "label": "5 Lives Studios"
+        },
+        {
+          "code": "Q33103644",
+          "label": "Sand Sailor Studio"
+        },
+        {
+          "code": "Q33104581",
+          "label": "Pencil Test Studios"
+        },
+        {
+          "code": "Q33108651",
+          "label": "777 Studios"
+        },
+        {
+          "code": "Q33111970",
+          "label": "Sauropod Studio"
+        },
+        {
+          "code": "Q33188597",
+          "label": "Avatar Creations"
+        },
+        {
+          "code": "Q33189214",
+          "label": "STUDIO RADI-8"
+        },
+        {
+          "code": "Q33198426",
+          "label": "SOF Studios Ltd"
+        },
+        {
+          "code": "Q33108641",
+          "label": "Idol FX"
+        },
+        {
+          "code": "Q33111958",
+          "label": "AwesomeBlade"
+        },
+        {
+          "code": "Q33104578",
+          "label": "EightyEight Games"
+        },
+        {
+          "code": "Q4926019",
+          "label": "Blendo Games"
+        },
+        {
+          "code": "Q4926947",
+          "label": "Blitz Arcade"
+        },
+        {
+          "code": "Q4929380",
+          "label": "Blue Lizard Games"
+        },
+        {
+          "code": "Q4943557",
+          "label": "Boomzap Entertainment"
+        },
+        {
+          "code": "Q4922154",
+          "label": "Black Widow Games"
+        },
+        {
+          "code": "Q4947547",
+          "label": "Bossa Studios"
+        },
+        {
+          "code": "Q4922077",
+          "label": "The Coalition"
+        },
+        {
+          "code": "Q4940102",
+          "label": "Bolt Creative"
+        },
+        {
+          "code": "Q4926952",
+          "label": "Blitz Games Studios"
+        },
+        {
+          "code": "Q4929596",
+          "label": "Blue Omega"
+        },
+        {
+          "code": "Q4906222",
+          "label": "Big Robot"
+        },
+        {
+          "code": "Q4926954",
+          "label": "Blitz Games"
+        },
+        {
+          "code": "Q4929941",
+          "label": "Blue Tea Games"
+        },
+        {
+          "code": "Q4905144",
+          "label": "Big Blue Bubble"
+        },
+        {
+          "code": "Q4906174",
+          "label": "Big Red Software"
+        },
+        {
+          "code": "Q4930550",
+          "label": "Blueside"
+        },
+        {
+          "code": "Q4904930",
+          "label": "Big Ant Studios"
+        },
+        {
+          "code": "Q131048322",
+          "label": "Sabay"
+        },
+        {
+          "code": "Q130453593",
+          "label": "16 Bit Arena"
+        },
+        {
+          "code": "Q130356637",
+          "label": "Little Chicken Game Company"
+        },
+        {
+          "code": "Q130364088",
+          "label": "Anduo Games"
+        },
+        {
+          "code": "Q130365939",
+          "label": "Hoothanes"
+        },
+        {
+          "code": "Q130370971",
+          "label": "SoulGame Studio"
+        },
+        {
+          "code": "Q130372740",
+          "label": "Syndicate Atomic"
+        },
+        {
+          "code": "Q130380726",
+          "label": "SK Soft"
+        },
+        {
+          "code": "Q130381672",
+          "label": "LITCHI GAME"
+        },
+        {
+          "code": "Q130383068",
+          "label": "Wrong Organ"
+        },
+        {
+          "code": "Q130383452",
+          "label": "Fuzz Force"
+        },
+        {
+          "code": "Q130384400",
+          "label": "Pixel Perfect Dude"
+        },
+        {
+          "code": "Q130384401",
+          "label": "Lionsharp Studios"
+        },
+        {
+          "code": "Q130385172",
+          "label": "Nautilus Mobile"
+        },
+        {
+          "code": "Q130386126",
+          "label": "Ostrich Banditos"
+        },
+        {
+          "code": "Q130387492",
+          "label": "GameDesignDan"
+        },
+        {
+          "code": "Q130393972",
+          "label": "Ink Stains Games"
+        },
+        {
+          "code": "Q130397764",
+          "label": "gypynkt Games"
+        },
+        {
+          "code": "Q130405208",
+          "label": "Moving Player"
+        },
+        {
+          "code": "Q130417284",
+          "label": "Cognilize"
+        },
+        {
+          "code": "Q130436679",
+          "label": "GLOWRIDER"
+        },
+        {
+          "code": "Q130436878",
+          "label": "WVPro"
+        },
+        {
+          "code": "Q130436906",
+          "label": "NCDigital"
+        },
+        {
+          "code": "Q130437872",
+          "label": "Yellow Dog Man Studios"
+        },
+        {
+          "code": "Q130453595",
+          "label": "Reco Technology"
+        },
+        {
+          "code": "Q130453596",
+          "label": "UIG Entertainment"
+        },
+        {
+          "code": "Q130453597",
+          "label": "Winking Skywalker Entertainment"
+        },
+        {
+          "code": "Q130478353",
+          "label": "Studio Peaches"
+        },
+        {
+          "code": "Q130528119",
+          "label": "Wolfgame"
+        },
+        {
+          "code": "Q130532895",
+          "label": "Big Bang Studio"
+        },
+        {
+          "code": "Q130541182",
+          "label": "BattleLine Games"
+        },
+        {
+          "code": "Q130545660",
+          "label": "Aruma Studios"
+        },
+        {
+          "code": "Q130550172",
+          "label": "2n Productions"
+        },
+        {
+          "code": "Q130563377",
+          "label": "lamedeveloper"
+        },
+        {
+          "code": "Q130565466",
+          "label": "Mediamond"
+        },
+        {
+          "code": "Q130614428",
+          "label": "Curve Animation"
+        },
+        {
+          "code": "Q130615694",
+          "label": "Dahku Creations"
+        },
+        {
+          "code": "Q130621883",
+          "label": "Team Jade"
+        },
+        {
+          "code": "Q130648212",
+          "label": "Gamesquad"
+        },
+        {
+          "code": "Q130676855",
+          "label": "Petit Fabrik"
+        },
+        {
+          "code": "Q130726143",
+          "label": "Crea-7"
+        },
+        {
+          "code": "Q130731627",
+          "label": "Fiveamp"
+        },
+        {
+          "code": "Q130734971",
+          "label": "Extra Toxic"
+        },
+        {
+          "code": "Q130747171",
+          "label": "Vittgen Inc."
+        },
+        {
+          "code": "Q130762107",
+          "label": "Spark Creative"
+        },
+        {
+          "code": "Q130832163",
+          "label": "Jarhead Games"
+        },
+        {
+          "code": "Q130980600",
+          "label": "TOO DX"
+        },
+        {
+          "code": "Q130993910",
+          "label": "Fen Research"
+        },
+        {
+          "code": "Q131124604",
+          "label": "Seedy Eye Software"
+        },
+        {
+          "code": "Q131143156",
+          "label": "Bolt Blaster Games"
+        },
+        {
+          "code": "Q131190462",
+          "label": "joker studio"
+        },
+        {
+          "code": "Q131194344",
+          "label": "Stratotainment, L.L.C."
+        },
+        {
+          "code": "Q131243891",
+          "label": "M.R. Games"
+        },
+        {
+          "code": "Q131285486",
+          "label": "Fire & Frost"
+        },
+        {
+          "code": "Q131293338",
+          "label": "Log Games"
+        },
+        {
+          "code": "Q131338845",
+          "label": "Qiiwi Games"
+        },
+        {
+          "code": "Q131345366",
+          "label": "PixlBit Studios"
+        },
+        {
+          "code": "Q131348465",
+          "label": "Cfx.re"
+        },
+        {
+          "code": "Q130629981",
+          "label": "New Deer"
+        },
+        {
+          "code": "Q7739534",
+          "label": "The Hidden"
+        },
+        {
+          "code": "Q7692650",
+          "label": "Technopop"
+        },
+        {
+          "code": "Q7726737",
+          "label": "The Collective"
+        },
+        {
+          "code": "Q7670288",
+          "label": "THQ Digital Studios UK"
+        },
+        {
+          "code": "Q7675088",
+          "label": "Tag Games"
+        },
+        {
+          "code": "Q7730973",
+          "label": "The Dreamers Guild"
+        },
+        {
+          "code": "Q7678649",
+          "label": "Takuyo"
+        },
+        {
+          "code": "Q7681873",
+          "label": "Tamsoft"
+        },
+        {
+          "code": "Q7703218",
+          "label": "Terraglyph Interactive Studios"
+        },
+        {
+          "code": "Q7692095",
+          "label": "TecMagik"
+        },
+        {
+          "code": "Q7714706",
+          "label": "The Assembly Line"
+        },
+        {
+          "code": "Q7734321",
+          "label": "Fizz Factor"
+        },
+        {
+          "code": "Q7672598",
+          "label": "TX Digital Illusions"
+        },
+        {
+          "code": "Q7691414",
+          "label": "TeamTNT"
+        },
+        {
+          "code": "Q7698390",
+          "label": "Templar Studios"
+        },
+        {
+          "code": "Q7683810",
+          "label": "Tantalus Media"
+        },
+        {
+          "code": "Q7708592",
+          "label": "Teyon"
+        },
+        {
+          "code": "Q7682424",
+          "label": "Tandem Games"
+        },
+        {
+          "code": "Q8074145",
+          "label": "Zoom"
+        },
+        {
+          "code": "Q8042304",
+          "label": "XMG Studio"
+        },
+        {
+          "code": "Q8046428",
+          "label": "Yacht Club Games"
+        },
+        {
+          "code": "Q8053036",
+          "label": "Yeti"
+        },
+        {
+          "code": "Q8062910",
+          "label": "Z2Live"
+        },
+        {
+          "code": "Q8068636",
+          "label": "Zeiva Inc"
+        },
+        {
+          "code": "Q8041515",
+          "label": "X-Ray Kid Studios"
+        },
+        {
+          "code": "Q8073511",
+          "label": "Zoink Games"
+        },
+        {
+          "code": "Q8068422",
+          "label": "Zeebo Inc."
+        },
+        {
+          "code": "Q8069170",
+          "label": "Zenobi"
+        },
+        {
+          "code": "Q8043371",
+          "label": "Launchworks"
+        },
+        {
+          "code": "Q8074739",
+          "label": "Zoë Mode"
+        },
+        {
+          "code": "Q8068274",
+          "label": "Zeboyd Games"
+        },
+        {
+          "code": "Q8028740",
+          "label": "Wizard Video"
+        },
+        {
+          "code": "Q8075731",
+          "label": "ZyX"
+        },
+        {
+          "code": "Q8189895",
+          "label": "Studio e.go!"
+        },
+        {
+          "code": "Q8036766",
+          "label": "Worldweaver Ltd"
+        },
+        {
+          "code": "Q8074193",
+          "label": "Zoonami"
+        },
+        {
+          "code": "Q8074223",
+          "label": "ZootFly"
+        },
+        {
+          "code": "Q7512143",
+          "label": "Sigil Games Online"
+        },
+        {
+          "code": "Q7517879",
+          "label": "Simis"
+        },
+        {
+          "code": "Q7533666",
+          "label": "Ska Studios"
+        },
+        {
+          "code": "Q7536445",
+          "label": "Skotos"
+        },
+        {
+          "code": "Q7451115",
+          "label": "Sensory Sweep Studios"
+        },
+        {
+          "code": "Q7450633",
+          "label": "Senile Team"
+        },
+        {
+          "code": "Q7517769",
+          "label": "Simian Squared"
+        },
+        {
+          "code": "Q7454892",
+          "label": "Serious Games Interactive"
+        },
+        {
+          "code": "Q7457322",
+          "label": "Seven Lights"
+        },
+        {
+          "code": "Q7514940",
+          "label": "Silicon Beach Software"
+        },
+        {
+          "code": "Q7533407",
+          "label": "Size Five Games"
+        },
+        {
+          "code": "Q7446160",
+          "label": "Sega Racing Studio"
+        },
+        {
+          "code": "Q7480253",
+          "label": "Tango Gameworks"
+        },
+        {
+          "code": "Q7515763",
+          "label": "SilverBirch Studios"
+        },
+        {
+          "code": "Q7537723",
+          "label": "Skygoblin"
+        },
+        {
+          "code": "Q7514976",
+          "label": "Silicon Sisters"
+        },
+        {
+          "code": "Q7514985",
+          "label": "Silicon Studio"
+        },
+        {
+          "code": "Q7537037",
+          "label": "Skunk Studios, Inc."
+        },
+        {
+          "code": "Q97498592",
+          "label": "Nathan Sorenson Inc."
+        },
+        {
+          "code": "Q97462711",
+          "label": "Pop Rocket"
+        },
+        {
+          "code": "Q97515850",
+          "label": "Geronimo Entertainment"
+        },
+        {
+          "code": "Q7047669",
+          "label": "Noise"
+        },
+        {
+          "code": "Q6948871",
+          "label": "Mystery Studio"
+        },
+        {
+          "code": "Q6955451",
+          "label": "NTDEC"
+        },
+        {
+          "code": "Q6958814",
+          "label": "Nagi-P Software"
+        },
+        {
+          "code": "Q7050580",
+          "label": "Nordcurrent"
+        },
+        {
+          "code": "Q7050635",
+          "label": "Nordeus"
+        },
+        {
+          "code": "Q6863981",
+          "label": "Mindstorm Studios"
+        },
+        {
+          "code": "Q6917741",
+          "label": "Motion Blur"
+        },
+        {
+          "code": "Q6928353",
+          "label": "Mr.Goodliving"
+        },
+        {
+          "code": "Q6998211",
+          "label": "NetDevil"
+        },
+        {
+          "code": "Q7012543",
+          "label": "New World Interactive"
+        },
+        {
+          "code": "Q7024361",
+          "label": "Nicalis"
+        },
+        {
+          "code": "Q6926465",
+          "label": "Movaya"
+        },
+        {
+          "code": "Q6961465",
+          "label": "Namco Networks"
+        },
+        {
+          "code": "Q6949287",
+          "label": "Mytopia"
+        },
+        {
+          "code": "Q6953368",
+          "label": "nDreams"
+        },
+        {
+          "code": "Q6998676",
+          "label": "Netbabyworld"
+        },
+        {
+          "code": "Q6886758",
+          "label": "Mobile21"
+        },
+        {
+          "code": "Q6944504",
+          "label": "Muzzy Lane"
+        },
+        {
+          "code": "Q6713732",
+          "label": "M2"
+        },
+        {
+          "code": "Q6489034",
+          "label": "Large Animal Games"
+        },
+        {
+          "code": "Q6546343",
+          "label": "Lighthouse Interactive"
+        },
+        {
+          "code": "Q6674337",
+          "label": "Longtail Studios"
+        },
+        {
+          "code": "Q6697870",
+          "label": "Lucky Chicken Games"
+        },
+        {
+          "code": "Q6546442",
+          "label": "Lightning Fish"
+        },
+        {
+          "code": "Q6667478",
+          "label": "Logical Design Works, Inc."
+        },
+        {
+          "code": "Q6451704",
+          "label": "Kylotonn"
+        },
+        {
+          "code": "Q6510065",
+          "label": "Learnalot"
+        },
+        {
+          "code": "Q6498128",
+          "label": "Laughing Jackal"
+        },
+        {
+          "code": "Q6723623",
+          "label": "MachineGames"
+        },
+        {
+          "code": "Q6517252",
+          "label": "Legacy Interactive"
+        },
+        {
+          "code": "Q6480773",
+          "label": "Lamagama Entertainment"
+        },
+        {
+          "code": "Q6702996",
+          "label": "Luma Arcade"
+        },
+        {
+          "code": "Q6522253",
+          "label": "Lenar"
+        },
+        {
+          "code": "Q6458919",
+          "label": "LK Avalon"
+        },
+        {
+          "code": "Q6506093",
+          "label": "Lazy 8 Studios"
+        },
+        {
+          "code": "Q6665966",
+          "label": "Locomotive Games"
+        },
+        {
+          "code": "Q6720517",
+          "label": "M Network"
+        },
+        {
+          "code": "Q7335430",
+          "label": "Riot"
+        },
+        {
+          "code": "Q7295493",
+          "label": "Ratbag Games"
+        },
+        {
+          "code": "Q7316872",
+          "label": "Reto-Moto"
+        },
+        {
+          "code": "Q7284120",
+          "label": "Dovetail Games"
+        },
+        {
+          "code": "Q7304783",
+          "label": "Red Redemption"
+        },
+        {
+          "code": "Q7310966",
+          "label": "Relentless Software"
+        },
+        {
+          "code": "Q7301342",
+          "label": "Realmforge Studios"
+        },
+        {
+          "code": "Q7301372",
+          "label": "Realtime Associates"
+        },
+        {
+          "code": "Q7304403",
+          "label": "Red Jade"
+        },
+        {
+          "code": "Q7305483",
+          "label": "Redboss"
+        },
+        {
+          "code": "Q7306314",
+          "label": "Redtribe"
+        },
+        {
+          "code": "Q7276607",
+          "label": "RFX Interactive"
+        },
+        {
+          "code": "Q7295822",
+          "label": "Ratloop"
+        },
+        {
+          "code": "Q7296793",
+          "label": "Ravn Studio"
+        },
+        {
+          "code": "Q7268181",
+          "label": "Qplaze"
+        },
+        {
+          "code": "Q7305448",
+          "label": "Redbana Corporation"
+        },
+        {
+          "code": "Q7353288",
+          "label": "Robomodo"
+        },
+        {
+          "code": "Q7301375",
+          "label": "Realtime Games Software"
+        },
+        {
+          "code": "Q7319098",
+          "label": "Rewolf Software"
+        },
+        {
+          "code": "Q7299660",
+          "label": "Razorworks"
+        },
+        {
+          "code": "Q8564980",
+          "label": "Foundation 9 Entertainment"
+        },
+        {
+          "code": "Q9197236",
+          "label": "CyberFront"
+        },
+        {
+          "code": "Q9290601",
+          "label": "Inti Creates"
+        },
+        {
+          "code": "Q10269187",
+          "label": "Dynacom"
+        },
+        {
+          "code": "Q10274953",
+          "label": "Espaço Informática"
+        },
+        {
+          "code": "Q10291484",
+          "label": "Green Land Studios"
+        },
+        {
+          "code": "Q10341211",
+          "label": "Optik Software"
+        },
+        {
+          "code": "Q10379079",
+          "label": "Zeebo Interactive Studios"
+        },
+        {
+          "code": "Q9305043",
+          "label": "RedMoon Studios"
+        },
+        {
+          "code": "Q9142801",
+          "label": "Aidem Media"
+        },
+        {
+          "code": "Q9335286",
+          "label": "Sennari Games"
+        },
+        {
+          "code": "Q10304571",
+          "label": "J-Wing"
+        },
+        {
+          "code": "Q10369375",
+          "label": "Sega Rosso"
+        },
+        {
+          "code": "Q10266295",
+          "label": "DigiFX Interactive"
+        },
+        {
+          "code": "Q10341236",
+          "label": "Orangepixel"
+        },
+        {
+          "code": "Q6143267",
+          "label": "Regista"
+        },
+        {
+          "code": "Q6325565",
+          "label": "KAZe"
+        },
+        {
+          "code": "Q6131461",
+          "label": "United Game Artists"
+        },
+        {
+          "code": "Q6142858",
+          "label": "AXL"
+        },
+        {
+          "code": "Q6125388",
+          "label": "Punchline"
+        },
+        {
+          "code": "Q6410724",
+          "label": "Kinesoft"
+        },
+        {
+          "code": "Q6418945",
+          "label": "Kixeye"
+        },
+        {
+          "code": "Q6423274",
+          "label": "JumpStart Games"
+        },
+        {
+          "code": "Q6121433",
+          "label": "Jadestone Group"
+        },
+        {
+          "code": "Q6279033",
+          "label": "Jorudan"
+        },
+        {
+          "code": "Q6445840",
+          "label": "Kure Software Koubou"
+        },
+        {
+          "code": "Q6433719",
+          "label": "Kot-in-Action Creative Artel"
+        },
+        {
+          "code": "Q6388765",
+          "label": "KenamicK Entertainment"
+        },
+        {
+          "code": "Q6444446",
+          "label": "Kung Fu Factory"
+        },
+        {
+          "code": "Q6450054",
+          "label": "Kwalee"
+        },
+        {
+          "code": "Q6156505",
+          "label": "Japan Art Media"
+        },
+        {
+          "code": "Q6165140",
+          "label": "Javaground"
+        },
+        {
+          "code": "Q7784257",
+          "label": "Thin Chen Enterprise"
+        },
+        {
+          "code": "Q7801136",
+          "label": "Tiertex Design Studios"
+        },
+        {
+          "code": "Q7801857",
+          "label": "TikGames"
+        },
+        {
+          "code": "Q7838306",
+          "label": "Trendy Entertainment"
+        },
+        {
+          "code": "Q7813446",
+          "label": "Toka"
+        },
+        {
+          "code": "Q7805202",
+          "label": "Time Warner Interactive"
+        },
+        {
+          "code": "Q7801484",
+          "label": "Tiger Style"
+        },
+        {
+          "code": "Q7774678",
+          "label": "The Whole Experience"
+        },
+        {
+          "code": "Q7777579",
+          "label": "Theatrix Interactive"
+        },
+        {
+          "code": "Q7834621",
+          "label": "Transmission Games"
+        },
+        {
+          "code": "Q7835553",
+          "label": "Trapdoor"
+        },
+        {
+          "code": "Q7840350",
+          "label": "TribePlay"
+        },
+        {
+          "code": "Q7837451",
+          "label": "Trecision"
+        },
+        {
+          "code": "Q7754688",
+          "label": "The Odd Gentlemen"
+        },
+        {
+          "code": "Q7784503",
+          "label": "Think Garage"
+        },
+        {
+          "code": "Q7797234",
+          "label": "Three-Sixty Pacific"
+        },
+        {
+          "code": "Q7803016",
+          "label": "Tiltfactor Lab"
+        },
+        {
+          "code": "Q7765135",
+          "label": "The Software Refinery"
+        },
+        {
+          "code": "Q7785015",
+          "label": "Third Wire"
+        },
+        {
+          "code": "Q7797716",
+          "label": "Three Rings Design"
+        },
+        {
+          "code": "Q7812896",
+          "label": "ToeJam & Earl Productions"
+        },
+        {
+          "code": "Q7167009",
+          "label": "Perception"
+        },
+        {
+          "code": "Q7131061",
+          "label": "Panic"
+        },
+        {
+          "code": "Q7122599",
+          "label": "Pacific Novelty"
+        },
+        {
+          "code": "Q7135092",
+          "label": "Param"
+        },
+        {
+          "code": "Q7168080",
+          "label": "Perfect World"
+        },
+        {
+          "code": "Q7131790",
+          "label": "Panther Games"
+        },
+        {
+          "code": "Q7140488",
+          "label": "Particle Systems"
+        },
+        {
+          "code": "Q7115945",
+          "label": "Oxygen Studios"
+        },
+        {
+          "code": "Q7134604",
+          "label": "Paragon Software"
+        },
+        {
+          "code": "Q7134605",
+          "label": "Paragon Studios"
+        },
+        {
+          "code": "Q7117011",
+          "label": "P.I.S.D."
+        },
+        {
+          "code": "Q7126369",
+          "label": "Paladin Studios"
+        },
+        {
+          "code": "Q7132534",
+          "label": "Papaya Studio"
+        },
+        {
+          "code": "Q7156467",
+          "label": "Pax Softnica"
+        },
+        {
+          "code": "Q10855877",
+          "label": "FiolaSoft Studio"
+        },
+        {
+          "code": "Q10855835",
+          "label": "Craneballs"
+        },
+        {
+          "code": "Q10854808",
+          "label": "Rosebleu"
+        },
+        {
+          "code": "Q10867971",
+          "label": "Aurogon Shanghai"
+        },
+        {
+          "code": "Q10847160",
+          "label": "Feng"
+        },
+        {
+          "code": "Q10847107",
+          "label": "Fairytale"
+        },
+        {
+          "code": "Q10502517",
+          "label": "Gammafon"
+        },
+        {
+          "code": "Q10786080",
+          "label": "Lima Sky"
+        },
+        {
+          "code": "Q10501780",
+          "label": "G5 Entertainment"
+        },
+        {
+          "code": "Q10851632",
+          "label": "Marmalade"
+        },
+        {
+          "code": "Q10846787",
+          "label": "Clochette"
+        },
+        {
+          "code": "Q10518726",
+          "label": "Headfirst Productions"
+        },
+        {
+          "code": "Q10613665",
+          "label": "Oxeye Game Studio"
+        },
+        {
+          "code": "Q10734337",
+          "label": "Hooksoft"
+        },
+        {
+          "code": "Q10852372",
+          "label": "Saga Planets"
+        },
+        {
+          "code": "Q10556387",
+          "label": "Legendo Entertainment AB"
+        },
+        {
+          "code": "Q10846562",
+          "label": "BaseSon"
+        },
+        {
+          "code": "Q10854427",
+          "label": "APh Technological Consulting"
+        },
+        {
+          "code": "Q10498407",
+          "label": "Fractile Games"
+        },
+        {
+          "code": "Q7857976",
+          "label": "Twilight"
+        },
+        {
+          "code": "Q7864546",
+          "label": "UFO Interactive Games"
+        },
+        {
+          "code": "Q7884447",
+          "label": "Respawn Entertainment"
+        },
+        {
+          "code": "Q7850159",
+          "label": "Tsunami Games"
+        },
+        {
+          "code": "Q7865507",
+          "label": "UPL"
+        },
+        {
+          "code": "Q7840515",
+          "label": "Tribute Games"
+        },
+        {
+          "code": "Q7858530",
+          "label": "Twisted Pixel Games"
+        },
+        {
+          "code": "Q7859859",
+          "label": "Tygron"
+        },
+        {
+          "code": "Q7847084",
+          "label": "TruSim"
+        },
+        {
+          "code": "Q7879236",
+          "label": "Sega Technical Institute"
+        },
+        {
+          "code": "Q7883635",
+          "label": "Underground Development"
+        },
+        {
+          "code": "Q7840406",
+          "label": "Tribetoy"
+        },
+        {
+          "code": "Q7843146",
+          "label": "Trion Worlds"
+        },
+        {
+          "code": "Q7853820",
+          "label": "Turbo Tape Games"
+        },
+        {
+          "code": "Q7861179",
+          "label": "Typhoon Games"
+        },
+        {
+          "code": "Q127480175",
+          "label": "INTENSE"
+        },
+        {
+          "code": "Q127464704",
+          "label": "AV Games"
+        },
+        {
+          "code": "Q127500935",
+          "label": "Penrose Studios"
+        },
+        {
+          "code": "Q127502579",
+          "label": "Mardonpol"
+        },
+        {
+          "code": "Q127502804",
+          "label": "OutsideIn Entertainment"
+        },
+        {
+          "code": "Q127514178",
+          "label": "Madia Entertainment"
+        },
+        {
+          "code": "Q127603226",
+          "label": "Ironwood Studios"
+        },
+        {
+          "code": "Q127604323",
+          "label": "RageSquid"
+        },
+        {
+          "code": "Q127669039",
+          "label": "8Bit Games"
+        },
+        {
+          "code": "Q128034813",
+          "label": "Ahegames"
+        },
+        {
+          "code": "Q128045101",
+          "label": "Coal Supper"
+        },
+        {
+          "code": "Q128231619",
+          "label": "Bitwave Games"
+        },
+        {
+          "code": "Q128232203",
+          "label": "TATSUJIN"
+        },
+        {
+          "code": "Q128304649",
+          "label": "CRT GAMES"
+        },
+        {
+          "code": "Q128398609",
+          "label": "Uladzislau Basin"
+        },
+        {
+          "code": "Q128480769",
+          "label": "Slyon Studios"
+        },
+        {
+          "code": "Q128712561",
+          "label": "Mudvark Games"
+        },
+        {
+          "code": "Q128791686",
+          "label": "Sunbreak Games"
+        },
+        {
+          "code": "Q128797281",
+          "label": "Bakodun Game Studios"
+        },
+        {
+          "code": "Q128797951",
+          "label": "Bantam City Games"
+        },
+        {
+          "code": "Q128404022",
+          "label": "Mobirix"
+        },
+        {
+          "code": "Q129078414",
+          "label": "Actos Games"
+        },
+        {
+          "code": "Q129196160",
+          "label": "Funbox Media"
+        },
+        {
+          "code": "Q129203351",
+          "label": "NPC Studio"
+        },
+        {
+          "code": "Q129240851",
+          "label": "Playwith Korea"
+        },
+        {
+          "code": "Q129260687",
+          "label": "Aeons Studio"
+        },
+        {
+          "code": "Q129328566",
+          "label": "DPH Studio"
+        },
+        {
+          "code": "Q129382068",
+          "label": "Flyin Kebab Studio"
+        },
+        {
+          "code": "Q129380929",
+          "label": "Yabukaratang"
+        },
+        {
+          "code": "Q129412004",
+          "label": "CggtGroup"
+        },
+        {
+          "code": "Q129455229",
+          "label": "LewdLoco"
+        },
+        {
+          "code": "Q129458108",
+          "label": "Femdom Game World"
+        },
+        {
+          "code": "Q129549496",
+          "label": "Femdom studio"
+        },
+        {
+          "code": "Q129550242",
+          "label": "Duigrind"
+        },
+        {
+          "code": "Q129550560",
+          "label": "Cyber Keks"
+        },
+        {
+          "code": "Q129664186",
+          "label": "Selo tech.corp."
+        },
+        {
+          "code": "Q129746602",
+          "label": "Chrono Studio"
+        },
+        {
+          "code": "Q129786681",
+          "label": "NSFWEntertainment"
+        },
+        {
+          "code": "Q129786713",
+          "label": "Hentai works"
+        },
+        {
+          "code": "Q129922938",
+          "label": "CangMo Game Entertainment"
+        },
+        {
+          "code": "Q130212933",
+          "label": "Reddiamondgames"
+        },
+        {
+          "code": "Q130213152",
+          "label": "Tin Man Games"
+        },
+        {
+          "code": "Q130213218",
+          "label": "TUTGame"
+        },
+        {
+          "code": "Q130222497",
+          "label": "GentleDriver"
+        },
+        {
+          "code": "Q130222500",
+          "label": "Puzzle L Porject"
+        },
+        {
+          "code": "Q130236082",
+          "label": "Action Square"
+        },
+        {
+          "code": "Q130272507",
+          "label": "Mountaintop Studios"
+        },
+        {
+          "code": "Q130285113",
+          "label": "horakai"
+        },
+        {
+          "code": "Q130287462",
+          "label": "Firewalk Studios"
+        },
+        {
+          "code": "Q130301391",
+          "label": "Paragon 5"
+        },
+        {
+          "code": "Q130320256",
+          "label": "Iron Jelly"
+        },
+        {
+          "code": "Q130320260",
+          "label": "WitchGames"
+        },
+        {
+          "code": "Q130324022",
+          "label": "Cr3 Studio"
+        },
+        {
+          "code": "Q130344769",
+          "label": "xRed Games"
+        },
+        {
+          "code": "Q130350788",
+          "label": "Theorycraft Games"
+        },
+        {
+          "code": "Q130355754",
+          "label": "C4rib"
+        },
+        {
+          "code": "Q111926176",
+          "label": "straka.studio"
+        },
+        {
+          "code": "Q111926351",
+          "label": "NanoPiko"
+        },
+        {
+          "code": "Q111926107",
+          "label": "Bad Vices Games"
+        },
+        {
+          "code": "Q111907834",
+          "label": "Asteristic Game Studio"
+        },
+        {
+          "code": "Q111924444",
+          "label": "Lunaris Iris"
+        },
+        {
+          "code": "Q111925995",
+          "label": "Volcano Bytes"
+        },
+        {
+          "code": "Q111926425",
+          "label": "Afil Games"
+        },
+        {
+          "code": "Q111912024",
+          "label": "Magenta Factory"
+        },
+        {
+          "code": "Q111907913",
+          "label": "Circus Atos"
+        },
+        {
+          "code": "Q7933527",
+          "label": "Vir2L Studios"
+        },
+        {
+          "code": "Q7935221",
+          "label": "Virtuos"
+        },
+        {
+          "code": "Q7917784",
+          "label": "VectorCell"
+        },
+        {
+          "code": "Q7917814",
+          "label": "Vector Unit"
+        },
+        {
+          "code": "Q7922955",
+          "label": "Vertigo Gaming"
+        },
+        {
+          "code": "Q7885169",
+          "label": "Unigine Company"
+        },
+        {
+          "code": "Q7917847",
+          "label": "Vectorbeam"
+        },
+        {
+          "code": "Q7918753",
+          "label": "Vektor Grafix"
+        },
+        {
+          "code": "Q7935019",
+          "label": "Virtual Playground"
+        },
+        {
+          "code": "Q7909334",
+          "label": "Valcon Games"
+        },
+        {
+          "code": "Q7919545",
+          "label": "Venan Entertainment"
+        },
+        {
+          "code": "Q7935253",
+          "label": "Virtway"
+        },
+        {
+          "code": "Q7887849",
+          "label": "The Game Designers Studio"
+        },
+        {
+          "code": "Q7934971",
+          "label": "Virtual Heroes, Inc."
+        },
+        {
+          "code": "Q7927611",
+          "label": "Vid Kidz"
+        }
+      ],
+    "publishers": [
+        {
+          "code": "Q109342583",
+          "label": "Game Science"
+        },
+        {
+          "code": "Q8093",
+          "label": "Nintendo"
+        },
+        {
+          "code": "Q11942",
+          "label": "ETH Zurich"
+        },
+        {
+          "code": "Q1389810",
+          "label": "Software 2000"
+        },
+        {
+          "code": "Q1384984",
+          "label": "Team17"
+        },
+        {
+          "code": "Q1383563",
+          "label": "Telltale Games"
+        },
+        {
+          "code": "Q1408498",
+          "label": "Ocean Software"
+        },
+        {
+          "code": "Q1438774",
+          "label": "Supercell"
+        },
+        {
+          "code": "Q1457468",
+          "label": "THQ Nordic"
+        },
+        {
+          "code": "Q28416421",
+          "label": "Golden Disc Electronic"
+        },
+        {
+          "code": "Q28686397",
+          "label": "miHoYo"
+        },
+        {
+          "code": "Q28873056",
+          "label": "Infogrames Interactive"
+        },
+        {
+          "code": "Q29047505",
+          "label": "thumbspire"
+        },
+        {
+          "code": "Q29578079",
+          "label": "Mindware Corp."
+        },
+        {
+          "code": "Q30041006",
+          "label": "TheMeatly Games"
+        },
+        {
+          "code": "Q28222801",
+          "label": "Survios"
+        },
+        {
+          "code": "Q28195060",
+          "label": "The Sales Curve"
+        },
+        {
+          "code": "Q28228468",
+          "label": "BMG Interactive"
+        },
+        {
+          "code": "Q28405991",
+          "label": "Wales Interactive"
+        },
+        {
+          "code": "Q29919441",
+          "label": "Williams Electronics Games"
+        },
+        {
+          "code": "Q30145026",
+          "label": "Adult Swim Games"
+        },
+        {
+          "code": "Q28406776",
+          "label": "Soedesco"
+        },
+        {
+          "code": "Q30105931",
+          "label": "Red Hook Studios"
+        },
+        {
+          "code": "Q4736479",
+          "label": "Alternative Software"
+        },
+        {
+          "code": "Q4746189",
+          "label": "Amiga, Inc."
+        },
+        {
+          "code": "Q4806100",
+          "label": "11 bit studios"
+        },
+        {
+          "code": "Q4812837",
+          "label": "Atari Program Exchange"
+        },
+        {
+          "code": "Q4826391",
+          "label": "Automata UK"
+        },
+        {
+          "code": "Q4897605",
+          "label": "Softcannon"
+        },
+        {
+          "code": "Q4947547",
+          "label": "Bossa Studios"
+        },
+        {
+          "code": "Q5009907",
+          "label": "CDC Games"
+        },
+        {
+          "code": "Q4957770",
+          "label": "Brash Entertainment"
+        },
+        {
+          "code": "Q4748798",
+          "label": "Amsoft"
+        },
+        {
+          "code": "Q5010013",
+          "label": "Idigicon Limited"
+        },
+        {
+          "code": "Q4732637",
+          "label": "Alligata Software Ltd."
+        },
+        {
+          "code": "Q4904930",
+          "label": "Big Ant Studios"
+        },
+        {
+          "code": "Q11328870",
+          "label": "PSK"
+        },
+        {
+          "code": "Q11293405",
+          "label": "Overdose"
+        },
+        {
+          "code": "Q12427844",
+          "label": "Rake in Grass"
+        },
+        {
+          "code": "Q11326720",
+          "label": "HAMSTER"
+        },
+        {
+          "code": "Q13409231",
+          "label": "Atari, Inc."
+        },
+        {
+          "code": "Q11281947",
+          "label": "Valkyria"
+        },
+        {
+          "code": "Q11230243",
+          "label": "Littlewitch"
+        },
+        {
+          "code": "Q11297257",
+          "label": "Character Soft"
+        },
+        {
+          "code": "Q11781632",
+          "label": "Mirage Media S.C."
+        },
+        {
+          "code": "Q12062864",
+          "label": "Creoteam"
+        },
+        {
+          "code": "Q11250605",
+          "label": "Terios"
+        },
+        {
+          "code": "Q11236056",
+          "label": "NTT Solmare"
+        },
+        {
+          "code": "Q11246868",
+          "label": "softhouse-seal"
+        },
+        {
+          "code": "Q11318258",
+          "label": "Champion Soft"
+        },
+        {
+          "code": "Q11689554",
+          "label": "Cenega"
+        },
+        {
+          "code": "Q11298146",
+          "label": "Gaga Corporation"
+        },
+        {
+          "code": "Q11321917",
+          "label": "Trabulance"
+        },
+        {
+          "code": "Q11243960",
+          "label": "Sorahane"
+        },
+        {
+          "code": "Q11269069",
+          "label": "Shakunage"
+        },
+        {
+          "code": "Q11276039",
+          "label": "Pajama Soft"
+        },
+        {
+          "code": "Q11256742",
+          "label": "Airyu"
+        },
+        {
+          "code": "Q5519804",
+          "label": "GameTek"
+        },
+        {
+          "code": "Q5686300",
+          "label": "Hayden Books"
+        },
+        {
+          "code": "Q5366830",
+          "label": "DMM.com"
+        },
+        {
+          "code": "Q5380509",
+          "label": "Entex Industries"
+        },
+        {
+          "code": "Q5915217",
+          "label": "Indescomp"
+        },
+        {
+          "code": "Q5434166",
+          "label": "Fantasoft"
+        },
+        {
+          "code": "Q5455143",
+          "label": "Fishtank Interactive"
+        },
+        {
+          "code": "Q5769368",
+          "label": "Hirameki"
+        },
+        {
+          "code": "Q5871728",
+          "label": "Hitcents"
+        },
+        {
+          "code": "Q5519649",
+          "label": "Good Shepherd Entertainment"
+        },
+        {
+          "code": "Q5595537",
+          "label": "Grandslam Entertainments"
+        },
+        {
+          "code": "Q5647718",
+          "label": "HandyGames"
+        },
+        {
+          "code": "Q5437078",
+          "label": "Faster Than Light"
+        },
+        {
+          "code": "Q6045669",
+          "label": "Interceptor Micros"
+        },
+        {
+          "code": "Q5647556",
+          "label": "Hands-On Mobile"
+        },
+        {
+          "code": "Q297315",
+          "label": "ASCII Media Works"
+        },
+        {
+          "code": "Q267427",
+          "label": "Humble Bundle"
+        },
+        {
+          "code": "Q339228",
+          "label": "Acclaim Entertainment"
+        },
+        {
+          "code": "Q306334",
+          "label": "Enterbrain"
+        },
+        {
+          "code": "Q14428",
+          "label": "Capcom"
+        },
+        {
+          "code": "Q18594",
+          "label": "Sony Interactive Entertainment"
+        },
+        {
+          "code": "Q122741",
+          "label": "Sega"
+        },
+        {
+          "code": "Q94937",
+          "label": "2K Games"
+        },
+        {
+          "code": "Q48756935",
+          "label": "Flyhigh Works"
+        },
+        {
+          "code": "Q44293084",
+          "label": "Fruitbat Factory"
+        },
+        {
+          "code": "Q48851768",
+          "label": "Portkey Games"
+        },
+        {
+          "code": "Q39047089",
+          "label": "Gamious"
+        },
+        {
+          "code": "Q48886565",
+          "label": "TapTap"
+        },
+        {
+          "code": "Q39058513",
+          "label": "Choice of Games"
+        },
+        {
+          "code": "Q47015754",
+          "label": "Yostar"
+        },
+        {
+          "code": "Q47498862",
+          "label": "Chorus Worldwide"
+        },
+        {
+          "code": "Q46617715",
+          "label": "Private Division"
+        },
+        {
+          "code": "Q48885544",
+          "label": "MorningTec"
+        },
+        {
+          "code": "Q7131061",
+          "label": "Panic"
+        },
+        {
+          "code": "Q7050580",
+          "label": "Nordcurrent"
+        },
+        {
+          "code": "Q7092366",
+          "label": "OneBigGame"
+        },
+        {
+          "code": "Q7536445",
+          "label": "Skotos"
+        },
+        {
+          "code": "Q7557166",
+          "label": "Sold-Out Software"
+        },
+        {
+          "code": "Q7168080",
+          "label": "Perfect World"
+        },
+        {
+          "code": "Q7165499",
+          "label": "People's Computer Company"
+        },
+        {
+          "code": "Q7278619",
+          "label": "Rabbit Software"
+        },
+        {
+          "code": "Q7072272",
+          "label": "O3 Entertainment"
+        },
+        {
+          "code": "Q7514940",
+          "label": "Silicon Beach Software"
+        },
+        {
+          "code": "Q7301375",
+          "label": "Realtime Games Software"
+        },
+        {
+          "code": "Q7415719",
+          "label": "Sanctuary Woods"
+        },
+        {
+          "code": "Q7521343",
+          "label": "Simulations Canada"
+        },
+        {
+          "code": "Q1474023",
+          "label": "Funatics Software"
+        },
+        {
+          "code": "Q1481820",
+          "label": "Virgin Interactive"
+        },
+        {
+          "code": "Q1517179",
+          "label": "System 3"
+        },
+        {
+          "code": "Q1469961",
+          "label": "ASC Games"
+        },
+        {
+          "code": "Q1501379",
+          "label": "Parker Brothers"
+        },
+        {
+          "code": "Q1484006",
+          "label": "Terzio Verlag"
+        },
+        {
+          "code": "Q3080720",
+          "label": "France Image Logiciel"
+        },
+        {
+          "code": "Q3153614",
+          "label": "Interstel Corporation"
+        },
+        {
+          "code": "Q3110042",
+          "label": "Kongregate"
+        },
+        {
+          "code": "Q3147611",
+          "label": "Iceberg Interactive"
+        },
+        {
+          "code": "Q3178586",
+          "label": "Coffee Stain Studios"
+        },
+        {
+          "code": "Q207922",
+          "label": "Atari"
+        },
+        {
+          "code": "Q23901",
+          "label": "Codemasters"
+        },
+        {
+          "code": "Q18356743",
+          "label": "Sekai Project"
+        },
+        {
+          "code": "Q17211555",
+          "label": "KITERETSU"
+        },
+        {
+          "code": "Q17561297",
+          "label": "Fullbright"
+        },
+        {
+          "code": "Q18210616",
+          "label": "Kiro'o Games"
+        },
+        {
+          "code": "Q18380936",
+          "label": "4399"
+        },
+        {
+          "code": "Q18708812",
+          "label": "Wanda Cinemas"
+        },
+        {
+          "code": "Q17228185",
+          "label": "Karin Entertainment"
+        },
+        {
+          "code": "Q17238705",
+          "label": "Playism"
+        },
+        {
+          "code": "Q18151782",
+          "label": "Nightdive Studios"
+        },
+        {
+          "code": "Q18208513",
+          "label": "Yodo1"
+        },
+        {
+          "code": "Q403714",
+          "label": "Majesco Entertainment"
+        },
+        {
+          "code": "Q417230",
+          "label": "Akella"
+        },
+        {
+          "code": "Q391183",
+          "label": "Incentive Software"
+        },
+        {
+          "code": "Q372471",
+          "label": "Wargaming"
+        },
+        {
+          "code": "Q188273",
+          "label": "Ubisoft"
+        },
+        {
+          "code": "Q32839567",
+          "label": "Idea"
+        },
+        {
+          "code": "Q30256731",
+          "label": "Electronic Arts (United Kingdom)"
+        },
+        {
+          "code": "Q33198629",
+          "label": "Mode 7"
+        },
+        {
+          "code": "Q30589821",
+          "label": "Psytronik Software"
+        },
+        {
+          "code": "Q32999145",
+          "label": "Playdigious"
+        },
+        {
+          "code": "Q30957005",
+          "label": "Cyber Light Game Studio"
+        },
+        {
+          "code": "Q33326497",
+          "label": "3909"
+        },
+        {
+          "code": "Q33462287",
+          "label": "Over The Moon"
+        },
+        {
+          "code": "Q30644872",
+          "label": "Raw Fury"
+        },
+        {
+          "code": "Q30892769",
+          "label": "Meridian4"
+        },
+        {
+          "code": "Q32839621",
+          "label": "Genias"
+        },
+        {
+          "code": "Q33326238",
+          "label": "EXOR Studios"
+        },
+        {
+          "code": "Q33440274",
+          "label": "Krillbite Studio"
+        },
+        {
+          "code": "Q33465537",
+          "label": "Young Horses"
+        },
+        {
+          "code": "Q33542636",
+          "label": "Reakktor Studios"
+        },
+        {
+          "code": "Q33570510",
+          "label": "Stellar Jockeys"
+        },
+        {
+          "code": "Q30925983",
+          "label": "Simon Creative"
+        },
+        {
+          "code": "Q31626043",
+          "label": "Dire Wolf Digital"
+        },
+        {
+          "code": "Q32860615",
+          "label": "Butterscotch Shenanigans"
+        },
+        {
+          "code": "Q31086789",
+          "label": "Small Giant Games"
+        },
+        {
+          "code": "Q33198526",
+          "label": "IMGN.PRO"
+        },
+        {
+          "code": "Q38045602",
+          "label": "Golden Era Games"
+        },
+        {
+          "code": "Q38805988",
+          "label": "Annapurna Interactive"
+        },
+        {
+          "code": "Q31803137",
+          "label": "Mytona"
+        },
+        {
+          "code": "Q19695395",
+          "label": "Masaya"
+        },
+        {
+          "code": "Q21189333",
+          "label": "Fig"
+        },
+        {
+          "code": "Q20052760",
+          "label": "Behold Studios"
+        },
+        {
+          "code": "Q21036514",
+          "label": "Starbyte"
+        },
+        {
+          "code": "Q21189319",
+          "label": "En Masse Entertainment"
+        },
+        {
+          "code": "Q20529838",
+          "label": "ZA/UM"
+        },
+        {
+          "code": "Q21189808",
+          "label": "tinyBuild Games"
+        },
+        {
+          "code": "Q19516403",
+          "label": "Playtonic Games"
+        },
+        {
+          "code": "Q20827200",
+          "label": "Rainbird Software"
+        },
+        {
+          "code": "Q18819564",
+          "label": "First Touch Games"
+        },
+        {
+          "code": "Q19704710",
+          "label": "Ketchapp"
+        },
+        {
+          "code": "Q21013688",
+          "label": "Versus Evil"
+        },
+        {
+          "code": "Q5227451",
+          "label": "Datamost"
+        },
+        {
+          "code": "Q5200430",
+          "label": "Cypronia"
+        },
+        {
+          "code": "Q5275891",
+          "label": "Digital Jesters"
+        },
+        {
+          "code": "Q5267669",
+          "label": "Devolver Digital"
+        },
+        {
+          "code": "Q5337654",
+          "label": "Edge Games"
+        },
+        {
+          "code": "Q5357363",
+          "label": "Electric Dreams Software"
+        },
+        {
+          "code": "Q5357296",
+          "label": "Yuzusoft"
+        },
+        {
+          "code": "Q5013911",
+          "label": "CRL Group"
+        },
+        {
+          "code": "Q5204120",
+          "label": "D4 Enterprise"
+        },
+        {
+          "code": "Q5174029",
+          "label": "Cosmi Corporation"
+        },
+        {
+          "code": "Q2324070",
+          "label": "Denda Games"
+        },
+        {
+          "code": "Q2373255",
+          "label": "Swisslos"
+        },
+        {
+          "code": "Q2300984",
+          "label": "Titus Interactive"
+        },
+        {
+          "code": "Q2297531",
+          "label": "Softgold Computerspiele"
+        },
+        {
+          "code": "Q2310496",
+          "label": "Palace Software"
+        },
+        {
+          "code": "Q2319420",
+          "label": "Warner Bros. Games"
+        },
+        {
+          "code": "Q2401222",
+          "label": "Telarium"
+        },
+        {
+          "code": "Q1806630",
+          "label": "Silmarils"
+        },
+        {
+          "code": "Q1894281",
+          "label": "Smaky"
+        },
+        {
+          "code": "Q1884071",
+          "label": "Magic Bytes"
+        },
+        {
+          "code": "Q1930918",
+          "label": "U.S. Gold"
+        },
+        {
+          "code": "Q2659812",
+          "label": "Pack-In-Video"
+        },
+        {
+          "code": "Q2602093",
+          "label": "Sumo Digital"
+        },
+        {
+          "code": "Q2577763",
+          "label": "Lucasfan Games"
+        },
+        {
+          "code": "Q2632192",
+          "label": "Strategy First"
+        },
+        {
+          "code": "Q2617855",
+          "label": "Arc System Works"
+        },
+        {
+          "code": "Q2553434",
+          "label": "Renegade Kid"
+        },
+        {
+          "code": "Q193559",
+          "label": "Valve Corporation"
+        },
+        {
+          "code": "Q217493",
+          "label": "Paradox Interactive"
+        },
+        {
+          "code": "Q208305",
+          "label": "Commodore International"
+        },
+        {
+          "code": "Q214036",
+          "label": "21st Century Entertainment"
+        },
+        {
+          "code": "Q216611",
+          "label": "Lucasfilm Games"
+        },
+        {
+          "code": "Q1547355",
+          "label": "Markt+Technik"
+        },
+        {
+          "code": "Q1570468",
+          "label": "Mindscape"
+        },
+        {
+          "code": "Q1574191",
+          "label": "Hanako Games"
+        },
+        {
+          "code": "Q1576915",
+          "label": "Koei Tecmo Holdings"
+        },
+        {
+          "code": "Q1576643",
+          "label": "Sulake Corporation"
+        },
+        {
+          "code": "Q1615297",
+          "label": "Mastertronic"
+        },
+        {
+          "code": "Q200491",
+          "label": "Activision Publishing"
+        },
+        {
+          "code": "Q207784",
+          "label": "Square Enix"
+        },
+        {
+          "code": "Q54255920",
+          "label": "Mobigame"
+        },
+        {
+          "code": "Q54257504",
+          "label": "MPForce, Inc."
+        },
+        {
+          "code": "Q54258978",
+          "label": "Peak Games"
+        },
+        {
+          "code": "Q54308709",
+          "label": "Super Evil Megacorp"
+        },
+        {
+          "code": "Q54131639",
+          "label": "HumaNature Studios"
+        },
+        {
+          "code": "Q54303510",
+          "label": "Vision Games"
+        },
+        {
+          "code": "Q54150472",
+          "label": "The Quantum Astrophysicists Guild"
+        },
+        {
+          "code": "Q54258449",
+          "label": "Oasis Games"
+        },
+        {
+          "code": "Q54307207",
+          "label": "PVP Studio"
+        },
+        {
+          "code": "Q54309902",
+          "label": "Tapps Games"
+        },
+        {
+          "code": "Q54132750",
+          "label": "ILLION Corp"
+        },
+        {
+          "code": "Q54305596",
+          "label": "Psydra Games"
+        },
+        {
+          "code": "Q54171012",
+          "label": "Libredia"
+        },
+        {
+          "code": "Q26689565",
+          "label": "Umbrella"
+        },
+        {
+          "code": "Q28129037",
+          "label": "Amazon Games"
+        },
+        {
+          "code": "Q26260375",
+          "label": "Gun Interactive"
+        },
+        {
+          "code": "Q26715541",
+          "label": "Dinosaur Polo Club"
+        },
+        {
+          "code": "Q26715626",
+          "label": "G2CREW"
+        },
+        {
+          "code": "Q28026114",
+          "label": "Limited Run Games"
+        },
+        {
+          "code": "Q25441778",
+          "label": "InLogic Software"
+        },
+        {
+          "code": "Q26720075",
+          "label": "Wube Software"
+        },
+        {
+          "code": "Q26715453",
+          "label": "Axolot Games"
+        },
+        {
+          "code": "Q26715402",
+          "label": "GrabTheGames"
+        },
+        {
+          "code": "Q24909573",
+          "label": "Modoka"
+        },
+        {
+          "code": "Q27044867",
+          "label": "Ocelot Society"
+        },
+        {
+          "code": "Q27703660",
+          "label": "Odnako Games"
+        },
+        {
+          "code": "Q16628821",
+          "label": "Digital Integration"
+        },
+        {
+          "code": "Q17193803",
+          "label": "Index Corporation"
+        },
+        {
+          "code": "Q16988330",
+          "label": "Curve Games"
+        },
+        {
+          "code": "Q17017989",
+          "label": "Nyu Media"
+        },
+        {
+          "code": "Q15950732",
+          "label": "Lianzhong"
+        },
+        {
+          "code": "Q15995083",
+          "label": "Game Grumps"
+        },
+        {
+          "code": "Q17038791",
+          "label": "Yoozoo Games"
+        },
+        {
+          "code": "Q15895939",
+          "label": "CBS Electronics"
+        },
+        {
+          "code": "Q16991942",
+          "label": "Excalibur Publishing"
+        },
+        {
+          "code": "Q15895956",
+          "label": "Roklan Corporation"
+        },
+        {
+          "code": "Q15911229",
+          "label": "Dream Software"
+        },
+        {
+          "code": "Q16558259",
+          "label": "DROsoft"
+        },
+        {
+          "code": "Q17033596",
+          "label": "Wangyuan Shengtang"
+        },
+        {
+          "code": "Q15905487",
+          "label": "Firedog Studio"
+        },
+        {
+          "code": "Q453802",
+          "label": "Imagic"
+        },
+        {
+          "code": "Q494614",
+          "label": "Sierra Entertainment"
+        },
+        {
+          "code": "Q513712",
+          "label": "Pony Canyon"
+        },
+        {
+          "code": "Q483036",
+          "label": "NCSoft"
+        },
+        {
+          "code": "Q15070456",
+          "label": "Smilesoft"
+        },
+        {
+          "code": "Q15232085",
+          "label": "Lexis Numérique"
+        },
+        {
+          "code": "Q15781815",
+          "label": "Aerosoft"
+        },
+        {
+          "code": "Q14001326",
+          "label": "MumboJumbo"
+        },
+        {
+          "code": "Q14752655",
+          "label": "Apus Software"
+        },
+        {
+          "code": "Q15031115",
+          "label": "Kadokawa Future Publishing"
+        },
+        {
+          "code": "Q15139437",
+          "label": "NEXON Korea"
+        },
+        {
+          "code": "Q13839393",
+          "label": "Arc Games"
+        },
+        {
+          "code": "Q2442965",
+          "label": "Toolbox"
+        },
+        {
+          "code": "Q2536056",
+          "label": "Tengen"
+        },
+        {
+          "code": "Q2450081",
+          "label": "Glu Mobile"
+        },
+        {
+          "code": "Q2549114",
+          "label": "CI Games S.A."
+        },
+        {
+          "code": "Q2492131",
+          "label": "Ultra Games"
+        },
+        {
+          "code": "Q2447732",
+          "label": "Tradewest"
+        },
+        {
+          "code": "Q7735062",
+          "label": "The Fourth Dimension"
+        },
+        {
+          "code": "Q7864546",
+          "label": "UFO Interactive Games"
+        },
+        {
+          "code": "Q8776769",
+          "label": "Erbe Software S.A."
+        },
+        {
+          "code": "Q7865507",
+          "label": "UPL"
+        },
+        {
+          "code": "Q7632010",
+          "label": "Subsim"
+        },
+        {
+          "code": "Q7643396",
+          "label": "Supergiant Games"
+        },
+        {
+          "code": "Q7663606",
+          "label": "SystemSoft Alpha"
+        },
+        {
+          "code": "Q7959294",
+          "label": "Wadjet Eye Games"
+        },
+        {
+          "code": "Q7577588",
+          "label": "Spinnaker Software"
+        },
+        {
+          "code": "Q7692095",
+          "label": "TecMagik"
+        },
+        {
+          "code": "Q7797234",
+          "label": "Three-Sixty Pacific"
+        },
+        {
+          "code": "Q8075731",
+          "label": "ZyX"
+        },
+        {
+          "code": "Q8189895",
+          "label": "Studio e.go!"
+        },
+        {
+          "code": "Q9142801",
+          "label": "Aidem Media"
+        },
+        {
+          "code": "Q2030718",
+          "label": "Rebellion Developments"
+        },
+        {
+          "code": "Q2068881",
+          "label": "Penguin Software"
+        },
+        {
+          "code": "Q2068658",
+          "label": "505 Games"
+        },
+        {
+          "code": "Q26188",
+          "label": "Kalypso Media"
+        },
+        {
+          "code": "Q45700",
+          "label": "Konami"
+        },
+        {
+          "code": "Q28225",
+          "label": "2K Play"
+        },
+        {
+          "code": "Q11228013",
+          "label": "Klein"
+        },
+        {
+          "code": "Q11189559",
+          "label": "Aria"
+        },
+        {
+          "code": "Q11195901",
+          "label": "Diva"
+        },
+        {
+          "code": "Q11193573",
+          "label": "Comfort"
+        },
+        {
+          "code": "Q9197236",
+          "label": "CyberFront"
+        },
+        {
+          "code": "Q10269187",
+          "label": "Dynacom"
+        },
+        {
+          "code": "Q10274953",
+          "label": "Espaço Informática"
+        },
+        {
+          "code": "Q10902322",
+          "label": "Suntendy Interactive Multimedia Co.,Ltd."
+        },
+        {
+          "code": "Q11223729",
+          "label": "I.D."
+        },
+        {
+          "code": "Q10890291",
+          "label": "Guangyu Huaxia"
+        },
+        {
+          "code": "Q11200696",
+          "label": "G.J?"
+        },
+        {
+          "code": "Q10734337",
+          "label": "Hooksoft"
+        },
+        {
+          "code": "Q10853322",
+          "label": "WillPlus."
+        },
+        {
+          "code": "Q11193399",
+          "label": "CLOCKUP"
+        },
+        {
+          "code": "Q10851063",
+          "label": "IDEA Games"
+        },
+        {
+          "code": "Q11201892",
+          "label": "GROOVER"
+        },
+        {
+          "code": "Q11230030",
+          "label": "LiLiM"
+        },
+        {
+          "code": "Q10875882",
+          "label": "CE-Asia"
+        },
+        {
+          "code": "Q11190270",
+          "label": "AngelSmile"
+        },
+        {
+          "code": "Q10906145",
+          "label": "King's International Multimedia Co., Ltd."
+        },
+        {
+          "code": "Q10889280",
+          "label": "X-Legend"
+        },
+        {
+          "code": "Q245723",
+          "label": "Zylom"
+        },
+        {
+          "code": "Q262760",
+          "label": "Swiss Federal Institute of Technology in Lausanne"
+        },
+        {
+          "code": "Q94912",
+          "label": "Rockstar Games"
+        },
+        {
+          "code": "Q694590",
+          "label": "Bigpoint GmbH"
+        },
+        {
+          "code": "Q696625",
+          "label": "JoWooD Entertainment"
+        },
+        {
+          "code": "Q738135",
+          "label": "Aspyr"
+        },
+        {
+          "code": "Q739711",
+          "label": "Epic Games"
+        },
+        {
+          "code": "Q2274654",
+          "label": "Gremlin Interactive"
+        },
+        {
+          "code": "Q2291232",
+          "label": "Toaplan"
+        },
+        {
+          "code": "Q2145745",
+          "label": "Resistance Records"
+        },
+        {
+          "code": "Q2275894",
+          "label": "TalonSoft"
+        },
+        {
+          "code": "Q2166710",
+          "label": "Roseverte"
+        },
+        {
+          "code": "Q1756771",
+          "label": "Psion"
+        },
+        {
+          "code": "Q1671616",
+          "label": "Introversion Software"
+        },
+        {
+          "code": "Q1692707",
+          "label": "Eidos Interactive"
+        },
+        {
+          "code": "Q1742154",
+          "label": "Kingsoft GmbH"
+        },
+        {
+          "code": "Q1782700",
+          "label": "Infogrames"
+        },
+        {
+          "code": "Q750414",
+          "label": "Astragon"
+        },
+        {
+          "code": "Q742561",
+          "label": "Infocom"
+        },
+        {
+          "code": "Q753684",
+          "label": "Atari SA"
+        },
+        {
+          "code": "Q2737049",
+          "label": "Quest"
+        },
+        {
+          "code": "Q2687460",
+          "label": "Rising Star Games"
+        },
+        {
+          "code": "Q2819359",
+          "label": "ARG Informatique"
+        },
+        {
+          "code": "Q3037459",
+          "label": "Double Eleven"
+        },
+        {
+          "code": "Q2714179",
+          "label": "Empire Interactive"
+        },
+        {
+          "code": "Q2845995",
+          "label": "Anco Software"
+        },
+        {
+          "code": "Q3055077",
+          "label": "Entertainment Software Publishing"
+        },
+        {
+          "code": "Q2864855",
+          "label": "Artefacts Studio"
+        },
+        {
+          "code": "Q3009079",
+          "label": "Mass Media Inc."
+        },
+        {
+          "code": "Q2912131",
+          "label": "Studio Ryokucha"
+        },
+        {
+          "code": "Q3975821",
+          "label": "Strangelite"
+        },
+        {
+          "code": "Q3606516",
+          "label": "Agetec"
+        },
+        {
+          "code": "Q3627870",
+          "label": "Atari Corporation"
+        },
+        {
+          "code": "Q4037549",
+          "label": "DotEmu"
+        },
+        {
+          "code": "Q3627878",
+          "label": "Atarisoft"
+        },
+        {
+          "code": "Q3775043",
+          "label": "GameHouse"
+        },
+        {
+          "code": "Q3962810",
+          "label": "Slitherine Software UK Limited"
+        },
+        {
+          "code": "Q3579482",
+          "label": "Editions Pix'n Love"
+        },
+        {
+          "code": "Q954877",
+          "label": "SETA Corporation"
+        },
+        {
+          "code": "Q1049502",
+          "label": "Hudson Soft"
+        },
+        {
+          "code": "Q1045037",
+          "label": "AliceSoft"
+        },
+        {
+          "code": "Q1046593",
+          "label": "Gearbox Software"
+        },
+        {
+          "code": "Q958101",
+          "label": "Jagex"
+        },
+        {
+          "code": "Q6824407",
+          "label": "Metro3D"
+        },
+        {
+          "code": "Q6931345",
+          "label": "Mud Duck Productions"
+        },
+        {
+          "code": "Q6785541",
+          "label": "Mastiff"
+        },
+        {
+          "code": "Q6841107",
+          "label": "Midas Interactive Entertainment"
+        },
+        {
+          "code": "Q6795851",
+          "label": "Maximum Games"
+        },
+        {
+          "code": "Q6839448",
+          "label": "Microdeal"
+        },
+        {
+          "code": "Q6083391",
+          "label": "Positech Games"
+        },
+        {
+          "code": "Q6915320",
+          "label": "Mosaic Publishing"
+        },
+        {
+          "code": "Q6535056",
+          "label": "Level Up! Games"
+        },
+        {
+          "code": "Q6072534",
+          "label": "Iron Galaxy Studios"
+        },
+        {
+          "code": "Q6518563",
+          "label": "Lego Interactive"
+        },
+        {
+          "code": "Q6720517",
+          "label": "M Network"
+        },
+        {
+          "code": "Q178824",
+          "label": "Blizzard Entertainment"
+        },
+        {
+          "code": "Q174561",
+          "label": "Kemco"
+        },
+        {
+          "code": "Q3410210",
+          "label": "Psygnosis"
+        },
+        {
+          "code": "Q3576011",
+          "label": "indiePub"
+        },
+        {
+          "code": "Q3327169",
+          "label": "Topo Soft"
+        },
+        {
+          "code": "Q3314312",
+          "label": "Millennium Interactive"
+        },
+        {
+          "code": "Q3520864",
+          "label": "The Fighter Collection"
+        },
+        {
+          "code": "Q3342525",
+          "label": "Nobilis"
+        },
+        {
+          "code": "Q3566785",
+          "label": "WayForward Technologies"
+        },
+        {
+          "code": "Q3325177",
+          "label": "Motion Twin"
+        },
+        {
+          "code": "Q3316179",
+          "label": "Mirrorsoft"
+        },
+        {
+          "code": "Q3337882",
+          "label": "Neko Entertainment"
+        },
+        {
+          "code": "Q3576010",
+          "label": "Zoo Corporation"
+        },
+        {
+          "code": "Q3206159",
+          "label": "Light & Shadow Production"
+        },
+        {
+          "code": "Q24081023",
+          "label": "Daniel Mullins Games"
+        },
+        {
+          "code": "Q24081284",
+          "label": "AGM PLAYISM"
+        },
+        {
+          "code": "Q21208888",
+          "label": "MAG Interactive"
+        },
+        {
+          "code": "Q24707091",
+          "label": "Finji"
+        },
+        {
+          "code": "Q21405666",
+          "label": "SkyBox Labs"
+        },
+        {
+          "code": "Q22078683",
+          "label": "Sysnet Info-Tech"
+        },
+        {
+          "code": "Q23761586",
+          "label": "Night School Studio"
+        },
+        {
+          "code": "Q24080184",
+          "label": "Brace Yourself Games"
+        },
+        {
+          "code": "Q22127855",
+          "label": "Digital Cute"
+        },
+        {
+          "code": "Q22908904",
+          "label": "Hipster Whale"
+        },
+        {
+          "code": "Q22909786",
+          "label": "Winged Cloud"
+        },
+        {
+          "code": "Q24869515",
+          "label": "Ape, Inc."
+        },
+        {
+          "code": "Q22079511",
+          "label": "Telesys"
+        },
+        {
+          "code": "Q23795636",
+          "label": "Northway Games"
+        },
+        {
+          "code": "Q24256223",
+          "label": "Transhuman Design"
+        },
+        {
+          "code": "Q21463692",
+          "label": "Tri Synergy"
+        },
+        {
+          "code": "Q23301680",
+          "label": "Kitfox Games"
+        },
+        {
+          "code": "Q24840496",
+          "label": "Phoenix Media"
+        },
+        {
+          "code": "Q22078689",
+          "label": "Matrix Interactive"
+        },
+        {
+          "code": "Q129745895",
+          "label": "Aktia"
+        },
+        {
+          "code": "Q129745481",
+          "label": "Future Italy"
+        },
+        {
+          "code": "Q131048322",
+          "label": "Sabay"
+        },
+        {
+          "code": "Q131386431",
+          "label": "Playground Productions"
+        },
+        {
+          "code": "Q129382068",
+          "label": "Flyin Kebab Studio"
+        },
+        {
+          "code": "Q129384008",
+          "label": "Digital Bridges"
+        },
+        {
+          "code": "Q129380929",
+          "label": "Yabukaratang"
+        },
+        {
+          "code": "Q129412004",
+          "label": "CggtGroup"
+        },
+        {
+          "code": "Q129549496",
+          "label": "Femdom studio"
+        },
+        {
+          "code": "Q129550242",
+          "label": "Duigrind"
+        },
+        {
+          "code": "Q129550560",
+          "label": "Cyber Keks"
+        },
+        {
+          "code": "Q129664186",
+          "label": "Selo tech.corp."
+        },
+        {
+          "code": "Q129745105",
+          "label": "Xenia Edizioni"
+        },
+        {
+          "code": "Q129745711",
+          "label": "Sprea Media"
+        },
+        {
+          "code": "Q129786681",
+          "label": "NSFWEntertainment"
+        },
+        {
+          "code": "Q129786713",
+          "label": "Hentai works"
+        },
+        {
+          "code": "Q129841948",
+          "label": "Associazione Culturale Airons di Vigevano"
+        },
+        {
+          "code": "Q130212933",
+          "label": "Reddiamondgames"
+        },
+        {
+          "code": "Q130213132",
+          "label": "DSGame"
+        },
+        {
+          "code": "Q130213152",
+          "label": "Tin Man Games"
+        },
+        {
+          "code": "Q130320256",
+          "label": "Iron Jelly"
+        },
+        {
+          "code": "Q130320260",
+          "label": "WitchGames"
+        },
+        {
+          "code": "Q130324022",
+          "label": "Cr3 Studio"
+        },
+        {
+          "code": "Q130355754",
+          "label": "C4rib"
+        },
+        {
+          "code": "Q130380726",
+          "label": "SK Soft"
+        },
+        {
+          "code": "Q130383222",
+          "label": "Critical Reflex"
+        },
+        {
+          "code": "Q130436882",
+          "label": "Official Wicked Vixen"
+        },
+        {
+          "code": "Q130437872",
+          "label": "Yellow Dog Man Studios"
+        },
+        {
+          "code": "Q130444774",
+          "label": "Digital Touch"
+        },
+        {
+          "code": "Q130453595",
+          "label": "Reco Technology"
+        },
+        {
+          "code": "Q130453596",
+          "label": "UIG Entertainment"
+        },
+        {
+          "code": "Q130453597",
+          "label": "Winking Skywalker Entertainment"
+        },
+        {
+          "code": "Q130453599",
+          "label": "Lace Mamba Group"
+        },
+        {
+          "code": "Q130526698",
+          "label": "Keypunch Software"
+        },
+        {
+          "code": "Q130532895",
+          "label": "Big Bang Studio"
+        },
+        {
+          "code": "Q130565466",
+          "label": "Mediamond"
+        },
+        {
+          "code": "Q130731627",
+          "label": "Fiveamp"
+        },
+        {
+          "code": "Q130747171",
+          "label": "Vittgen Inc."
+        },
+        {
+          "code": "Q131369789",
+          "label": "PiXEL"
+        },
+        {
+          "code": "Q131386481",
+          "label": "Movie Games"
+        },
+        {
+          "code": "Q131406106",
+          "label": "Freedom Productions"
+        },
+        {
+          "code": "Q131437009",
+          "label": "Freeciv Team"
+        },
+        {
+          "code": "Q133445",
+          "label": "2K Sports"
+        },
+        {
+          "code": "Q173941",
+          "label": "Electronic Arts"
+        },
+        {
+          "code": "Q553658",
+          "label": "Deep Silver"
+        },
+        {
+          "code": "Q561385",
+          "label": "Travian Games"
+        },
+        {
+          "code": "Q565073",
+          "label": "Rainbow Arts"
+        },
+        {
+          "code": "Q579796",
+          "label": "Hasbro Interactive"
+        },
+        {
+          "code": "Q59618146",
+          "label": "IQ Media Nordic"
+        },
+        {
+          "code": "Q59647789",
+          "label": "Elliptic Games"
+        },
+        {
+          "code": "Q60029546",
+          "label": "Night Owl Gaming LLC"
+        },
+        {
+          "code": "Q60169569",
+          "label": "QubicGames"
+        },
+        {
+          "code": "Q60618445",
+          "label": "GFX47"
+        },
+        {
+          "code": "Q60564866",
+          "label": "Ghost_RUS Games"
+        },
+        {
+          "code": "Q60173735",
+          "label": "KISS"
+        },
+        {
+          "code": "Q59398251",
+          "label": "Shatterline Productions"
+        },
+        {
+          "code": "Q59400716",
+          "label": "Zever Games"
+        },
+        {
+          "code": "Q60476133",
+          "label": "Zeppelin Games"
+        },
+        {
+          "code": "Q60617056",
+          "label": "SpiteWrench"
+        },
+        {
+          "code": "Q60161310",
+          "label": "Undertow Games"
+        },
+        {
+          "code": "Q60174436",
+          "label": "Dry Cactus"
+        },
+        {
+          "code": "Q60616885",
+          "label": "Three Guys Game Studio"
+        },
+        {
+          "code": "Q59560112",
+          "label": "Moonlight Studios"
+        },
+        {
+          "code": "Q60173388",
+          "label": "Arcane Raise"
+        },
+        {
+          "code": "Q60603602",
+          "label": "Sony Computer Entertainment Europe Ltd."
+        },
+        {
+          "code": "Q59278955",
+          "label": "Robot Invader"
+        },
+        {
+          "code": "Q59617720",
+          "label": "NStorm"
+        },
+        {
+          "code": "Q60101804",
+          "label": "Infinite Monkeys Entertainment"
+        },
+        {
+          "code": "Q60174302",
+          "label": "Leti Arts"
+        },
+        {
+          "code": "Q60317287",
+          "label": "Back To Basics Gaming"
+        },
+        {
+          "code": "Q60172676",
+          "label": "ACID"
+        },
+        {
+          "code": "Q60616881",
+          "label": "Gethsemane Publishing"
+        },
+        {
+          "code": "Q59559127",
+          "label": "Narratio Studios"
+        },
+        {
+          "code": "Q60221856",
+          "label": "TACTICAL Soft Inc."
+        },
+        {
+          "code": "Q60614515",
+          "label": "Merge Games"
+        },
+        {
+          "code": "Q59786082",
+          "label": "Holy Sheep"
+        },
+        {
+          "code": "Q60169489",
+          "label": "Dark-1"
+        },
+        {
+          "code": "Q60188061",
+          "label": "Hypixel Studios"
+        },
+        {
+          "code": "Q60182664",
+          "label": "Northwood Studios"
+        },
+        {
+          "code": "Q60324673",
+          "label": "VizionEck"
+        },
+        {
+          "code": "Q60616868",
+          "label": "The Family Collective"
+        },
+        {
+          "code": "Q527336",
+          "label": "Atari, Inc."
+        },
+        {
+          "code": "Q542018",
+          "label": "PlayStation Studios"
+        },
+        {
+          "code": "Q795348",
+          "label": "Neowiz"
+        },
+        {
+          "code": "Q798642",
+          "label": "Asmik Ace Entertainment"
+        },
+        {
+          "code": "Q780528",
+          "label": "Atlus"
+        },
+        {
+          "code": "Q859575",
+          "label": "Nacon"
+        },
+        {
+          "code": "Q839441",
+          "label": "KineticNovel"
+        },
+        {
+          "code": "Q758872",
+          "label": "Audiogenic"
+        },
+        {
+          "code": "Q795583",
+          "label": "NEOWIZ"
+        },
+        {
+          "code": "Q64624936",
+          "label": "Alpha-Unit"
+        },
+        {
+          "code": "Q65032689",
+          "label": "Imadio"
+        },
+        {
+          "code": "Q64349081",
+          "label": "Fairprice Games"
+        },
+        {
+          "code": "Q64495277",
+          "label": "Phoenix Games Group"
+        },
+        {
+          "code": "Q64814857",
+          "label": "Voodoo"
+        },
+        {
+          "code": "Q64167382",
+          "label": "OPeNBooK Co., Ltd."
+        },
+        {
+          "code": "Q64364469",
+          "label": "Popcorn Arcade"
+        },
+        {
+          "code": "Q64447391",
+          "label": "Time Warner Interactive Ltd."
+        },
+        {
+          "code": "Q64918019",
+          "label": "Marvel Games"
+        },
+        {
+          "code": "Q64495247",
+          "label": "Phoenix Games B.V."
+        },
+        {
+          "code": "Q65144337",
+          "label": "ThankCreate Studio"
+        },
+        {
+          "code": "Q66314471",
+          "label": "Screenwave Media"
+        },
+        {
+          "code": "Q64685211",
+          "label": "AurumDust"
+        },
+        {
+          "code": "Q64826846",
+          "label": "Dharker Studio"
+        },
+        {
+          "code": "Q65083539",
+          "label": "Embracer Group"
+        },
+        {
+          "code": "Q64141528",
+          "label": "E-Line Media"
+        },
+        {
+          "code": "Q64447020",
+          "label": "Toho Cinefile-Soft Library"
+        },
+        {
+          "code": "Q64495248",
+          "label": "Phoenix Games Ltd."
+        },
+        {
+          "code": "Q65786285",
+          "label": "Flare Media Limited"
+        },
+        {
+          "code": "Q64224941",
+          "label": "Design Design"
+        },
+        {
+          "code": "Q64351782",
+          "label": "Big Future"
+        },
+        {
+          "code": "Q64447764",
+          "label": "Kawada Co., Ltd."
+        },
+        {
+          "code": "Q65803772",
+          "label": "Critical Bliss"
+        },
+        {
+          "code": "Q64569499",
+          "label": "Pamplin Entertainment"
+        },
+        {
+          "code": "Q64829506",
+          "label": "Opal Games"
+        },
+        {
+          "code": "Q65228585",
+          "label": "KADOKAWA Game Linkage"
+        },
+        {
+          "code": "Q65643831",
+          "label": "Dramatic Create"
+        },
+        {
+          "code": "Q601299",
+          "label": "Video System"
+        },
+        {
+          "code": "Q615181",
+          "label": "Strategic Studies Group"
+        },
+        {
+          "code": "Q628249",
+          "label": "Interplay Entertainment"
+        },
+        {
+          "code": "Q655493",
+          "label": "Petroglyph Games"
+        },
+        {
+          "code": "Q587502",
+          "label": "Tandy Corporation"
+        },
+        {
+          "code": "Q621599",
+          "label": "Application Systems Heidelberg"
+        },
+        {
+          "code": "Q634677",
+          "label": "Hewson Consultants"
+        },
+        {
+          "code": "Q52144653",
+          "label": "8th Day Software"
+        },
+        {
+          "code": "Q52159646",
+          "label": "North of Earth"
+        },
+        {
+          "code": "Q52159607",
+          "label": "Total Monkery"
+        },
+        {
+          "code": "Q52345503",
+          "label": "Cosmonaut Games"
+        },
+        {
+          "code": "Q52694640",
+          "label": "Noodlecake"
+        },
+        {
+          "code": "Q52539890",
+          "label": "Love Gun"
+        },
+        {
+          "code": "Q51955248",
+          "label": "EarthWork Games"
+        },
+        {
+          "code": "Q52085298",
+          "label": "Artifex Mundi"
+        },
+        {
+          "code": "Q52164641",
+          "label": "HexWar Games"
+        },
+        {
+          "code": "Q52084691",
+          "label": "Players Software"
+        },
+        {
+          "code": "Q52152915",
+          "label": "Amused Sloth"
+        },
+        {
+          "code": "Q52153177",
+          "label": "Osgoode Media"
+        },
+        {
+          "code": "Q52153423",
+          "label": "TREVA Entertainment"
+        },
+        {
+          "code": "Q54121489",
+          "label": "Chubby Pixel"
+        },
+        {
+          "code": "Q52200626",
+          "label": "we.R.play"
+        },
+        {
+          "code": "Q52692538",
+          "label": "Above and Beyond Technologies"
+        },
+        {
+          "code": "Q54117155",
+          "label": "Adage Games"
+        },
+        {
+          "code": "Q54122845",
+          "label": "Crows Crows Crows"
+        },
+        {
+          "code": "Q51856931",
+          "label": "Paleozoic"
+        },
+        {
+          "code": "Q48967969",
+          "label": "AtariAge"
+        },
+        {
+          "code": "Q51701831",
+          "label": "Team Salvato"
+        },
+        {
+          "code": "Q52029200",
+          "label": "BadLand Games"
+        },
+        {
+          "code": "Q52084103",
+          "label": "Hibernum Créations Inc."
+        },
+        {
+          "code": "Q52136141",
+          "label": "Blueshift Media"
+        },
+        {
+          "code": "Q52341326",
+          "label": "Cheesy Software"
+        },
+        {
+          "code": "Q52693236",
+          "label": "Idea Fabrik"
+        },
+        {
+          "code": "Q52730802",
+          "label": "Imperium42 Game Studio"
+        },
+        {
+          "code": "Q48976504",
+          "label": "Mattel Interactive"
+        },
+        {
+          "code": "Q52279640",
+          "label": "Enkord"
+        },
+        {
+          "code": "Q52695329",
+          "label": "Ravenous Games"
+        },
+        {
+          "code": "Q54129401",
+          "label": "Game Troopers, SL"
+        },
+        {
+          "code": "Q54130855",
+          "label": "Gunjin Games Limited"
+        },
+        {
+          "code": "Q52021004",
+          "label": "Ysbryd Games"
+        },
+        {
+          "code": "Q52159429",
+          "label": "Electronic Zoo"
+        },
+        {
+          "code": "Q52201719",
+          "label": "Eagleware International Productions"
+        },
+        {
+          "code": "Q52035108",
+          "label": "Gameblyr"
+        },
+        {
+          "code": "Q52163459",
+          "label": "EnjoyUp"
+        },
+        {
+          "code": "Q51010538",
+          "label": "Chillingo"
+        },
+        {
+          "code": "Q60978211",
+          "label": "Fulqrum Publishing"
+        },
+        {
+          "code": "Q61629925",
+          "label": "Fellow Traveller"
+        },
+        {
+          "code": "Q61793218",
+          "label": "Fig"
+        },
+        {
+          "code": "Q60630224",
+          "label": "Outer Planet Studios"
+        },
+        {
+          "code": "Q60630558",
+          "label": "Gravity Whale Games"
+        },
+        {
+          "code": "Q60860593",
+          "label": "PlayWay"
+        },
+        {
+          "code": "Q61741241",
+          "label": "Army Game Project"
+        },
+        {
+          "code": "Q61748427",
+          "label": "Polarbit AB"
+        },
+        {
+          "code": "Q61731728",
+          "label": "Origin Systems"
+        },
+        {
+          "code": "Q60629919",
+          "label": "Kasedo Games"
+        },
+        {
+          "code": "Q61731739",
+          "label": "Konami of America"
+        },
+        {
+          "code": "Q61793216",
+          "label": "Triband"
+        },
+        {
+          "code": "Q60775793",
+          "label": "Super Rare Games"
+        },
+        {
+          "code": "Q61793219",
+          "label": "The Label"
+        },
+        {
+          "code": "Q61943448",
+          "label": "Pujia8 Studio"
+        },
+        {
+          "code": "Q60761534",
+          "label": "City Connection"
+        },
+        {
+          "code": "Q60634040",
+          "label": "The Hidden Levels"
+        },
+        {
+          "code": "Q61469155",
+          "label": "BS Studios"
+        },
+        {
+          "code": "Q61699211",
+          "label": "TinyMob Games"
+        },
+        {
+          "code": "Q61947965",
+          "label": "Cantaloupe Kids"
+        },
+        {
+          "code": "Q60618995",
+          "label": "Rockwell Studios, LLC"
+        },
+        {
+          "code": "Q61602104",
+          "label": "Storm City Entertainment, Inc."
+        },
+        {
+          "code": "Q61699906",
+          "label": "Ember Entertainment"
+        },
+        {
+          "code": "Q61700161",
+          "label": "Grimm Bros"
+        },
+        {
+          "code": "Q61749354",
+          "label": "Zeebo Brasil"
+        },
+        {
+          "code": "Q61757094",
+          "label": "Studio Cypix"
+        },
+        {
+          "code": "Q61959692",
+          "label": "Atom Team"
+        },
+        {
+          "code": "Q61994680",
+          "label": "Paper Cult"
+        },
+        {
+          "code": "Q61756986",
+          "label": "Joathrent Studios"
+        },
+        {
+          "code": "Q62011455",
+          "label": "NetEase Games"
+        },
+        {
+          "code": "Q60993169",
+          "label": "Game Cores"
+        },
+        {
+          "code": "Q662567",
+          "label": "Ariolasoft"
+        },
+        {
+          "code": "Q684425",
+          "label": "Bethesda Softworks"
+        },
+        {
+          "code": "Q674686",
+          "label": "Level-5"
+        },
+        {
+          "code": "Q684357",
+          "label": "Federal Ministry for Economic Cooperation and Development"
+        },
+        {
+          "code": "Q1054844",
+          "label": "Taito"
+        },
+        {
+          "code": "Q1092474",
+          "label": "Cinemaware"
+        },
+        {
+          "code": "Q1061580",
+          "label": "Atari Games"
+        },
+        {
+          "code": "Q57901762",
+          "label": "Sabarasa Entertainment"
+        },
+        {
+          "code": "Q58646345",
+          "label": "Head Games Publishing"
+        },
+        {
+          "code": "Q58854381",
+          "label": "Krea Medie"
+        },
+        {
+          "code": "Q56750827",
+          "label": "Wx3 Labs"
+        },
+        {
+          "code": "Q59198758",
+          "label": "Polypogon Games"
+        },
+        {
+          "code": "Q56825525",
+          "label": "Hyper Fox Studios"
+        },
+        {
+          "code": "Q57019633",
+          "label": "Red Fox Game Studios"
+        },
+        {
+          "code": "Q57473164",
+          "label": "Loveshack Entertainment"
+        },
+        {
+          "code": "Q57834351",
+          "label": "ms.app"
+        },
+        {
+          "code": "Q59198303",
+          "label": "Battlestate Games"
+        },
+        {
+          "code": "Q59277454",
+          "label": "Fangamer"
+        },
+        {
+          "code": "Q56872873",
+          "label": "Opaque Space"
+        },
+        {
+          "code": "Q58645141",
+          "label": "TriSoft"
+        },
+        {
+          "code": "Q58886464",
+          "label": "Kodera Software"
+        },
+        {
+          "code": "Q59276079",
+          "label": "Falcon Development"
+        },
+        {
+          "code": "Q56754217",
+          "label": "Defiant Development"
+        },
+        {
+          "code": "Q57250474",
+          "label": "Heartomics"
+        },
+        {
+          "code": "Q57251843",
+          "label": "Worthless Bums"
+        },
+        {
+          "code": "Q57362423",
+          "label": "Bithell Games"
+        },
+        {
+          "code": "Q57476904",
+          "label": "Panic Barn"
+        },
+        {
+          "code": "Q57650411",
+          "label": "Aloft Studio"
+        },
+        {
+          "code": "Q57252431",
+          "label": "Spacepup Entertainment"
+        },
+        {
+          "code": "Q57400784",
+          "label": "Lavaboots Studios"
+        },
+        {
+          "code": "Q58645561",
+          "label": "SoftKey Multimedia"
+        },
+        {
+          "code": "Q58885287",
+          "label": "Level-10"
+        },
+        {
+          "code": "Q59222994",
+          "label": "Plug In Digital"
+        },
+        {
+          "code": "Q59224980",
+          "label": "MiniChimera Game Studio"
+        },
+        {
+          "code": "Q59229674",
+          "label": "Suncrash"
+        },
+        {
+          "code": "Q59254735",
+          "label": "Unfold Games"
+        },
+        {
+          "code": "Q56878935",
+          "label": "Burrik"
+        },
+        {
+          "code": "Q57017144",
+          "label": "REDFOX™ Game Studio Limited"
+        },
+        {
+          "code": "Q57249750",
+          "label": "Itharius"
+        },
+        {
+          "code": "Q57834910",
+          "label": "Shroeder Studios"
+        },
+        {
+          "code": "Q58461310",
+          "label": "Ynor"
+        },
+        {
+          "code": "Q58642690",
+          "label": "Nordic Softsales"
+        },
+        {
+          "code": "Q58646054",
+          "label": "Telstar Electronic Studios"
+        },
+        {
+          "code": "Q59194478",
+          "label": "Schmidt Workshops"
+        },
+        {
+          "code": "Q59222830",
+          "label": "Meltdown Interactive Media"
+        },
+        {
+          "code": "Q59243891",
+          "label": "Blast Entertainment"
+        },
+        {
+          "code": "Q59247850",
+          "label": "Brighter Minds"
+        },
+        {
+          "code": "Q56849899",
+          "label": "Crystalline Green Ltd."
+        },
+        {
+          "code": "Q57082807",
+          "label": "Machine Studios"
+        },
+        {
+          "code": "Q4401085",
+          "label": "Russobit-M"
+        },
+        {
+          "code": "Q4045349",
+          "label": "Nikita Online"
+        },
+        {
+          "code": "Q4047302",
+          "label": "PQube"
+        },
+        {
+          "code": "Q4604373",
+          "label": "MangaGamer"
+        },
+        {
+          "code": "Q4644252",
+          "label": "8-4"
+        },
+        {
+          "code": "Q4120720",
+          "label": "Kuma Reality Games"
+        },
+        {
+          "code": "Q4040478",
+          "label": "Headup Games"
+        },
+        {
+          "code": "Q4042609",
+          "label": "Larian Studios"
+        },
+        {
+          "code": "Q1148541",
+          "label": "Visual Arts"
+        },
+        {
+          "code": "Q1143795",
+          "label": "August"
+        },
+        {
+          "code": "Q1135204",
+          "label": "Wizards of the Coast"
+        },
+        {
+          "code": "Q1141245",
+          "label": "Insomniac Games"
+        },
+        {
+          "code": "Q104541491",
+          "label": "Nimble Neuron"
+        },
+        {
+          "code": "Q104636206",
+          "label": "Serenity Forge"
+        },
+        {
+          "code": "Q104828536",
+          "label": "Aldorlea Games"
+        },
+        {
+          "code": "Q105151088",
+          "label": "The Dairymen"
+        },
+        {
+          "code": "Q105324891",
+          "label": "Graffiti Games"
+        },
+        {
+          "code": "Q104531592",
+          "label": "Cascade Games"
+        },
+        {
+          "code": "Q104813485",
+          "label": "Lever Games"
+        },
+        {
+          "code": "Q104884967",
+          "label": "W3D Hub"
+        },
+        {
+          "code": "Q105070916",
+          "label": "Sirlin Games"
+        },
+        {
+          "code": "Q105102486",
+          "label": "Supergonk"
+        },
+        {
+          "code": "Q104580902",
+          "label": "Flashbulb Games"
+        },
+        {
+          "code": "Q104670579",
+          "label": "PBI Software"
+        },
+        {
+          "code": "Q104921862",
+          "label": "Silverbyte"
+        },
+        {
+          "code": "Q105106371",
+          "label": "Braingame Publishing"
+        },
+        {
+          "code": "Q105154362",
+          "label": "Fiftytwo"
+        },
+        {
+          "code": "Q105222217",
+          "label": "Robot House Games"
+        },
+        {
+          "code": "Q105304774",
+          "label": "Gearbox Publishing"
+        },
+        {
+          "code": "Q104785259",
+          "label": "Devespresso Games"
+        },
+        {
+          "code": "Q104863489",
+          "label": "Tilting Point"
+        },
+        {
+          "code": "Q104866429",
+          "label": "Discis Knowledge Research"
+        },
+        {
+          "code": "Q105010204",
+          "label": "Flamebait Games"
+        },
+        {
+          "code": "Q105075493",
+          "label": "Ripstone"
+        },
+        {
+          "code": "Q105107086",
+          "label": "Heureka-Klett-Softwareverlag"
+        },
+        {
+          "code": "Q104537050",
+          "label": "New Reality Games"
+        },
+        {
+          "code": "Q104830657",
+          "label": "Glitch"
+        },
+        {
+          "code": "Q104804097",
+          "label": "Halifax"
+        },
+        {
+          "code": "Q104804157",
+          "label": "Blaze"
+        },
+        {
+          "code": "Q104535820",
+          "label": "Dangen Entertainment"
+        },
+        {
+          "code": "Q104827386",
+          "label": "Humble Games"
+        },
+        {
+          "code": "Q104879174",
+          "label": "Modularity"
+        },
+        {
+          "code": "Q104601053",
+          "label": "Wolfy"
+        },
+        {
+          "code": "Q104542008",
+          "label": "Rocketcat Games"
+        },
+        {
+          "code": "Q104845515",
+          "label": "Ukiyo Publishing"
+        },
+        {
+          "code": "Q105089922",
+          "label": "Firefly Games"
+        },
+        {
+          "code": "Q105161596",
+          "label": "State of Play"
+        },
+        {
+          "code": "Q75049650",
+          "label": "Twofaced Games"
+        },
+        {
+          "code": "Q67046041",
+          "label": "Naraven Games"
+        },
+        {
+          "code": "Q68088835",
+          "label": "Popcannibal"
+        },
+        {
+          "code": "Q72368711",
+          "label": "CIRCLE Entertainment"
+        },
+        {
+          "code": "Q73088402",
+          "label": "2Dimensions"
+        },
+        {
+          "code": "Q74491941",
+          "label": "Graybeard Games"
+        },
+        {
+          "code": "Q74892870",
+          "label": "MayoNinja Games"
+        },
+        {
+          "code": "Q66796984",
+          "label": "Dear Villagers"
+        },
+        {
+          "code": "Q67413292",
+          "label": "IfThen Software LLC"
+        },
+        {
+          "code": "Q70266232",
+          "label": "KO_OP"
+        },
+        {
+          "code": "Q71916378",
+          "label": "QUByte Interactive"
+        },
+        {
+          "code": "Q76359404",
+          "label": "Pixel Error"
+        },
+        {
+          "code": "Q79402333",
+          "label": "Sharkmob"
+        },
+        {
+          "code": "Q67050943",
+          "label": "AppSir"
+        },
+        {
+          "code": "Q67161782",
+          "label": "Motion Miracles"
+        },
+        {
+          "code": "Q68094551",
+          "label": "Return To Adventure Mountain, LLC"
+        },
+        {
+          "code": "Q70274956",
+          "label": "Buckethead Entertainment"
+        },
+        {
+          "code": "Q66834424",
+          "label": "Nacon"
+        },
+        {
+          "code": "Q77369313",
+          "label": "Stumbling Cat"
+        },
+        {
+          "code": "Q71338225",
+          "label": "Tainted Games"
+        },
+        {
+          "code": "Q76887630",
+          "label": "Actual Humans"
+        },
+        {
+          "code": "Q66457828",
+          "label": "Yangyang Mobile"
+        },
+        {
+          "code": "Q67524450",
+          "label": "YumeHaven"
+        },
+        {
+          "code": "Q68190735",
+          "label": "K Bros Games"
+        },
+        {
+          "code": "Q69352476",
+          "label": "COVER Corporation"
+        },
+        {
+          "code": "Q70890142",
+          "label": "Iconic Gaming Studio"
+        },
+        {
+          "code": "Q71445307",
+          "label": "S-court"
+        },
+        {
+          "code": "Q72975717",
+          "label": "Maranyo Games"
+        },
+        {
+          "code": "Q75672726",
+          "label": "Devil Kitty Games"
+        },
+        {
+          "code": "Q76349217",
+          "label": "Placeholder Gameworks"
+        },
+        {
+          "code": "Q67530734",
+          "label": "Volcanic Games"
+        },
+        {
+          "code": "Q69891912",
+          "label": "GreenupGames"
+        },
+        {
+          "code": "Q70258963",
+          "label": "Arbitrary Metric"
+        },
+        {
+          "code": "Q70584772",
+          "label": "Edenic Era LLC"
+        },
+        {
+          "code": "Q72327814",
+          "label": "Chilla's Art"
+        },
+        {
+          "code": "Q66777838",
+          "label": "Seriously"
+        },
+        {
+          "code": "Q69556200",
+          "label": "Ludomotion"
+        },
+        {
+          "code": "Q71005670",
+          "label": "SlyGames"
+        },
+        {
+          "code": "Q1156046",
+          "label": "The Pokémon Company"
+        },
+        {
+          "code": "Q1172213",
+          "label": "Data East"
+        },
+        {
+          "code": "Q1172285",
+          "label": "Datasoft"
+        },
+        {
+          "code": "Q1246399",
+          "label": "MediaWorks"
+        },
+        {
+          "code": "Q1268871",
+          "label": "Strategic Simulations"
+        },
+        {
+          "code": "Q1194689",
+          "label": "Bandai Namco Entertainment"
+        },
+        {
+          "code": "Q1191932",
+          "label": "0verflow"
+        },
+        {
+          "code": "Q1177836",
+          "label": "Davilex Games"
+        },
+        {
+          "code": "Q55425357",
+          "label": "Scetlander Ltd."
+        },
+        {
+          "code": "Q55436731",
+          "label": "Extrokold Games"
+        },
+        {
+          "code": "Q55441096",
+          "label": "Granada Publishing Ltd."
+        },
+        {
+          "code": "Q55639133",
+          "label": "Akupara Games"
+        },
+        {
+          "code": "Q55663530",
+          "label": "Indie Glue"
+        },
+        {
+          "code": "Q55418540",
+          "label": "Ricochet"
+        },
+        {
+          "code": "Q55331909",
+          "label": "Storm"
+        },
+        {
+          "code": "Q55331944",
+          "label": "Emotional Pictures"
+        },
+        {
+          "code": "Q55394606",
+          "label": "Deothic"
+        },
+        {
+          "code": "Q55560815",
+          "label": "Buckrider Studio"
+        },
+        {
+          "code": "Q55587315",
+          "label": "Linel"
+        },
+        {
+          "code": "Q55662193",
+          "label": "Snarky Ant, LLC"
+        },
+        {
+          "code": "Q55332320",
+          "label": "XD"
+        },
+        {
+          "code": "Q54822032",
+          "label": "Glock Software"
+        },
+        {
+          "code": "Q55251985",
+          "label": "ShareData"
+        },
+        {
+          "code": "Q55341001",
+          "label": "Cyberstyle"
+        },
+        {
+          "code": "Q55342434",
+          "label": "Tom Mix Software"
+        },
+        {
+          "code": "Q55423152",
+          "label": "Edizioni Società SIPE srl."
+        },
+        {
+          "code": "Q54823201",
+          "label": "BURA"
+        },
+        {
+          "code": "Q54878373",
+          "label": "Box Office Software"
+        },
+        {
+          "code": "Q55027399",
+          "label": "Roberts Space Industries International, Ltd."
+        },
+        {
+          "code": "Q55313577",
+          "label": "On-Line Entertainment Ltd."
+        },
+        {
+          "code": "Q55387181",
+          "label": "Seemingly Pointless"
+        },
+        {
+          "code": "Q55344818",
+          "label": "Sparklers"
+        },
+        {
+          "code": "Q54834702",
+          "label": "phime studio"
+        },
+        {
+          "code": "Q54877457",
+          "label": "Grey Alien Games"
+        },
+        {
+          "code": "Q55171146",
+          "label": "Spooky Doorway"
+        },
+        {
+          "code": "Q55239429",
+          "label": "Commodore Magazine"
+        },
+        {
+          "code": "Q55253703",
+          "label": "Byte Back"
+        },
+        {
+          "code": "Q55317356",
+          "label": "DLM (Developmental Learning Materials)"
+        },
+        {
+          "code": "Q55363517",
+          "label": "Games From The Deep"
+        },
+        {
+          "code": "Q55423273",
+          "label": "Ediciones Ingelek S.A."
+        },
+        {
+          "code": "Q55426172",
+          "label": "Nissho Iwai Infocom Systems Co., Ltd."
+        },
+        {
+          "code": "Q55437692",
+          "label": "Myroid-Type Comics"
+        },
+        {
+          "code": "Q54897956",
+          "label": "White Giant RPG Studios"
+        },
+        {
+          "code": "Q55313672",
+          "label": "Systems Editoriale s.r.l."
+        },
+        {
+          "code": "Q55331750",
+          "label": "Compute! Publications, Inc."
+        },
+        {
+          "code": "Q55592364",
+          "label": "CRASS Infotech"
+        },
+        {
+          "code": "Q55402181",
+          "label": "OneOcean LLC"
+        },
+        {
+          "code": "Q55508821",
+          "label": "Pixel Wizards"
+        },
+        {
+          "code": "Q55661355",
+          "label": "Pubblirome"
+        },
+        {
+          "code": "Q55662724",
+          "label": "Studio Gamaii"
+        },
+        {
+          "code": "Q54890557",
+          "label": "IceSitruuna"
+        },
+        {
+          "code": "Q55091126",
+          "label": "LavaMind"
+        },
+        {
+          "code": "Q55251565",
+          "label": "Funtastic"
+        },
+        {
+          "code": "Q55283017",
+          "label": "Dilmer Games"
+        },
+        {
+          "code": "Q55336954",
+          "label": "MicroProse-Spectrum HoloByte UK-Europe"
+        },
+        {
+          "code": "Q55438436",
+          "label": "WhisperGames"
+        },
+        {
+          "code": "Q108099290",
+          "label": "2tainment"
+        },
+        {
+          "code": "Q109063277",
+          "label": "ChiliDog Interactive"
+        },
+        {
+          "code": "Q109007194",
+          "label": "Accelerate Games"
+        },
+        {
+          "code": "Q109314703",
+          "label": "NekoNyan"
+        },
+        {
+          "code": "Q108142468",
+          "label": "Ultimate Games"
+        },
+        {
+          "code": "Q108304729",
+          "label": "Onion Games"
+        },
+        {
+          "code": "Q108325233",
+          "label": "Blayze Games"
+        },
+        {
+          "code": "Q108438121",
+          "label": "COWCAT Games"
+        },
+        {
+          "code": "Q108659876",
+          "label": "Octro, Inc."
+        },
+        {
+          "code": "Q109081789",
+          "label": "EpiXR Games"
+        },
+        {
+          "code": "Q108169843",
+          "label": "Falling Squirrel"
+        },
+        {
+          "code": "Q108815228",
+          "label": "BOKE"
+        },
+        {
+          "code": "Q108934913",
+          "label": "RaceRoom Entertainment"
+        },
+        {
+          "code": "Q109060082",
+          "label": "Motorsport Games"
+        },
+        {
+          "code": "Q109079674",
+          "label": "Dolores Entertainment"
+        },
+        {
+          "code": "Q109081377",
+          "label": "Hidden Trap"
+        },
+        {
+          "code": "Q109064526",
+          "label": "Mega9pixel"
+        },
+        {
+          "code": "Q109300214",
+          "label": "Pyramid Games"
+        },
+        {
+          "code": "Q108947430",
+          "label": "The MIX Games"
+        },
+        {
+          "code": "Q108945266",
+          "label": "Eastasiasoft"
+        },
+        {
+          "code": "Q108938000",
+          "label": "Thermite Games"
+        },
+        {
+          "code": "Q108940857",
+          "label": "Sometimes You"
+        },
+        {
+          "code": "Q109064497",
+          "label": "Big Way Games"
+        },
+        {
+          "code": "Q109077833",
+          "label": "JanduSoft"
+        },
+        {
+          "code": "Q107986107",
+          "label": "Whitethorn Games"
+        },
+        {
+          "code": "Q108525814",
+          "label": "Codigames"
+        },
+        {
+          "code": "Q109305962",
+          "label": "Exkee"
+        },
+        {
+          "code": "Q109357960",
+          "label": "ZlonGame"
+        },
+        {
+          "code": "Q105392197",
+          "label": "Blowfish Studios"
+        },
+        {
+          "code": "Q105423930",
+          "label": "Draknek Limited"
+        },
+        {
+          "code": "Q105960384",
+          "label": "Flipline Studios"
+        },
+        {
+          "code": "Q106171121",
+          "label": "My.Games"
+        },
+        {
+          "code": "Q105355950",
+          "label": "Crazy Labs"
+        },
+        {
+          "code": "Q105518752",
+          "label": "Maximum Family Games"
+        },
+        {
+          "code": "Q106323066",
+          "label": "Hound Picked Games"
+        },
+        {
+          "code": "Q106323633",
+          "label": "indienova"
+        },
+        {
+          "code": "Q105585242",
+          "label": "Anarch Entertainment"
+        },
+        {
+          "code": "Q105722121",
+          "label": "Cobra Mobile"
+        },
+        {
+          "code": "Q105623468",
+          "label": "Scorpion Software"
+        },
+        {
+          "code": "Q106070909",
+          "label": "Mundfish"
+        },
+        {
+          "code": "Q105364475",
+          "label": "Crescent Moon Games"
+        },
+        {
+          "code": "Q105630357",
+          "label": "Awe Interactive"
+        },
+        {
+          "code": "Q105673206",
+          "label": "The Adventure Workshop"
+        },
+        {
+          "code": "Q105741166",
+          "label": "INTV"
+        },
+        {
+          "code": "Q106104223",
+          "label": "FriendTimes"
+        },
+        {
+          "code": "Q105450826",
+          "label": "Studio MDHR"
+        },
+        {
+          "code": "Q105641121",
+          "label": "Boss Team Games"
+        },
+        {
+          "code": "Q105701577",
+          "label": "IzanagiGames"
+        },
+        {
+          "code": "Q105956976",
+          "label": "Surefire.Games"
+        },
+        {
+          "code": "Q106019597",
+          "label": "Leaf Mobile"
+        },
+        {
+          "code": "Q106311529",
+          "label": "Aoca Game Lab"
+        },
+        {
+          "code": "Q105623524",
+          "label": "East Cube"
+        },
+        {
+          "code": "Q105956821",
+          "label": "Foreign Gnomes"
+        },
+        {
+          "code": "Q105976524",
+          "label": "MWM Interactive"
+        },
+        {
+          "code": "Q106229313",
+          "label": "RedRoc Interactive"
+        },
+        {
+          "code": "Q921944",
+          "label": "Focus Entertainment"
+        },
+        {
+          "code": "Q864366",
+          "label": "Lump of Sugar"
+        },
+        {
+          "code": "Q930354",
+          "label": "GT Interactive Software"
+        },
+        {
+          "code": "Q875609",
+          "label": "Siemens Nixdorf Informationssysteme"
+        },
+        {
+          "code": "Q918638",
+          "label": "Funcom"
+        },
+        {
+          "code": "Q1361716",
+          "label": "D3 Publisher"
+        },
+        {
+          "code": "Q1371744",
+          "label": "Banpresto"
+        },
+        {
+          "code": "Q4686510",
+          "label": "Adventure International"
+        },
+        {
+          "code": "Q4681127",
+          "label": "Addictive Games"
+        },
+        {
+          "code": "Q131449401",
+          "label": "Sikalosoft"
+        },
+        {
+          "code": "Q131703535",
+          "label": "Appcharge"
+        },
+        {
+          "code": "Q131704206",
+          "label": "念念而忘(Indelible Studio)"
+        },
+        {
+          "code": "Q131704218",
+          "label": "Storytaco"
+        },
+        {
+          "code": "Q132126001",
+          "label": "Abracadata"
+        },
+        {
+          "code": "Q85786254",
+          "label": "Moonton"
+        },
+        {
+          "code": "Q85805488",
+          "label": "LCG Entertainment, Inc."
+        },
+        {
+          "code": "Q86756163",
+          "label": "Playgendary"
+        },
+        {
+          "code": "Q89292991",
+          "label": "Fiction Factory Games"
+        },
+        {
+          "code": "Q92009942",
+          "label": "Ratalaika Games"
+        },
+        {
+          "code": "Q85691737",
+          "label": "FDG Entertainment"
+        },
+        {
+          "code": "Q85850231",
+          "label": "Auroch Digital"
+        },
+        {
+          "code": "Q89100104",
+          "label": "Forever Entertainment"
+        },
+        {
+          "code": "Q91620371",
+          "label": "Maddy Makes Games"
+        },
+        {
+          "code": "Q90909484",
+          "label": "Blood Music"
+        },
+        {
+          "code": "Q85671146",
+          "label": "Magic Design Studios"
+        },
+        {
+          "code": "Q85957868",
+          "label": "animate GAMES"
+        },
+        {
+          "code": "Q87766793",
+          "label": "Cinemaware, Inc."
+        },
+        {
+          "code": "Q85561408",
+          "label": "Gamestorming"
+        },
+        {
+          "code": "Q85607259",
+          "label": "Nexters"
+        },
+        {
+          "code": "Q86690447",
+          "label": "KillHouse Games"
+        },
+        {
+          "code": "Q91038266",
+          "label": "PlayStation Mobile, Inc."
+        },
+        {
+          "code": "Q85639499",
+          "label": "OtakuMaker"
+        },
+        {
+          "code": "Q86679800",
+          "label": "All in! Games"
+        },
+        {
+          "code": "Q88788847",
+          "label": "Yamba Media"
+        },
+        {
+          "code": "Q55707866",
+          "label": "Papergames"
+        },
+        {
+          "code": "Q55764945",
+          "label": "Diamond Bytes"
+        },
+        {
+          "code": "Q55807196",
+          "label": "Viking Tao"
+        },
+        {
+          "code": "Q55850759",
+          "label": "CBS Software"
+        },
+        {
+          "code": "Q56037119",
+          "label": "Editoriale Video (EV)"
+        },
+        {
+          "code": "Q56224237",
+          "label": "CookieByte Entertainment"
+        },
+        {
+          "code": "Q56545189",
+          "label": "Oh, a Rock! Studios"
+        },
+        {
+          "code": "Q56433268",
+          "label": "Pandora"
+        },
+        {
+          "code": "Q55765109",
+          "label": "The World Outside"
+        },
+        {
+          "code": "Q56046990",
+          "label": "Winner"
+        },
+        {
+          "code": "Q55764766",
+          "label": "Edizioni Hobby"
+        },
+        {
+          "code": "Q55813555",
+          "label": "Bypass Game Studios"
+        },
+        {
+          "code": "Q56056109",
+          "label": "SimFabric"
+        },
+        {
+          "code": "Q56440780",
+          "label": "Gamepires"
+        },
+        {
+          "code": "Q56641082",
+          "label": "Terahard"
+        },
+        {
+          "code": "Q56072801",
+          "label": "Ariolasoft UK"
+        },
+        {
+          "code": "Q56061994",
+          "label": "Spotlight Software"
+        },
+        {
+          "code": "Q55936642",
+          "label": "MVP Software"
+        },
+        {
+          "code": "Q56039564",
+          "label": "Rino Marketing Ltd."
+        },
+        {
+          "code": "Q56151092",
+          "label": "No More Robots"
+        },
+        {
+          "code": "Q56419712",
+          "label": "Micro Fun"
+        },
+        {
+          "code": "Q56679137",
+          "label": "Cardboard Keep"
+        },
+        {
+          "code": "Q56683352",
+          "label": "Digerati"
+        },
+        {
+          "code": "Q55693750",
+          "label": "Cult Games"
+        },
+        {
+          "code": "Q56088761",
+          "label": "Mindscape International"
+        },
+        {
+          "code": "Q56204362",
+          "label": "Nkidu Games"
+        },
+        {
+          "code": "Q56256991",
+          "label": "Mad Dog Games"
+        },
+        {
+          "code": "Q56683028",
+          "label": "Transposia"
+        },
+        {
+          "code": "Q55754285",
+          "label": "dilithium Press"
+        },
+        {
+          "code": "Q55764961",
+          "label": "Logyk Software"
+        },
+        {
+          "code": "Q55901401",
+          "label": "Binary Zone Interactive"
+        },
+        {
+          "code": "Q55982432",
+          "label": "CW Communications, Inc."
+        },
+        {
+          "code": "Q56035096",
+          "label": "Tensoft"
+        },
+        {
+          "code": "Q56039123",
+          "label": "PDPD Software"
+        },
+        {
+          "code": "Q56054944",
+          "label": "Philips Interactive Media, Inc."
+        },
+        {
+          "code": "Q56062007",
+          "label": "Micro Status"
+        },
+        {
+          "code": "Q56255885",
+          "label": "Interactive Technology"
+        },
+        {
+          "code": "Q56378830",
+          "label": "Fraxel Games"
+        },
+        {
+          "code": "Q56649198",
+          "label": "Bitten Toast Games"
+        },
+        {
+          "code": "Q56056311",
+          "label": "Decabry"
+        },
+        {
+          "code": "Q55758953",
+          "label": "House Pixel Games"
+        },
+        {
+          "code": "Q55839772",
+          "label": "Necrosoft Games"
+        },
+        {
+          "code": "Q55864418",
+          "label": "Bold Games"
+        },
+        {
+          "code": "Q55948609",
+          "label": "ValuSoft"
+        },
+        {
+          "code": "Q56049630",
+          "label": "Visions (Software Factory) Ltd."
+        },
+        {
+          "code": "Q56404101",
+          "label": "Commodore Business Machines (UK)"
+        },
+        {
+          "code": "Q109533609",
+          "label": "neko.works"
+        },
+        {
+          "code": "Q109420021",
+          "label": "Turner Interactive"
+        },
+        {
+          "code": "Q109588057",
+          "label": "HypeTrain Digital"
+        },
+        {
+          "code": "Q109381699",
+          "label": "RedDeerGames"
+        },
+        {
+          "code": "Q109422630",
+          "label": "Giiku Games"
+        },
+        {
+          "code": "Q109564626",
+          "label": "Milk Bottle Studio"
+        },
+        {
+          "code": "Q109588130",
+          "label": "Ant Workshop"
+        },
+        {
+          "code": "Q109620657",
+          "label": "Moe App"
+        },
+        {
+          "code": "Q109657082",
+          "label": "Snaggletooth Studios"
+        },
+        {
+          "code": "Q109451801",
+          "label": "Penguin Pop Games"
+        },
+        {
+          "code": "Q109501387",
+          "label": "BonusXP"
+        },
+        {
+          "code": "Q109557313",
+          "label": "Sedoc LLC"
+        },
+        {
+          "code": "Q109619982",
+          "label": "Chaos Group Games"
+        },
+        {
+          "code": "Q109418161",
+          "label": "Windstone Games"
+        },
+        {
+          "code": "Q109532700",
+          "label": "PixelHeart"
+        },
+        {
+          "code": "Q109556837",
+          "label": "Numskull Games"
+        },
+        {
+          "code": "Q109668958",
+          "label": "Fantastico Studio"
+        },
+        {
+          "code": "Q109714029",
+          "label": "Jinke"
+        },
+        {
+          "code": "Q109531508",
+          "label": "Koei Tecmo Europe"
+        },
+        {
+          "code": "Q109582894",
+          "label": "SakuraGame"
+        },
+        {
+          "code": "Q109587972",
+          "label": "Red Art Games"
+        },
+        {
+          "code": "Q109592760",
+          "label": "Playtonic Friends"
+        },
+        {
+          "code": "Q109620774",
+          "label": "HUBLOTS CO., Ltd"
+        },
+        {
+          "code": "Q109423693",
+          "label": "Twin Sails Interactive"
+        },
+        {
+          "code": "Q109532985",
+          "label": "No Gravity Games"
+        },
+        {
+          "code": "Q109622375",
+          "label": "Crystal Game Works"
+        },
+        {
+          "code": "Q109669676",
+          "label": "Radical Phi"
+        },
+        {
+          "code": "Q106438156",
+          "label": "Amanotes"
+        },
+        {
+          "code": "Q106463005",
+          "label": "Anirog Software"
+        },
+        {
+          "code": "Q106470371",
+          "label": "NIS America"
+        },
+        {
+          "code": "Q106471494",
+          "label": "Jaleco USA"
+        },
+        {
+          "code": "Q106489269",
+          "label": "Shorebound Studios"
+        },
+        {
+          "code": "Q106538595",
+          "label": "Mana Games"
+        },
+        {
+          "code": "Q106986614",
+          "label": "Ironhide Ireland Limited"
+        },
+        {
+          "code": "Q106435531",
+          "label": "Nekki"
+        },
+        {
+          "code": "Q106427854",
+          "label": "Victura"
+        },
+        {
+          "code": "Q106658870",
+          "label": "Just for Games"
+        },
+        {
+          "code": "Q107137263",
+          "label": "Bloodlust Software"
+        },
+        {
+          "code": "Q107137326",
+          "label": "Winter Wolves"
+        },
+        {
+          "code": "Q106495389",
+          "label": "Crunching Koalas"
+        },
+        {
+          "code": "Q106610148",
+          "label": "Frosty Pop"
+        },
+        {
+          "code": "Q106635418",
+          "label": "Lonely Troops"
+        },
+        {
+          "code": "Q106977646",
+          "label": "Leonardo Interactive"
+        },
+        {
+          "code": "Q106418945",
+          "label": "Summitsoft Entertainment"
+        },
+        {
+          "code": "Q106483478",
+          "label": "Midway Home Entertainment"
+        },
+        {
+          "code": "Q106918849",
+          "label": "Klabater"
+        },
+        {
+          "code": "Q107075363",
+          "label": "Unties"
+        },
+        {
+          "code": "Q106472375",
+          "label": "Why so serious"
+        },
+        {
+          "code": "Q106945444",
+          "label": "qureate"
+        },
+        {
+          "code": "Q107111983",
+          "label": "Kuro Games"
+        },
+        {
+          "code": "Q106495344",
+          "label": "Gaming Company"
+        },
+        {
+          "code": "Q106419504",
+          "label": "PM Studios"
+        },
+        {
+          "code": "Q106977718",
+          "label": "Elex"
+        },
+        {
+          "code": "Q107133904",
+          "label": "Stirfire Studios"
+        },
+        {
+          "code": "Q107137285",
+          "label": "Crystal Shard"
+        },
+        {
+          "code": "Q1330823",
+          "label": "Elite Systems"
+        },
+        {
+          "code": "Q1347787",
+          "label": "Epyx"
+        },
+        {
+          "code": "Q1355060",
+          "label": "Miniclip"
+        },
+        {
+          "code": "Q1344080",
+          "label": "Jaleco"
+        },
+        {
+          "code": "Q111640815",
+          "label": "GT Interactive Software Australia"
+        },
+        {
+          "code": "Q111941633",
+          "label": "OURPALM"
+        },
+        {
+          "code": "Q112245645",
+          "label": "Traffic Games"
+        },
+        {
+          "code": "Q112306689",
+          "label": "Nuverse"
+        },
+        {
+          "code": "Q113400696",
+          "label": "Halycon Media"
+        },
+        {
+          "code": "Q111342143",
+          "label": "34BigThings"
+        },
+        {
+          "code": "Q111342152",
+          "label": "Raiser Games"
+        },
+        {
+          "code": "Q111994190",
+          "label": "7k7k"
+        },
+        {
+          "code": "Q113407866",
+          "label": "Causa Creations"
+        },
+        {
+          "code": "Q111417174",
+          "label": "Fireshine Games"
+        },
+        {
+          "code": "Q111743152",
+          "label": "Team Xonotic"
+        },
+        {
+          "code": "Q112968479",
+          "label": "Valorware"
+        },
+        {
+          "code": "Q111260294",
+          "label": "Big Black Bear"
+        },
+        {
+          "code": "Q111641288",
+          "label": "Konami Digital Entertainment GmbH"
+        },
+        {
+          "code": "Q113130847",
+          "label": "Neon Doctrine"
+        },
+        {
+          "code": "Q113361289",
+          "label": "Alpha Blend Interactive"
+        },
+        {
+          "code": "Q113401262",
+          "label": "YFYX GAMES"
+        },
+        {
+          "code": "Q111340786",
+          "label": "Axyos Games"
+        },
+        {
+          "code": "Q112594854",
+          "label": "Phoenix Games Asia"
+        },
+        {
+          "code": "Q111179100",
+          "label": "GirlGames"
+        },
+        {
+          "code": "Q111912024",
+          "label": "Magenta Factory"
+        },
+        {
+          "code": "Q111994667",
+          "label": "IndieArk"
+        },
+        {
+          "code": "Q112943466",
+          "label": "Bimo Entertainment"
+        },
+        {
+          "code": "Q112079071",
+          "label": "France Telecom Multimedia"
+        },
+        {
+          "code": "Q111202967",
+          "label": "Levande Böcker"
+        },
+        {
+          "code": "Q111591434",
+          "label": "Bandai Namco Entertainment Australia"
+        },
+        {
+          "code": "Q111631065",
+          "label": "Sony Interactive Entertainment Australia"
+        },
+        {
+          "code": "Q111662863",
+          "label": "RiceFun Games"
+        },
+        {
+          "code": "Q111740090",
+          "label": "Waku Waku Games"
+        },
+        {
+          "code": "Q112220007",
+          "label": "PlayStation PC LLC"
+        },
+        {
+          "code": "Q112998973",
+          "label": "Kagura Games"
+        },
+        {
+          "code": "Q111164482",
+          "label": "Playstige Interactive"
+        },
+        {
+          "code": "Q111187025",
+          "label": "Project Helius"
+        },
+        {
+          "code": "Q111516144",
+          "label": "Bandai Namco Amusement"
+        },
+        {
+          "code": "Q111743178",
+          "label": "Turbo Pixel Studios"
+        },
+        {
+          "code": "Q111904092",
+          "label": "OTAKU Plan"
+        },
+        {
+          "code": "Q112113013",
+          "label": "Tapzen Pte. Ltd."
+        },
+        {
+          "code": "Q112340874",
+          "label": "Skystone Games"
+        },
+        {
+          "code": "Q112988000",
+          "label": "Big Sugar Games"
+        },
+        {
+          "code": "Q93671545",
+          "label": "Green Panda Games"
+        },
+        {
+          "code": "Q94127681",
+          "label": "Hikari Field"
+        },
+        {
+          "code": "Q94657742",
+          "label": "Modus Games"
+        },
+        {
+          "code": "Q96741285",
+          "label": "Warzone 2100 Project"
+        },
+        {
+          "code": "Q97208610",
+          "label": "Phoenixx"
+        },
+        {
+          "code": "Q97133694",
+          "label": "Palcom Software"
+        },
+        {
+          "code": "Q96045983",
+          "label": "Relentless Game Studios"
+        },
+        {
+          "code": "Q97097184",
+          "label": "3Division Entertainment"
+        },
+        {
+          "code": "Q97097199",
+          "label": "Frogster Interactive"
+        },
+        {
+          "code": "Q93671484",
+          "label": "Blue Mammoth Games"
+        },
+        {
+          "code": "Q94652401",
+          "label": "Dalcom Soft"
+        },
+        {
+          "code": "Q94658505",
+          "label": "3goo"
+        },
+        {
+          "code": "Q96278593",
+          "label": "Toge Productions"
+        },
+        {
+          "code": "Q97070116",
+          "label": "Activision Value Publishing"
+        },
+        {
+          "code": "Q93671170",
+          "label": "1492 Studio"
+        },
+        {
+          "code": "Q96375821",
+          "label": "DECA Games"
+        },
+        {
+          "code": "Q96612282",
+          "label": "Nomad Games"
+        },
+        {
+          "code": "Q97183834",
+          "label": "Mega Cat Studios"
+        },
+        {
+          "code": "Q96044404",
+          "label": "Bugbyte"
+        },
+        {
+          "code": "Q96177142",
+          "label": "Reset Media"
+        },
+        {
+          "code": "Q96379060",
+          "label": "GameClub"
+        },
+        {
+          "code": "Q96612086",
+          "label": "Liquid Games"
+        },
+        {
+          "code": "Q97300197",
+          "label": "NExT Studios"
+        },
+        {
+          "code": "Q107289465",
+          "label": "Anomalous Games"
+        },
+        {
+          "code": "Q107329000",
+          "label": "Chuhai Labs"
+        },
+        {
+          "code": "Q107337014",
+          "label": "Redhill Games"
+        },
+        {
+          "code": "Q107340189",
+          "label": "Creashock studios"
+        },
+        {
+          "code": "Q107633566",
+          "label": "Pixmain"
+        },
+        {
+          "code": "Q107420126",
+          "label": "Freedom Games"
+        },
+        {
+          "code": "Q107611582",
+          "label": "N3TWORK"
+        },
+        {
+          "code": "Q107149806",
+          "label": "Vatical Entertainment"
+        },
+        {
+          "code": "Q107631140",
+          "label": "Idea Factory International"
+        },
+        {
+          "code": "Q107980182",
+          "label": "aPriori Digital"
+        },
+        {
+          "code": "Q107345633",
+          "label": "AGL Studios"
+        },
+        {
+          "code": "Q107377476",
+          "label": "Madmind Studio"
+        },
+        {
+          "code": "Q107228333",
+          "label": "Team HalfBeard"
+        },
+        {
+          "code": "Q107287237",
+          "label": "Noir Soft"
+        },
+        {
+          "code": "Q107362102",
+          "label": "Blackrose Industries"
+        },
+        {
+          "code": "Q107458700",
+          "label": "The Game Creators"
+        },
+        {
+          "code": "Q107226111",
+          "label": "Koei Tecmo America"
+        },
+        {
+          "code": "Q107253745",
+          "label": "Salty Salty Studios"
+        },
+        {
+          "code": "Q107299060",
+          "label": "Crytivo Games"
+        },
+        {
+          "code": "Q107458579",
+          "label": "AOUProductions"
+        },
+        {
+          "code": "Q107185395",
+          "label": "Super X Studios"
+        },
+        {
+          "code": "Q107189268",
+          "label": "Big Evil Corporation"
+        },
+        {
+          "code": "Q107378372",
+          "label": "Polyslash"
+        },
+        {
+          "code": "Q107411870",
+          "label": "C2Praparat"
+        },
+        {
+          "code": "Q107557526",
+          "label": "Matra Computer Automations"
+        },
+        {
+          "code": "Q107614635",
+          "label": "CGE Digital"
+        },
+        {
+          "code": "Q107138156",
+          "label": "ERS Game Studios"
+        },
+        {
+          "code": "Q107291476",
+          "label": "PsychoFlux Entertainment"
+        },
+        {
+          "code": "Q107349471",
+          "label": "Kristanix Games"
+        },
+        {
+          "code": "Q107492286",
+          "label": "MSXdev"
+        },
+        {
+          "code": "Q107806350",
+          "label": "Scumhead"
+        },
+        {
+          "code": "Q110193156",
+          "label": "8-Bit Legit"
+        },
+        {
+          "code": "Q110247402",
+          "label": "Alcon Interactive Group"
+        },
+        {
+          "code": "Q110493215",
+          "label": "Sinister Design"
+        },
+        {
+          "code": "Q109860161",
+          "label": "Future Friends Games"
+        },
+        {
+          "code": "Q110159554",
+          "label": "Xitilon"
+        },
+        {
+          "code": "Q110493344",
+          "label": "Hemisphere Games"
+        },
+        {
+          "code": "Q109735668",
+          "label": "Hangzhou zhexin IT Co.,Ltd"
+        },
+        {
+          "code": "Q109942749",
+          "label": "1BITTO"
+        },
+        {
+          "code": "Q109969412",
+          "label": "Audiogames Association"
+        },
+        {
+          "code": "Q109996611",
+          "label": "BUG-Studio"
+        },
+        {
+          "code": "Q109928554",
+          "label": "Gameplay First"
+        },
+        {
+          "code": "Q109969389",
+          "label": "IV Productions"
+        },
+        {
+          "code": "Q110493869",
+          "label": "Fish Factory Games"
+        },
+        {
+          "code": "Q109949399",
+          "label": "Brave At Night"
+        },
+        {
+          "code": "Q109969323",
+          "label": "DigiArt Interactive"
+        },
+        {
+          "code": "Q109715904",
+          "label": "Yume Creations"
+        },
+        {
+          "code": "Q109932485",
+          "label": "PID Games"
+        },
+        {
+          "code": "Q109933806",
+          "label": "Take Two Interactive GmbH"
+        },
+        {
+          "code": "Q110037519",
+          "label": "Drageus Games"
+        },
+        {
+          "code": "Q110493873",
+          "label": "Fire Hose Games"
+        },
+        {
+          "code": "Q109923630",
+          "label": "Mob Entertainment"
+        },
+        {
+          "code": "Q109928766",
+          "label": "Ravenscourt"
+        },
+        {
+          "code": "Q110193428",
+          "label": "Untold Tales"
+        },
+        {
+          "code": "Q109797218",
+          "label": "Rekoo"
+        },
+        {
+          "code": "Q109928292",
+          "label": "OverGamez"
+        },
+        {
+          "code": "Q110060955",
+          "label": "Rogue Games"
+        },
+        {
+          "code": "Q110154887",
+          "label": "Level Infinite"
+        },
+        {
+          "code": "Q110016185",
+          "label": "Way Down Deep"
+        },
+        {
+          "code": "Q109829037",
+          "label": "Snow Cannon Games"
+        },
+        {
+          "code": "Q109942429",
+          "label": "Prison Games"
+        },
+        {
+          "code": "Q110059537",
+          "label": "Super PowerUp Games"
+        },
+        {
+          "code": "Q110196689",
+          "label": "Game Nacional"
+        },
+        {
+          "code": "Q63141394",
+          "label": "Rix Soft"
+        },
+        {
+          "code": "Q63252750",
+          "label": "Gamera Games"
+        },
+        {
+          "code": "Q62416270",
+          "label": "Cobra Team"
+        },
+        {
+          "code": "Q62477188",
+          "label": "Shin-Nihon Laser Soft Co., Ltd."
+        },
+        {
+          "code": "Q63867185",
+          "label": "Ubisoft, Inc."
+        },
+        {
+          "code": "Q62070714",
+          "label": "Tomahawk"
+        },
+        {
+          "code": "Q62027238",
+          "label": "ANPA.US"
+        },
+        {
+          "code": "Q62559062",
+          "label": "Starfish Inc."
+        },
+        {
+          "code": "Q62573242",
+          "label": "Homebrew.AT"
+        },
+        {
+          "code": "Q63378796",
+          "label": "New Blood Interactive"
+        },
+        {
+          "code": "Q64007316",
+          "label": "Micromouse"
+        },
+        {
+          "code": "Q62701024",
+          "label": "Tetris Online Japan, Inc."
+        },
+        {
+          "code": "Q63430387",
+          "label": "CuiCui Studios"
+        },
+        {
+          "code": "Q63644892",
+          "label": "Reverb Communications"
+        },
+        {
+          "code": "Q64014355",
+          "label": "Troglobytes Games"
+        },
+        {
+          "code": "Q62477290",
+          "label": "TNN"
+        },
+        {
+          "code": "Q62554992",
+          "label": "Børnenes Favoritter"
+        },
+        {
+          "code": "Q62561322",
+          "label": "Communication Group Plum"
+        },
+        {
+          "code": "Q63644187",
+          "label": "Activision Deutschland GmbH"
+        },
+        {
+          "code": "Q64014139",
+          "label": "Pathea Games"
+        },
+        {
+          "code": "Q64014962",
+          "label": "Jauda Labs"
+        },
+        {
+          "code": "Q63012395",
+          "label": "PinkySwear"
+        },
+        {
+          "code": "Q63644933",
+          "label": "ND GAMES"
+        },
+        {
+          "code": "Q62501511",
+          "label": "Goblinz Studio"
+        },
+        {
+          "code": "Q62513347",
+          "label": "Apple Arcade"
+        },
+        {
+          "code": "Q62559192",
+          "label": "Micro World"
+        },
+        {
+          "code": "Q63867244",
+          "label": "SEGA of America"
+        },
+        {
+          "code": "Q62416379",
+          "label": "Marionette Co., Ltd."
+        },
+        {
+          "code": "Q114929137",
+          "label": "Kowloon Nights"
+        },
+        {
+          "code": "Q115257530",
+          "label": "Viridian Software"
+        },
+        {
+          "code": "Q115618449",
+          "label": "DYA Games"
+        },
+        {
+          "code": "Q114643557",
+          "label": "Eclipse Software Design"
+        },
+        {
+          "code": "Q114669882",
+          "label": "Blindflug Studios"
+        },
+        {
+          "code": "Q114834714",
+          "label": "PlayPun"
+        },
+        {
+          "code": "Q114931582",
+          "label": "E-Home Entertainment"
+        },
+        {
+          "code": "Q116146221",
+          "label": "Bigmode"
+        },
+        {
+          "code": "Q114833982",
+          "label": "Pixel Plant LLC"
+        },
+        {
+          "code": "Q115469692",
+          "label": "Andromeda Software"
+        },
+        {
+          "code": "Q115478292",
+          "label": "Triple Topping"
+        },
+        {
+          "code": "Q115787047",
+          "label": "EnsenaSoft"
+        },
+        {
+          "code": "Q113961518",
+          "label": "Playmates Interactive Entertainment"
+        },
+        {
+          "code": "Q116141720",
+          "label": "Rainy Frog"
+        },
+        {
+          "code": "Q116166351",
+          "label": "DreadXP"
+        },
+        {
+          "code": "Q113989998",
+          "label": "BoomBit"
+        },
+        {
+          "code": "Q114996275",
+          "label": "Akatsuki Games"
+        },
+        {
+          "code": "Q116141758",
+          "label": "Aurora Punks"
+        },
+        {
+          "code": "Q113633779",
+          "label": "Solar Software"
+        },
+        {
+          "code": "Q114071467",
+          "label": "Holy Wow"
+        },
+        {
+          "code": "Q114264210",
+          "label": "Haegin"
+        },
+        {
+          "code": "Q113672867",
+          "label": "MD Games"
+        },
+        {
+          "code": "Q113972994",
+          "label": "Perp Games"
+        },
+        {
+          "code": "Q114458531",
+          "label": "EAS Software"
+        },
+        {
+          "code": "Q114664931",
+          "label": "Awfully Nice Studios"
+        },
+        {
+          "code": "Q114708539",
+          "label": "Digital Excess"
+        },
+        {
+          "code": "Q115055449",
+          "label": "Resolution Games"
+        },
+        {
+          "code": "Q115188791",
+          "label": "Sundae Factory"
+        },
+        {
+          "code": "Q115625323",
+          "label": "Weakfish Studio Publishing"
+        },
+        {
+          "code": "Q115676513",
+          "label": "FredBear Games"
+        },
+        {
+          "code": "Q116189096",
+          "label": "COGNOSPHERE"
+        },
+        {
+          "code": "Q115800073",
+          "label": "Meridiem Games"
+        },
+        {
+          "code": "Q115182955",
+          "label": "Sonka"
+        },
+        {
+          "code": "Q113639243",
+          "label": "My Way Games"
+        },
+        {
+          "code": "Q114833851",
+          "label": "WASABAE Studios"
+        },
+        {
+          "code": "Q114860571",
+          "label": "The Backrooms"
+        },
+        {
+          "code": "Q115113860",
+          "label": "MP Entertainment"
+        },
+        {
+          "code": "Q113587382",
+          "label": "8floor"
+        },
+        {
+          "code": "Q114833755",
+          "label": "Pie On A Plate Productions"
+        },
+        {
+          "code": "Q97819802",
+          "label": "Excalibur Games"
+        },
+        {
+          "code": "Q97515150",
+          "label": "CDTV Publishing"
+        },
+        {
+          "code": "Q97584703",
+          "label": "looterkings"
+        },
+        {
+          "code": "Q97325212",
+          "label": "Coconut Island Games"
+        },
+        {
+          "code": "Q97703807",
+          "label": "Compton's New Media"
+        },
+        {
+          "code": "Q98756957",
+          "label": "Hi-Tec Software"
+        },
+        {
+          "code": "Q98792972",
+          "label": "GlobalFun"
+        },
+        {
+          "code": "Q97461153",
+          "label": "Whiptail Interactive"
+        },
+        {
+          "code": "Q97514874",
+          "label": "Philips Interactive Media Systems"
+        },
+        {
+          "code": "Q97854782",
+          "label": "Marc Ecko Entertainment"
+        },
+        {
+          "code": "Q98877634",
+          "label": "Top Hat Studios"
+        },
+        {
+          "code": "Q97534061",
+          "label": "VooFoo Studios"
+        },
+        {
+          "code": "Q98168926",
+          "label": "Wired Productions"
+        },
+        {
+          "code": "Q99169076",
+          "label": "Rocket Juice Games"
+        },
+        {
+          "code": "Q99841136",
+          "label": "THQ Wireless"
+        },
+        {
+          "code": "Q97348386",
+          "label": "Game Source Entertainment"
+        },
+        {
+          "code": "Q97529890",
+          "label": "Metro3D Europe"
+        },
+        {
+          "code": "Q98882067",
+          "label": "Team Reptile"
+        },
+        {
+          "code": "Q97461174",
+          "label": "Vidis Electronic Vertriebs"
+        },
+        {
+          "code": "Q97705086",
+          "label": "Headsoft"
+        },
+        {
+          "code": "Q98406626",
+          "label": "ByteRealms"
+        },
+        {
+          "code": "Q100158597",
+          "label": "Meta Publishing"
+        },
+        {
+          "code": "Q98145746",
+          "label": "Bomico Entertainment Software GmbH"
+        },
+        {
+          "code": "Q98398347",
+          "label": "Beau Jolly"
+        },
+        {
+          "code": "Q97509655",
+          "label": "Mirror Image"
+        },
+        {
+          "code": "Q97367074",
+          "label": "Zoo Publishing"
+        },
+        {
+          "code": "Q97704762",
+          "label": "Walkabout Games"
+        },
+        {
+          "code": "Q99270931",
+          "label": "Ziggurat Interactive"
+        },
+        {
+          "code": "Q99479109",
+          "label": "Spearhead Games"
+        },
+        {
+          "code": "Q98072239",
+          "label": "Sierra Attractions"
+        },
+        {
+          "code": "Q98599250",
+          "label": "Draw Distance"
+        },
+        {
+          "code": "Q98745239",
+          "label": "Cartoon Network Games"
+        },
+        {
+          "code": "Q98912234",
+          "label": "Friendware"
+        },
+        {
+          "code": "Q99441927",
+          "label": "Happy Life Animation"
+        },
+        {
+          "code": "Q99540288",
+          "label": "Etter Studio"
+        },
+        {
+          "code": "Q118176998",
+          "label": "The Software Business"
+        },
+        {
+          "code": "Q118215113",
+          "label": "Pin-Ball Games Ltd."
+        },
+        {
+          "code": "Q118252050",
+          "label": "Euphoric Brothers"
+        },
+        {
+          "code": "Q118370061",
+          "label": "Firesquid"
+        },
+        {
+          "code": "Q118495815",
+          "label": "GESTALT-§"
+        },
+        {
+          "code": "Q118766708",
+          "label": "Eternal Alice Studio"
+        },
+        {
+          "code": "Q119397118",
+          "label": "Dragonest"
+        },
+        {
+          "code": "Q119846247",
+          "label": "Dongleware"
+        },
+        {
+          "code": "Q119880398",
+          "label": "Five Aces Publishing"
+        },
+        {
+          "code": "Q119950602",
+          "label": "Jim Henson Interactive"
+        },
+        {
+          "code": "Q120174076",
+          "label": "Team SNEED"
+        },
+        {
+          "code": "Q120716270",
+          "label": "Restless Corp"
+        },
+        {
+          "code": "Q121071272",
+          "label": "Software Country"
+        },
+        {
+          "code": "Q121097589",
+          "label": "VG Games"
+        },
+        {
+          "code": "Q121201615",
+          "label": "Feardemic"
+        },
+        {
+          "code": "Q121268991",
+          "label": "Shiravune"
+        },
+        {
+          "code": "Q121302197",
+          "label": "Cranberry Software"
+        },
+        {
+          "code": "Q121307115",
+          "label": "EroticGamesClub"
+        },
+        {
+          "code": "Q121307146",
+          "label": "Octo Games"
+        },
+        {
+          "code": "Q121554923",
+          "label": "Rising Win Tech. Co., Ltd."
+        },
+        {
+          "code": "Q121821090",
+          "label": "Firebug Games"
+        },
+        {
+          "code": "Q121842892",
+          "label": "Studio Mono"
+        },
+        {
+          "code": "Q122040867",
+          "label": "Bitmap Soft"
+        },
+        {
+          "code": "Q122070252",
+          "label": "Deep Type Games"
+        },
+        {
+          "code": "Q122130432",
+          "label": "Double Dagger Studio"
+        },
+        {
+          "code": "Q120694078",
+          "label": "Romik Software"
+        },
+        {
+          "code": "Q122326698",
+          "label": "Incarnate Games"
+        },
+        {
+          "code": "Q122335277",
+          "label": "Snowcastle Games"
+        },
+        {
+          "code": "Q122337294",
+          "label": "BNW Entertainment"
+        },
+        {
+          "code": "Q122363016",
+          "label": "Blue Isle Publishing"
+        },
+        {
+          "code": "Q122500058",
+          "label": "2124 Publishing"
+        },
+        {
+          "code": "Q122583224",
+          "label": "Cubejoy"
+        },
+        {
+          "code": "Q122710406",
+          "label": "Iocaine Studios"
+        },
+        {
+          "code": "Q122755268",
+          "label": "Aerovery Lab"
+        },
+        {
+          "code": "Q122766597",
+          "label": "Source Technology"
+        },
+        {
+          "code": "Q122829124",
+          "label": "Gravity Game Arise"
+        },
+        {
+          "code": "Q122912940",
+          "label": "Postmodern Adventures"
+        },
+        {
+          "code": "Q122943784",
+          "label": "Digital Kids"
+        },
+        {
+          "code": "Q122947845",
+          "label": "KOMODO"
+        },
+        {
+          "code": "Q122948121",
+          "label": "Prismatika"
+        },
+        {
+          "code": "Q123019724",
+          "label": "1001 Software Development"
+        },
+        {
+          "code": "Q123019764",
+          "label": "Dragonware"
+        },
+        {
+          "code": "Q121764840",
+          "label": "ACE Software"
+        },
+        {
+          "code": "Q122363639",
+          "label": "CDP"
+        },
+        {
+          "code": "Q121694127",
+          "label": "Fragaria"
+        },
+        {
+          "code": "Q119658130",
+          "label": "CTW"
+        },
+        {
+          "code": "Q116197653",
+          "label": "Desert Water Games"
+        },
+        {
+          "code": "Q116201080",
+          "label": "Secret Mode"
+        },
+        {
+          "code": "Q116265782",
+          "label": "Aviary Films"
+        },
+        {
+          "code": "Q116678303",
+          "label": "iRacing.com Motorsport Simulations"
+        },
+        {
+          "code": "Q116680351",
+          "label": "M-Dream"
+        },
+        {
+          "code": "Q116757361",
+          "label": "Firestoke"
+        },
+        {
+          "code": "Q116764888",
+          "label": "ESDigital Games"
+        },
+        {
+          "code": "Q116765414",
+          "label": "TACS Games"
+        },
+        {
+          "code": "Q116766167",
+          "label": "Wild River Games"
+        },
+        {
+          "code": "Q116786225",
+          "label": "Kepler Interactive"
+        },
+        {
+          "code": "Q116786739",
+          "label": "Diamond Software"
+        },
+        {
+          "code": "Q116823245",
+          "label": "Paradark Studio"
+        },
+        {
+          "code": "Q116857637",
+          "label": "4Divinity"
+        },
+        {
+          "code": "Q116904012",
+          "label": "Playstack"
+        },
+        {
+          "code": "Q116977097",
+          "label": "Dream-Up"
+        },
+        {
+          "code": "Q116983863",
+          "label": "Coffee Stain Publishing"
+        },
+        {
+          "code": "Q117007016",
+          "label": "GOAT Games"
+        },
+        {
+          "code": "Q117007736",
+          "label": "AKPublish"
+        },
+        {
+          "code": "Q117087272",
+          "label": "ZPLAY Games"
+        },
+        {
+          "code": "Q117193823",
+          "label": "CP Verlag"
+        },
+        {
+          "code": "Q117211871",
+          "label": "SomniumSoft"
+        },
+        {
+          "code": "Q117268190",
+          "label": "Inin Games"
+        },
+        {
+          "code": "Q117288387",
+          "label": "Komoe Technology"
+        },
+        {
+          "code": "Q117323619",
+          "label": "Boltrend Games"
+        },
+        {
+          "code": "Q117405243",
+          "label": "Choose Multiple"
+        },
+        {
+          "code": "Q117421835",
+          "label": "SunDust"
+        },
+        {
+          "code": "Q117472473",
+          "label": "Dirty Fox Games"
+        },
+        {
+          "code": "Q117697465",
+          "label": "WAHLAP TECHNOLOGY"
+        },
+        {
+          "code": "Q117765818",
+          "label": "Handmade Interactive"
+        },
+        {
+          "code": "Q117771389",
+          "label": "Entergram"
+        },
+        {
+          "code": "Q117808708",
+          "label": "Llamasoft"
+        },
+        {
+          "code": "Q117843625",
+          "label": "Argonica"
+        },
+        {
+          "code": "Q118111635",
+          "label": "Game Seer"
+        },
+        {
+          "code": "Q118142409",
+          "label": "ColePowered Games"
+        },
+        {
+          "code": "Q118173596",
+          "label": "Quantum Lion Labs"
+        },
+        {
+          "code": "Q117011272",
+          "label": "110 Industries"
+        },
+        {
+          "code": "Q116208129",
+          "label": "Young Genius"
+        },
+        {
+          "code": "Q117324316",
+          "label": "Harukaze"
+        },
+        {
+          "code": "Q117061504",
+          "label": "Hook"
+        },
+        {
+          "code": "Q110494000",
+          "label": "Elecorn"
+        },
+        {
+          "code": "Q110829127",
+          "label": "Entity3"
+        },
+        {
+          "code": "Q110493903",
+          "label": "Fair Play Labs"
+        },
+        {
+          "code": "Q110494065",
+          "label": "Eclipse Productions"
+        },
+        {
+          "code": "Q110521207",
+          "label": "Bonus Stage Publishing"
+        },
+        {
+          "code": "Q110748800",
+          "label": "Gamuzumi"
+        },
+        {
+          "code": "Q110493915",
+          "label": "Evolution Games"
+        },
+        {
+          "code": "Q110494551",
+          "label": "DolphinBarn"
+        },
+        {
+          "code": "Q110520099",
+          "label": "Dispatch Games"
+        },
+        {
+          "code": "Q110746257",
+          "label": "Green Man Gaming Publishing"
+        },
+        {
+          "code": "Q110775344",
+          "label": "Totalconsole"
+        },
+        {
+          "code": "Q110664214",
+          "label": "New Tales"
+        },
+        {
+          "code": "Q110494005",
+          "label": "Elder Games"
+        },
+        {
+          "code": "Q110494163",
+          "label": "Eat Create Sleep"
+        },
+        {
+          "code": "Q110749318",
+          "label": "Gametry"
+        },
+        {
+          "code": "Q110834831",
+          "label": "PLiCy"
+        },
+        {
+          "code": "Q111023638",
+          "label": "Spiral Game Studios"
+        },
+        {
+          "code": "Q110494476",
+          "label": "Dreadbit"
+        },
+        {
+          "code": "Q110739151",
+          "label": "101xp"
+        },
+        {
+          "code": "Q110746115",
+          "label": "Digital Game Group"
+        },
+        {
+          "code": "Q110896280",
+          "label": "The Arcade Crew"
+        },
+        {
+          "code": "Q110637367",
+          "label": "Leoful"
+        },
+        {
+          "code": "Q110763505",
+          "label": "Pix Arts"
+        },
+        {
+          "code": "Q110793001",
+          "label": "The Digital Lounge"
+        },
+        {
+          "code": "Q111033892",
+          "label": "B&W Studios"
+        },
+        {
+          "code": "Q110493928",
+          "label": "Eurogold"
+        },
+        {
+          "code": "Q110493968",
+          "label": "Enhance Games"
+        },
+        {
+          "code": "Q110499667",
+          "label": "X Plus"
+        },
+        {
+          "code": "Q110645087",
+          "label": "2Awesome Studio"
+        },
+        {
+          "code": "Q110712354",
+          "label": "1C Online Games"
+        },
+        {
+          "code": "Q110867227",
+          "label": "Cooking & Publishing"
+        },
+        {
+          "code": "Q110573154",
+          "label": "Dev4Play"
+        },
+        {
+          "code": "Q123059106",
+          "label": "RapidEyeMovers"
+        },
+        {
+          "code": "Q123173370",
+          "label": "Riot Forge"
+        },
+        {
+          "code": "Q123180329",
+          "label": "HOF Studios"
+        },
+        {
+          "code": "Q123181340",
+          "label": "Hooded Horse"
+        },
+        {
+          "code": "Q123201449",
+          "label": "Bamboo Bandit"
+        },
+        {
+          "code": "Q123206859",
+          "label": "RazorSoft"
+        },
+        {
+          "code": "Q123229848",
+          "label": "xLand"
+        },
+        {
+          "code": "Q123249881",
+          "label": "Time Galleon"
+        },
+        {
+          "code": "Q123287227",
+          "label": "Terad Games"
+        },
+        {
+          "code": "Q123340062",
+          "label": "CheckMate Publishing"
+        },
+        {
+          "code": "Q123375941",
+          "label": "TAIWAN TGL CORPORATION"
+        },
+        {
+          "code": "Q123409631",
+          "label": "Epic Marketing"
+        },
+        {
+          "code": "Q123423685",
+          "label": "Netlex Studio"
+        },
+        {
+          "code": "Q123423928",
+          "label": "Hero Game Studios"
+        },
+        {
+          "code": "Q123423942",
+          "label": "ABCpub"
+        },
+        {
+          "code": "Q123396195",
+          "label": "Ludosity Interactive"
+        },
+        {
+          "code": "Q123438496",
+          "label": "Paradox Arc"
+        },
+        {
+          "code": "Q123438578",
+          "label": "Highline Studio"
+        },
+        {
+          "code": "Q123438637",
+          "label": "Astrosnout"
+        },
+        {
+          "code": "Q123466386",
+          "label": "A List Games"
+        },
+        {
+          "code": "Q123471724",
+          "label": "Ammobox Studios"
+        },
+        {
+          "code": "Q123472035",
+          "label": "Nexon Europe"
+        },
+        {
+          "code": "Q123472045",
+          "label": "Circle Five Publishing"
+        },
+        {
+          "code": "Q123474584",
+          "label": "Trapped Nerve Games"
+        },
+        {
+          "code": "Q123474616",
+          "label": "Hatinh Interactive"
+        },
+        {
+          "code": "Q123500016",
+          "label": "Dopamine Software"
+        },
+        {
+          "code": "Q123558603",
+          "label": "PlayFTW"
+        },
+        {
+          "code": "Q123558802",
+          "label": "HitsNapp"
+        },
+        {
+          "code": "Q123559294",
+          "label": "Gamytech"
+        },
+        {
+          "code": "Q123561827",
+          "label": "Best Arabic Games"
+        },
+        {
+          "code": "Q123585617",
+          "label": "Kit9 Studio"
+        },
+        {
+          "code": "Q123631789",
+          "label": "Forthright Entertainment"
+        },
+        {
+          "code": "Q123745795",
+          "label": "Yogscast Games"
+        },
+        {
+          "code": "Q123916300",
+          "label": "Shady Corner Games"
+        },
+        {
+          "code": "Q123929950",
+          "label": "Spiral Up Games"
+        },
+        {
+          "code": "Q123937933",
+          "label": "The Broken Horn"
+        },
+        {
+          "code": "Q123760277",
+          "label": "Ahead Multimedia"
+        },
+        {
+          "code": "Q123995894",
+          "label": "A&F Software"
+        },
+        {
+          "code": "Q124005205",
+          "label": "Thirdverse"
+        },
+        {
+          "code": "Q124005823",
+          "label": "GameTomo"
+        },
+        {
+          "code": "Q124023511",
+          "label": "Elektrogames"
+        },
+        {
+          "code": "Q124056756",
+          "label": "StickyLock"
+        },
+        {
+          "code": "Q124067850",
+          "label": "Little Orbit Europe, LTD"
+        },
+        {
+          "code": "Q123474676",
+          "label": "Mischief"
+        },
+        {
+          "code": "Q123423848",
+          "label": "Belver"
+        },
+        {
+          "code": "Q123555173",
+          "label": "Live Wire"
+        },
+        {
+          "code": "Q101086301",
+          "label": "Vogelfänger"
+        },
+        {
+          "code": "Q100907329",
+          "label": "Offworld Industries"
+        },
+        {
+          "code": "Q104431624",
+          "label": "FYRE Games"
+        },
+        {
+          "code": "Q104529353",
+          "label": "PID Publishing"
+        },
+        {
+          "code": "Q100268798",
+          "label": "Kinetic Games"
+        },
+        {
+          "code": "Q102423885",
+          "label": "Lance Haffner Games"
+        },
+        {
+          "code": "Q102501123",
+          "label": "Earthware Computer Services"
+        },
+        {
+          "code": "Q103161993",
+          "label": "Blue Chip Software"
+        },
+        {
+          "code": "Q104425771",
+          "label": "Anaya Interactiva"
+        },
+        {
+          "code": "Q101069308",
+          "label": "KORION"
+        },
+        {
+          "code": "Q104241491",
+          "label": "Moebial Studios"
+        },
+        {
+          "code": "Q104519117",
+          "label": "Outright Games"
+        },
+        {
+          "code": "Q100371924",
+          "label": "Coatsink"
+        },
+        {
+          "code": "Q100786002",
+          "label": "SadSquare Studio"
+        },
+        {
+          "code": "Q103156929",
+          "label": "Strictly Limited Games"
+        },
+        {
+          "code": "Q101364685",
+          "label": "Graffiti Entertainment"
+        },
+        {
+          "code": "Q102423046",
+          "label": "Motivated Software"
+        },
+        {
+          "code": "Q104438093",
+          "label": "Kupaa Studios"
+        },
+        {
+          "code": "Q104531162",
+          "label": "Deep Thought Software"
+        },
+        {
+          "code": "Q100333045",
+          "label": "Another Indie"
+        },
+        {
+          "code": "Q100796552",
+          "label": "Darril Arts"
+        },
+        {
+          "code": "Q100987671",
+          "label": "Nitrime"
+        },
+        {
+          "code": "Q100530795",
+          "label": "MTV Games"
+        },
+        {
+          "code": "Q103821054",
+          "label": "HotStage"
+        },
+        {
+          "code": "Q100326487",
+          "label": "3D-Ages"
+        },
+        {
+          "code": "Q100597769",
+          "label": "Łukasz Jakowski Games"
+        },
+        {
+          "code": "Q100873685",
+          "label": "Jetdogs Studios"
+        },
+        {
+          "code": "Q101153212",
+          "label": "Silver Lightning Software"
+        },
+        {
+          "code": "Q101214683",
+          "label": "100 Stones Interactive"
+        },
+        {
+          "code": "Q101232975",
+          "label": "Modern Wolf"
+        },
+        {
+          "code": "Q102424219",
+          "label": "United Label"
+        },
+        {
+          "code": "Q103821139",
+          "label": "Military Simulations"
+        },
+        {
+          "code": "Q100392399",
+          "label": "Nolla Games"
+        },
+        {
+          "code": "Q101214003",
+          "label": "Enhance"
+        },
+        {
+          "code": "Q101252572",
+          "label": "Kyugo Trading"
+        },
+        {
+          "code": "Q101976826",
+          "label": "Quite Interesting Talkback"
+        },
+        {
+          "code": "Q124680556",
+          "label": "TopWare Interactive"
+        },
+        {
+          "code": "Q124373148",
+          "label": "Robtek"
+        },
+        {
+          "code": "Q124068072",
+          "label": "Little Orbit"
+        },
+        {
+          "code": "Q124082927",
+          "label": "Phat Phrog Studios"
+        },
+        {
+          "code": "Q124153192",
+          "label": "Shifty Eye Games"
+        },
+        {
+          "code": "Q124154500",
+          "label": "Bushiroad Games"
+        },
+        {
+          "code": "Q124246335",
+          "label": "Tiny Games"
+        },
+        {
+          "code": "Q124287484",
+          "label": "WildTangent Games"
+        },
+        {
+          "code": "Q124294446",
+          "label": "Queasy Games"
+        },
+        {
+          "code": "Q124299875",
+          "label": "Emberheart Games"
+        },
+        {
+          "code": "Q124299936",
+          "label": "Space Fox Games"
+        },
+        {
+          "code": "Q124300419",
+          "label": "Alpha Helix"
+        },
+        {
+          "code": "Q124300420",
+          "label": "Anachronia"
+        },
+        {
+          "code": "Q124300430",
+          "label": "Evolution Trading AG"
+        },
+        {
+          "code": "Q124300429",
+          "label": "Epsitec SA"
+        },
+        {
+          "code": "Q124300434",
+          "label": "la1n"
+        },
+        {
+          "code": "Q124300435",
+          "label": "Modern Arts"
+        },
+        {
+          "code": "Q124300437",
+          "label": "Optobyte"
+        },
+        {
+          "code": "Q124304157",
+          "label": "Mintrocket"
+        },
+        {
+          "code": "Q124304852",
+          "label": "Binary Haze Interactive"
+        },
+        {
+          "code": "Q124373051",
+          "label": "Accrosoft"
+        },
+        {
+          "code": "Q124373055",
+          "label": "GOLEM Computer Vertriebs"
+        },
+        {
+          "code": "Q124373052",
+          "label": "Aids Info Docu Schweiz"
+        },
+        {
+          "code": "Q124373058",
+          "label": "Pablosoft"
+        },
+        {
+          "code": "Q124373059",
+          "label": "Sui Generis Verlag"
+        },
+        {
+          "code": "Q124373056",
+          "label": "LOGO Software"
+        },
+        {
+          "code": "Q124373057",
+          "label": "Macworld Schweiz"
+        },
+        {
+          "code": "Q124373060",
+          "label": "Verkosoft"
+        },
+        {
+          "code": "Q124373151",
+          "label": "Seven Hills Software"
+        },
+        {
+          "code": "Q124373157",
+          "label": "Merit Studios"
+        },
+        {
+          "code": "Q124614846",
+          "label": "Freetronic SA"
+        },
+        {
+          "code": "Q124615408",
+          "label": "Pactronics"
+        },
+        {
+          "code": "Q124615413",
+          "label": "SYSTEM 4 de España"
+        },
+        {
+          "code": "Q124666295",
+          "label": "HexyArts"
+        },
+        {
+          "code": "Q124668370",
+          "label": "SofterCode"
+        },
+        {
+          "code": "Q124669515",
+          "label": "General Admission Software"
+        },
+        {
+          "code": "Q124986552",
+          "label": "Cinergi Interactive"
+        },
+        {
+          "code": "Q124989109",
+          "label": "PORTANIS"
+        },
+        {
+          "code": "Q125000371",
+          "label": "fap girls"
+        },
+        {
+          "code": "Q125134585",
+          "label": "Zodiac Interactive"
+        },
+        {
+          "code": "Q125168369",
+          "label": "Maximum Entertainment"
+        },
+        {
+          "code": "Q125373841",
+          "label": "McPeppergames"
+        },
+        {
+          "code": "Q125374173",
+          "label": "nuGAME"
+        },
+        {
+          "code": "Q125405475",
+          "label": "Arc Games"
+        },
+        {
+          "code": "Q125400731",
+          "label": "Astrum Entertainment"
+        },
+        {
+          "code": "Q125450618",
+          "label": "Blobfish Games"
+        },
+        {
+          "code": "Q125465483",
+          "label": "Indie Asylum"
+        },
+        {
+          "code": "Q125475133",
+          "label": "Asylum Labs"
+        },
+        {
+          "code": "Q125491200",
+          "label": "ManaVoid Entertainment"
+        },
+        {
+          "code": "Q125491291",
+          "label": "BadRez Games"
+        },
+        {
+          "code": "Q125526068",
+          "label": "funkitron"
+        },
+        {
+          "code": "Q125612337",
+          "label": "RealArcade"
+        },
+        {
+          "code": "Q125660356",
+          "label": "Symbolic Software"
+        },
+        {
+          "code": "Q125701888",
+          "label": "RCMADIAX LLC"
+        },
+        {
+          "code": "Q125703364",
+          "label": "OXiAB Game Studio"
+        },
+        {
+          "code": "Q125714477",
+          "label": "Cyna Games"
+        },
+        {
+          "code": "Q125715143",
+          "label": "Tepui Products"
+        },
+        {
+          "code": "Q125748299",
+          "label": "Dakko Dakko"
+        },
+        {
+          "code": "Q125754293",
+          "label": "Nostatic Software"
+        },
+        {
+          "code": "Q125769152",
+          "label": "Visual Impact"
+        },
+        {
+          "code": "Q125879163",
+          "label": "Arawella Corporation"
+        },
+        {
+          "code": "Q125948510",
+          "label": "Digital Dream Studios"
+        },
+        {
+          "code": "Q125950497",
+          "label": "Dezvolt Games"
+        },
+        {
+          "code": "Q125986388",
+          "label": "Digital DNA Games"
+        },
+        {
+          "code": "Q126008842",
+          "label": "Jose Valera"
+        },
+        {
+          "code": "Q126010408",
+          "label": "Sirius Publishing"
+        },
+        {
+          "code": "Q126010565",
+          "label": "IBM Multimedia Studio"
+        },
+        {
+          "code": "Q126047516",
+          "label": "Masque Publishing"
+        },
+        {
+          "code": "Q126071379",
+          "label": "Blinkmoon Games"
+        },
+        {
+          "code": "Q126085569",
+          "label": "Nitrolic Games"
+        },
+        {
+          "code": "Q126085597",
+          "label": "Createasaurus"
+        },
+        {
+          "code": "Q124373053",
+          "label": "Eterna"
+        },
+        {
+          "code": "Q126198321",
+          "label": "Scorpius"
+        },
+        {
+          "code": "Q126098750",
+          "label": "Playduction"
+        },
+        {
+          "code": "Q126098760",
+          "label": "Nutaku Publishing"
+        },
+        {
+          "code": "Q126160237",
+          "label": "Oxygene Media"
+        },
+        {
+          "code": "Q126168120",
+          "label": "Sparks Games"
+        },
+        {
+          "code": "Q126194809",
+          "label": "Homeschool Studios"
+        },
+        {
+          "code": "Q126198236",
+          "label": "Eagle Tree Software"
+        },
+        {
+          "code": "Q126198282",
+          "label": "Softgang"
+        },
+        {
+          "code": "Q126198375",
+          "label": "Magic Soft"
+        },
+        {
+          "code": "Q126325998",
+          "label": "Goyeah"
+        },
+        {
+          "code": "Q126328470",
+          "label": "Wild Rooster"
+        },
+        {
+          "code": "Q126328906",
+          "label": "Mokuzai Studio"
+        },
+        {
+          "code": "Q126414492",
+          "label": "Offbrand Games"
+        },
+        {
+          "code": "Q126486797",
+          "label": "GAMETOTOP.CC"
+        },
+        {
+          "code": "Q126487134",
+          "label": "Soroka Games"
+        },
+        {
+          "code": "Q126487283",
+          "label": "Big Way"
+        },
+        {
+          "code": "Q126500936",
+          "label": "Billion Gaming Studio"
+        },
+        {
+          "code": "Q126563420",
+          "label": "Turbo Suslic EEE"
+        },
+        {
+          "code": "Q126563928",
+          "label": "Genius Studio Japan Inc."
+        },
+        {
+          "code": "Q126664504",
+          "label": "Blumhouse Games"
+        },
+        {
+          "code": "Q126708311",
+          "label": "Mango Party"
+        },
+        {
+          "code": "Q126719665",
+          "label": "GenITeam LLC"
+        },
+        {
+          "code": "Q126720778",
+          "label": "ZNK Games"
+        },
+        {
+          "code": "Q126727419",
+          "label": "Playmeow Games"
+        },
+        {
+          "code": "Q126733240",
+          "label": "LumiNet Kft."
+        },
+        {
+          "code": "Q126952860",
+          "label": "COSEN Co., Ltd."
+        },
+        {
+          "code": "Q127117946",
+          "label": "Hikari Pulse"
+        },
+        {
+          "code": "Q127480363",
+          "label": "D3Publisher of America"
+        },
+        {
+          "code": "Q127480443",
+          "label": "D3Publisher of Europe"
+        },
+        {
+          "code": "Q127533670",
+          "label": "United Games Entertainment GmbH"
+        },
+        {
+          "code": "Q128082281",
+          "label": "Colorful Palette"
+        },
+        {
+          "code": "Q128231619",
+          "label": "Bitwave Games"
+        },
+        {
+          "code": "Q128232203",
+          "label": "TATSUJIN"
+        },
+        {
+          "code": "Q128398710",
+          "label": "Uladzislau Yanushka"
+        },
+        {
+          "code": "Q128405967",
+          "label": "Clear River Games"
+        },
+        {
+          "code": "Q128452637",
+          "label": "QooApp"
+        },
+        {
+          "code": "Q128797281",
+          "label": "Bakodun Game Studios"
+        },
+        {
+          "code": "Q128404022",
+          "label": "Mobirix"
+        },
+        {
+          "code": "Q129196160",
+          "label": "Funbox Media"
+        },
+        {
+          "code": "Q129203351",
+          "label": "NPC Studio"
+        },
+        {
+          "code": "Q129241724",
+          "label": "VALOFE"
+        }
+      ],
+    "platforms": [
+        {
+          "code": "Q10680",
+          "label": "PlayStation 2"
+        },
+        {
+          "code": "Q10683",
+          "label": "PlayStation 3"
+        },
+        {
+            "code": "Q5014725",
+            "label": "PlayStation 4"
+        },
+        {
+            "code": "Q63184502",
+            "label": "PlayStation 5"
+        },
+        {
+            "code": "Q132020",
+            "label": "Xbox"
+        },
+        {
+          "code": "Q48263",
+          "label": "Xbox 360"
+        },
+        {
+            "code": "Q13361286",
+            "label": "Xbox One"
+        },
+        {
+            "code": "Q98973368",
+            "label": "Xbox Series X and Series S"
+        },
+        {
+            "code": "Q98967383",
+            "label": "Xbox Series S"
+        },
+        {
+            "code": "Q64513817",
+            "label": "Xbox Series X"
+        },
+        {
+            "code": "Q1406",
+            "label": "Microsoft Windows"
+        },
+        {
+            "code": "Q14116",
+            "label": "macOS"
+        },
+        {
+          "code": "Q94",
+          "label": "Android"
+        },
+        {
+          "code": "Q48493",
+          "label": "iOS"
+        },
+        {
+          "code": "Q188642",
+          "label": "Game Boy Advance"
+        },
+        {
+          "code": "Q56942",
+          "label": "Wii U"
+        },
+        {
+          "code": "Q19610114",
+          "label": "Nintendo Switch"
+        },
+        {
+          "code": "Q6368",
+          "label": "web browser"
+        }
+    ],
+    "types": [
+        {
+            "code": "Q7889",
+            "label": "video game"
+        },
+        {
+            "code": "Q1066707",
+            "label": "DLC"
+        },
+        {
+            "code": "Q209163",
+            "label": "expansion pack"
+        }
+    ]
+}

--- a/app.py
+++ b/app.py
@@ -28,3 +28,5 @@ asyncio.run(main())
 #     args = arg_parser.parse_args()
 
 #     asyncio.run(resolve_game_entry(args.search_title, args.page_num, args.offset))
+
+

--- a/app.py
+++ b/app.py
@@ -2,15 +2,16 @@
 import asyncio
 import argparse
 from db_manager import create_db, init_pool, local_db_host, local_db_passwd, local_db_port, local_db_user, game_db_schema_path, query_db_with_pool
-from game_manager import resolve_game_entry
 import os
+from game_manager import GameManager
 
 
 async def main():
     # Initialize `game_db`
     await create_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
     db_connection_pool = await init_pool(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db')
-    await resolve_game_entry('dynasty warriors: origins', db_connection_pool)
+    game_manager = GameManager()
+    game = await game_manager.resolve_game_entry('ninja gaiden 4', db_connection_pool)
 
     # The last to step before closing the app
     db_connection_pool.close()
@@ -28,5 +29,4 @@ asyncio.run(main())
 #     args = arg_parser.parse_args()
 
 #     asyncio.run(resolve_game_entry(args.search_title, args.page_num, args.offset))
-
 

--- a/db_manager.py
+++ b/db_manager.py
@@ -5,7 +5,6 @@ import os
 from typing import Any, Dict, Tuple, Optional
 from SPARQLWrapper import JSON
 
-
 # load the credential for the DB
 load_dotenv()
 

--- a/game_manager.py
+++ b/game_manager.py
@@ -5,471 +5,422 @@ from game import Game
 import httpx
 from tabulate import tabulate # temp mesure for user interaction
 from typing import Any, Dict, List, Optional
-
+import os
+import json
 
 URL_METACRITIC = 'https://www.metacritic.com/game/'
 URL_OPENCRITIC = 'https://opencritic.com/game/'
 date_pattern = r'^\d{4}-\d{2}-\d{2}$'
+property_json_path = os.path.join(os.getcwd(), 'DB', 'wikidata_properties.json')
 
 
-async def resolve_game_entry(search_title: str, db_connection_pool, search_page_num: int = 10, search_offset: int = 0) -> Optional[Game]:
-    """Creates an instance of `Game` class when it's found in game_db or Wikidata.
-    
-    Args:
-        search_title: the user's input for the game title to search for.
-        db_connection_pool: the pool of Connection to use to connect to DB. This will only used by the methods requiring `game_db`.
-        search_page_num: the number of pages to look into at once when searching Wikidata.
-        search_offset: the number of pages to ignore to retrieve the next batch of pages when searching Wikidata.
-    """
-    try:
-        response = await _search_game_db(search_title, db_connection_pool)
-        candidates_from_game_db = _make_candiate_list_game_db(response)
-
-        if candidates_from_game_db:
-            selected_candidate = _display_game_candidates(candidates_from_game_db, 'game_db')
-            if selected_candidate:
-                print('The game has been found in game_db')
-                # TODO GTPS-49 have it return the data from game_table and date_platform_table no in Game
-                # TODO change required for the client
-                return Game(selected_candidate)
-
-        print('The game was not found in game_db, trying in Wikidata')
-        response = _cirrus_searrch_wikidata(search_title)
-        candidates_from_wikidata = _make_cadidate_list_wikidata(response)
-
-        if candidates_from_wikidata:
-            selected_candidate = _display_game_candidates(candidates_from_wikidata, 'wikidata')
-            if selected_candidate:
-                await _add_return_new_game(db_connection_pool, new_game=selected_candidate)
-                # TODO GTPS-49 have it return the data from game_table and date_platform_table no in Game
-                # TODO GTPS-49 have it return the new game data right away(game_table, date_platform_table)
-                # TODO change required for the client
-                return Game(selected_candidate)
-
-        print('The game was not even found in Wikidata. Please try again with another name.')
-        return None
-    
-    except IntegrityError as e:
-        raise IntegrityError(f'IntegrityError has occurred. | {e.__cause__}') from e
-    except Exception as e:
-        raise RuntimeError(f'Error occurred in `resolve_game_entry()`: {e}') from e
+class GameManager:
+    """A manager class that process data from game_db or Wikidata to create Game instances"""
+    def __init__(self):
+        self.properties = self._load_json_for_properties(property_json_path)
 
 
-async def _search_game_db(search_title, db_connection_pool) -> Any:
-    """Searches game_db for a game"""
-    select_query = 'SELECT * FROM game_table WHERE MATCH(title, aliases) AGAINST(%s IN NATURAL LANGUAGE MODE);'
-    select_values = (search_title)
-    await query_db_with_pool(db_connection_pool, 'USE', 'USE game_db;')
-    response = await query_db_with_pool(db_connection_pool, 'SELECT', select_query, select_values)
-    return response
-
-
-def _search_for_wikidata_code(search_title: str) -> List[str]:
-    """Searches Wikidata to get the entity codes of entitis that match the search title."""
-    url = 'https://www.wikidata.org/w/api.php'
-    params = {
-        'action': 'query',
-        'list': 'search',
-        'srsearch': search_title,
-        'srnamespace': 0,
-        'format': 'json'
-    }
-
-    response = httpx.get(url=url, params=params)
-    response.raise_for_status()
-    data = response.json()
-    codes = []
-    for element in data['query']['search']:
-        codes.append(element['title'])
-    return codes
-
-
-def _saerch_for_games_with_codes(codes: List[str]) -> Any:
-    """With the given Wikidata entity codes, retrieve the entities."""
-    formatted_codes = '| '.join(codes)
-    url = 'https://www.wikidata.org/w/api.php'
-    params = {
-        'action': 'query',
-        'list': 'search',
-        'srsearch': formatted_codes,
-        'srnamespace': 0,
-        'format': 'json'
-    }
-
-    response = httpx.get(url=url, params=params)
-    response.raise_for_status()
-    data = response.json()
-    return data
-
-async def _search_wikidata(search_title, search_page_num, search_offset) -> Any:
-    """Searches Wikidata for a game"""
-    query_template = """
-    SELECT DISTINCT ?item ?titleLabel ?is_DLC (GROUP_CONCAT(DISTINCT ?platformLabel; separator=", ") AS ?platforms)
-    WHERE {{
-        ?item wdt:P31 ?type.
-        VALUES ?type {{wd:Q7889 wd:Q64170203 wd:Q1066707 wd:Q209163}}.
-        BIND(IF(?type = wd:Q1066707 || ?type = wd:Q209163, 1, 0) AS ?is_DLC).
+    async def resolve_game_entry(self, search_title: str, db_connection_pool, search_page_num: int = 10, search_offset: int = 0) -> Optional[Game]:
+        """Creates an instance of `Game` class when it's found in game_db or Wikidata.
         
-        ?item rdfs:label ?titleLabel.
-        FILTER(LANG(?titleLabel)="en").
-    
-        OPTIONAL{{
-            ?item skos:altLabel ?search_alias. 
-            FILTER(LANG(?search_alias)="en").
-        }}
-    
-        FILTER(CONTAINS(LCASE(?titleLabel), LCASE("{search_title}")) || CONTAINS(LCASE(?search_alias), LCASE("{search_title}"))).
-    
-        OPTIONAL {{
-            ?item p:P400 ?platformNode.
-            ?platformNode ps:P400 ?platformCode.
-            ?platformCode rdfs:label ?platformLabel.
-            FILTER(LANG(?platformLabel) = "en")
-        }}
-    }}
-    GROUP BY ?item ?titleLabel ?is_DLC ?platforms
-    LIMIT {search_page_num}
-    OFFSET {search_offset}
-    """
-    values = {'search_title': f'{search_title}',
-              'search_page_num': f'{search_page_num}',
-              'search_offset': f'{search_offset}'}
-    response = await query_wikidata(query_template, values)
-    return response
+        Args:
+            search_title: the user's input for the game title to search for.
+            db_connection_pool: the pool of Connection to use to connect to DB. This will only used by the methods requiring `game_db`.
+            search_page_num: the number of pages to look into at once when searching Wikidata.
+            search_offset: the number of pages to ignore to retrieve the next batch of pages when searching Wikidata.
+        
+        Returns:
+            an instance of Game containing the data of the target game if found.
+        """
+        try:
+            # Check in game_db
+            response = await self._search_game_db(search_title, db_connection_pool)
+            candidates_from_game_db = self._make_candiate_list_game_db(response)
 
+            if candidates_from_game_db:
+                selected_candidate = self._display_game_candidates(candidates_from_game_db, 'game_db')
+                if selected_candidate:
+                    print('The game has been found in game_db')
+                    # TODO GTPS-49 have it return the data from game_table and date_platform_table no in Game
+                    # TODO change required for the client
+                    return Game(selected_candidate)
 
-def _make_candiate_list_game_db(sql_response) -> List[Dict[str, str]]:
-    """Makes a list of found games as candidates from game_db for the user to choose as a target game.
+            # Fall back to Wikidata
+            print('The game was not found in game_db, trying in Wikidata')
+            wikidata_codes = self._search_wikidata_for_game(search_title)
+            candidates_from_wikidata = self._make_candidate_list_wikidata(wikidata_codes)
 
-    Args:
-        sql_response : The response of SQL query containing games from game_db.
+            if candidates_from_wikidata:
+                selected_candidate = self._display_game_candidates(candidates_from_wikidata, 'wikidata')
+                if selected_candidate:
+                    await self._add_return_new_game(db_connection_pool, new_game=selected_candidate)
+                    # TODO GTPS-49 have it return the data from game_table and date_platform_table no in Game
+                    # TODO GTPS-49 have it return the new game data right away(game_table, date_platform_table)
+                    # TODO change required for the client
+                    return Game(selected_candidate)
 
-    Returns:
-        game_candidates : A list of dictionaries containing multiple games' metadata.
-    """
-    # not yet implemented
-    # pro_enhanced = None
-    # meta_critic_score = 0
-    # meta_user_socre = 0
-    # open_ciritic_score = 0
-    # open_user_score = 0
-    # my_score = 0
-
-    game_candiates: List[Dict[str, Any]] = []
-
-    for element in sql_response:
-        candidate = {
-            'title': element.get('title', None),
-            'is_DLC': element.get('is_DLC', None),
-            'aliases': element.get('aliases', None),
-            'wikidata_code': element.get('wikidata_code', None),
-            'genres': element.get('genres', None),
-            'developers': element.get('developers', None),
-            'publishers': element.get('publishers', None),
-            }
-        game_candiates.append(candidate)
-
-    return game_candiates
-
-
-def _make_cadidate_list_wikidata(sparql_response) -> List[Dict[str, str]]:
-    """Makes a list of found games as candidates from Wikidata for the user to choose as a target game.
-
-    Args:
-        sparql_response : The response of SPARQL query containing probably multiple pages of games.
-
-    Returns:
-        game_candiates : A list of dictionaries containing multiple games' metadata.
-    """
-    target_keys = ['item', 'titleLabel']
-
-    game_candiates: List[Dict[str, Any]] = []
-
-    for element in sparql_response['results']['bindings']:  # -> List of Dicts, `element` is a dict
-        if all(key in element for key in target_keys):  # Lower the level of detail here
-            wikidata_link = element.get('item', {}).get('value', None)
-            platforms = element.get('platforms', {}).get('value', 'not available')
-            title = element.get('titleLabel', {}).get('value', None)
-            is_dlc = element.get('is_DLC', {}).get('value', None)
-            
-            candidate = {
-                'wikidata_link': wikidata_link,
-                'platforms': platforms,
-                'title': title,
-                'is_DLC': is_dlc
-            }
-
-            game_candiates.append(candidate)
-
-    return game_candiates
-
-
-def _display_game_candidates(game_candidates: List[Dict[str, str]], data_source: str) -> Optional[Dict[str, str]]:
-    # GTPS-49 for the client
-    """Displays found candidates to the user to choose.
-    
-    Args:
-        game_candiates: A list of dictionaries containing games found in the data_source
-        data_source: The indicator to tell where the data come from either `game_db` or `WikiData`.
-    Returns:
-        A dictionary of selected game if the user choose the target game from the candiates.
-    """
-    # Create a table to display
-    temp = []
-    for index, candidate in enumerate(game_candidates):
-        if data_source == 'game_db':
-            temp.append({'index': index + 1,
-                         'title': candidate.get('title'),
-                         'is_DLC': 'Yes' if candidate.get('is_DLC') == 1 else 'No',
-                         'genres': candidate.get('genres', 'N/A'),
-                         'developers': candidate.get('developers', 'N/A'),
-                         'publishers': candidate.get('publishers', 'N/A'),
-                         'wikidata': f"https://www.wikidata.org/wiki/{candidate.get('wikidata_code')}" if candidate.get('wikidata_code', None) != None else 'N/A'})
-        elif data_source == 'wikidata':
-            temp.append({'index': index + 1,
-                         'title': candidate.get('title'),
-                         'is_DLC': candidate.get('is_DLC'),
-                         'platforms': candidate.get('platforms'), 
-                         'wikidata': candidate.get('wikidata_link')})
-    print('Choose the desired game or parent game from the list.')
-    print(tabulate(temp, headers='keys', tablefmt='rounded_outline'))
-
-    while True:
-        while True:
-            try:
-                choice = int(input('Enter the number of the game that you want.\nIf the desired game is not in the list, press 0.\n'))
-            except ValueError:
-                print('Please enter a valid number.\nIf the desired is not present in the list, press 0.\n')
-                continue
-            break
-        if choice == 0:
+            print('The game was not even found in Wikidata. Please try again with another name.')
             return None
-        elif 1 <= choice <= len(temp):
-            print(f'You selected {temp[choice-1]["title"]}')
-            return game_candidates[choice-1]
+        
+        except IntegrityError as e:
+            raise IntegrityError(f'IntegrityError has occurred. | {e.__cause__}') from e
+        except Exception as e:
+            raise RuntimeError(f'Error occurred in `resolve_game_entry()`: {e}') from e
 
 
-async def _add_return_new_game(db_connection_pool, new_game: Dict[str, str]) -> Game:
-    """Adds a new game into `game_db` and return it as Game.
-    
-    Args:
-        db_connection_pool: the pool of Connection to use to connect to DB.
-        new_game: a dictionary of a new game to be added into game_db.
-
-    Returns:
-        An instance of Game of the new game.
-    """
-
-    title = None
-    is_DLC = None
-    wikidata_code = None
-    aliases = None
-    genres = None
-    developers = None
-    publishers = None
-    dates_and_platforms = None
-    parent_id = 'N/A'
-
-    try:
-        title = new_game.get('title')
-        is_DLC = True if new_game.get('is_DLC') == '1' else False
-        wikidata_code = new_game.get('wikidata_link').rsplit('/', 1)[-1]
-
-        metadata = await _get_metadata_from_wikidata(wikidata_code)
-        # TODO Implement features for the critics
-        # metascores = get_metacritic()
-        # openscores = get_opencritic()
-        aliases = metadata.get('aliases', None)
-        genres = metadata.get('genres', None)
-        developers = metadata.get('developers', None)
-        publishers = metadata.get('publishers', None)
-        dates_and_platforms = metadata.get('dates_and_platforms', {})
-
-        if is_DLC:
-            response = await _search_game_db(title, db_connection_pool)
-            parent_cadiates_from_game_db = _make_candiate_list_game_db(response)
-            selected_parent = _display_game_candidates(parent_cadiates_from_game_db, 'game_db')
-            if not selected_parent:
-                raise RuntimeError(f'The original game of {title} is not present in `game_db`')
-            parent_id = selected_parent.get('game_id')
-            aliases += selected_parent.get('aliases', '')
-            genres += selected_parent.get('genres', '')
-            developers += selected_parent.get('developers', '')
-            publishers += selected_parent.get('publishers', '')
-
-        # Sends query to `game_table` to add the new game.
-        query_insert_game = """
-        USE game_db;
-        INSERT INTO game_table 
-        (title, is_DLC, aliases, wikidata_code, genres, developers, publishers, parent_id)
-        VALUES(%s, %s, %s, %s, %s, %s, %s, %s);
-        """
-        value_insert_game = (title, is_DLC, aliases, wikidata_code, genres, developers, publishers, parent_id)
-        await query_db_with_pool(db_connection_pool, 'INSERT', query_insert_game, value_insert_game)
-
-        # Sends query to retrieve `game_id`
-        game_id_response = await query_db_with_pool(db_connection_pool, 'SELECT', 'SELECT LAST_INSERT_ID() AS game_id;')
-        game_id = game_id_response[0].get('game_id', None)
-
-        # Sends query to `release table` to add release data platforms and etc.
-        base_query = """
-        USE game_db;
-        INSERT INTO date_platform_table
-        (game_id, release_date, released, platforms, regions)
-        """
-        complete_query = lambda base_query, length: base_query + "VALUE " + ", ".join(['(%s, %s, %s, %s, %s)'] * length) + ';'
-        query_insert_data = complete_query(base_query, len(dates_and_platforms))
-        value_insert_data = tuple()
-        for element in dates_and_platforms:
-            release_date = _process_release_date(element.get('release_date', None))
-            released = 0
-            if release_date is not None:
-                release_date = release_date[:10]
-                released = 1 if release_date and datetime.strptime(release_date, '%Y-%m-%d') <= datetime.today() else 0
-            platforms = element.get('platforms', None)
-            regions = element.get('regions', None)
-            value_insert_data += (game_id, release_date, released, platforms, regions)
-        await query_db_with_pool(db_connection_pool, 'INSERT', query_insert_data, value_insert_data)
-
-    except IntegrityError as e:
-        raise IntegrityError(f'IntegrityError has occurred. {title} is already present in the DB. Please check. | {e.__cause__}') from e
-    except Exception as e:
-        raise RuntimeError(f'Error occurred in `_add_return_new_game()` | {e}') from e
+    async def _search_game_db(self, search_title, db_connection_pool) -> Any:
+        """Searches game_db for a game"""
+        select_query = 'SELECT * FROM game_table WHERE MATCH(title, aliases) AGAINST(%s IN NATURAL LANGUAGE MODE);'
+        select_values = (search_title)
+        await query_db_with_pool(db_connection_pool, 'USE', 'USE game_db;')
+        response = await query_db_with_pool(db_connection_pool, 'SELECT', select_query, select_values)
+        return response
 
 
-async def _get_metadata_from_wikidata(wikidata_code: str) -> Dict[str, str]:
-    """ Retrieves the following metadata of the target game from `Wikidata`:
-        aliases, genres, developers, publishers, platforms and publication data.
+    def _make_candiate_list_game_db(self, response) -> List[Dict[str, str]]:
+        """Makes a list of found games as candidates from game_db for the user to choose as a target game.
 
         Args:
-            wikidata_code: the entity code of the target game in `Wikidata`.
- 
-    """
-    template_simple_metadata = """
-    SELECT DISTINCT
-        (GROUP_CONCAT(DISTINCT ?alias; separator=", ") AS ?aliases)
-        (GROUP_CONCAT(DISTINCT ?genreLabel; separator=", ") AS ?genres)
-        (GROUP_CONCAT(DISTINCT ?developerLabel; separator=", ") AS ?developers)
-        (GROUP_CONCAT(DISTINCT ?publisherLabel; separator=", ") AS ?publishers)
+            sql_response : The response of SQL query containing games from game_db.
 
-    WHERE {{
-        BIND(wd:{wikidata_code} AS ?item)
-        OPTIONAL {{
-            ?item skos:altLabel ?alias.
-            FILTER(LANG(?alias)="en")
-        }}
+        Returns:
+            game_candidates : A list of dictionaries containing multiple games' metadata.
+        """
+        # not yet implemented
+        # pro_enhanced = None
+        # meta_critic_score = 0
+        # meta_user_socre = 0
+        # open_ciritic_score = 0
+        # open_user_score = 0
+        # my_score = 0
 
-        OPTIONAL {{
-            ?item wdt:P136 ?genre.
-            ?genre rdfs:label ?genreLabel.
-            FILTER(LANG(?genreLabel)="en")
-        }}
+        game_candiates: List[Dict[str, Any]] = []
 
-        OPTIONAL {{
-            ?item wdt:P178 ?developer.
-            ?developer rdfs:label ?developerLabel.
-            FILTER(LANG(?developerLabel)="en")
-        }}
+        for element in response:
+            candidate = {
+                'game_id': element.get('game_id', None),
+                'title': element.get('title', None),
+                'is_DLC': element.get('is_DLC', None),
+                'aliases': element.get('aliases', None),
+                'wikidata_code': element.get('wikidata_code', None),
+                'genres': element.get('genres', None),
+                'developers': element.get('developers', None),
+                'publishers': element.get('publishers', None),
+                }
+            game_candiates.append(candidate)
 
-        OPTIONAL {{
-            ?item wdt:P123 ?publisher.
-            ?publisher rdfs:label ?publisherLabel.
-            FILTER(LANG(?publisherLabel)="en")
-        }}
-    }}
-    """
+        return game_candiates
 
-    template_date_platform = """
-        SELECT DISTINCT
-        ?publicationDateLabel 
-        (GROUP_CONCAT(DISTINCT ?finalPlatformLabel; separator=", ") AS ?platforms)
-        ?region
-        WHERE {{
-            BIND(wd:{wikidata_code} AS ?item)
-            OPTIONAL {{
-                ?item p:P577 ?publicationDateNode.
-                FILTER NOT EXISTS {{
-                    ?publicationDateNode pq:P2241 ?deprecationReason
-                }}
-                ?publicationDateNode ps:P577 ?publicationDateLabel.
-                OPTIONAL {{
-                    ?publicationDateNode pq:P400 ?platformNodeFromDate.
-                    ?platformNodeFromDate rdfs:label ?platformLabelFromDate.
-                    FILTER(LANG(?platformLabelFromDate) = "en").
-                }}
-                OPTIONAL {{
-                    ?publicationDateNode pq:P291 ?placeOfDistribution.
-                    ?placeOfDistribution rdfs:label ?region.
-                    FILTER(LANG(?region) = "en")
-                }}
-            }}
 
-            OPTIONAL {{
-                ?item p:P400 ?platformNode.
-                ?platformNode ps:P400 ?platformCode.
-                ?platformCode rdfs:label ?platformLabel.
-                FILTER(LANG(?platformLabel) = "en").
-            }}
+    def _search_wikidata_for_game(self, search_title: str) -> List[str]:
+        """Searches Wikidata to get the entity codes of entities that match the search title."""
+        url = 'https://www.wikidata.org/w/api.php'
+        params = {
+            'action': 'query',
+            'list': 'search',
+            'srsearch': search_title,
+            'srnamespace': 0,
+            'format': 'json'
+        }
 
-            BIND(COALESCE(?platformLabelFromDate, ?platformLabel) AS ?finalPlatformLabel).
-        }}
+        response = httpx.get(url=url, params=params)
+        response.raise_for_status()
+        data = response.json()
+        codes = []
+        for element in data['query']['search']:
+            codes.append(element['title'])
+        return codes
 
-        GROUP BY ?publicationDateLabel ?platforms ?region
-    """
+
+    def _make_candidate_list_wikidata(self, wikidata_codes: List[str], language: str = 'en') -> List[Dict[str, str]]:
+        url = 'https://www.wikidata.org/w/api.php'
+        codes = '|'.join(wikidata_codes)
+        params = {
+            'action': 'wbgetentities',
+            'ids': codes,
+            'languages': language,
+            'format': 'json',
+            'props': 'labels|claims'
+        }
+        response = httpx.get(url=url, params=params)
+        response.raise_for_status()
+        data = response.json()
+        # title, wikidata link, platform need to be displayed
+        game_candiates: List[Dict[str, Any]] = []
+        for code, entity in data.get('entities', {}).items():
+            temp = {}
+            entity_types = [entity_type.get('mainsnak', {}).get('datavalue', {}).get('value', {}).get('id', 'N/A') for entity_type in entity.get('claims', {}).get('P31', {})]
+            target_types = ['Q7889', 'Q1066707', 'Q209163']
+
+            if any(target_type in entity_types for target_type in target_types):
+                wikidata_link = f'https://www.wikidata.org/wiki/{code}'
+                title = entity.get('labels', {}).get(language, {}).get('value', 'N/A')
+                platforms = [platform.get('mainsnak', {}).get('datavalue', {}).get('value', {}).get('id', 'N/A') for platform in entity.get('claims', {}).get('P400', {})]
+                temp['wikidata_link'] = wikidata_link
+                temp['title'] = title
+                temp['platforms'] = self._replace_code('platforms', platforms)
+                temp['is_DLC'] = True if any(target_type in entity_types for target_type in ['Q1066707', 'Q209163']) else False
+
+                game_candiates.append(temp)
+
+        return game_candiates
+
+
+    def _get_metadata(self, code: str, language: str = 'en') -> Any:
+        """With the given Wikidata entity code, retrieve metadata."""
+        url = 'https://www.wikidata.org/w/api.php'
+        params = {
+            'action': 'wbgetentities',
+            'ids': code,
+            'languages': language,
+            'format': 'json',
+            'props': 'labels|aliases|claims'
+        }
+
+        response = httpx.get(url=url, params=params)
+        response.raise_for_status()
+        data = response.json()
+        processed_data = {}
+        for entity in data['entities'].values():
+            processed_data['title'] = entity.get('labels', {}).get(language, {}).get('value', 'N/A')
+            processed_data['aliases'] = [alias.get('value', 'N/A') for alias in entity.get('aliases', {}).get(language, {})]
+            processed_data['wikidata_code'] = entity.get('id', 'N/A')
+            processed_data['is_DLC'] = True if entity.get('claims', {}).get('P31', [])[0].get('mainsnak', {}).get('datavalue', {}).get('value', {}).get('id', 'N/A') in ('Q1066707', 'Q209163') else False
+            processed_data['genres'] = [genre.get('mainsnak', {}).get('datavalue', {}).get('value', {}).get('id', 'N/A') for genre in entity.get('claims', {}).get('P136', {})]
+            processed_data['developers'] = [developer.get('mainsnak', {}).get('datavalue', {}).get('value', {}).get('id', 'N/A') for developer in entity.get('claims', {}).get('P178', {})]
+            processed_data['publishers'] = [publisher.get('mainsnak', {}).get('datavalue', {}).get('value', {}).get('id', 'N/A') for publisher in entity.get('claims', {}).get('P123', {})]
+            processed_data['platforms'] = [platform.get('mainsnak', {}).get('datavalue', {}).get('value', {}).get('id', 'N/A') for platform in entity.get('claims', {}).get('P400', {})]
+            processed_data['publication_dates'] = []
+            for date_node in entity.get('claims', {}).get('P577', {}):
+                skip_outer = False
+                temp = {}
+                temp['publication_date'] = date_node.get('mainsnak', {}).get('datavalue', {}).get('value', {}).get('time', 'N/A')
+                temp['platforms'] = ''
+                for qualifier_code, qualifier_node in date_node.get('qualifiers', {}).items():
+                    # TODO in case of delayed
+                    if qualifier_code == 'P2241':
+                        skip_outer = True
+                        break
+                    if qualifier_code == 'P400':
+                        temp['platforms'] = [platform_node.get('datavalue', {}).get('value', {}).get('id', 'N/A') for platform_node in qualifier_node]
+                    if not temp['platforms']:
+                        temp['platforms'] = processed_data['platforms']
+                if skip_outer:
+                    continue
+                    # in case no platforms mentioned
+                if not temp['platforms']:
+                    temp.update({'platforms': processed_data['platforms']})
+                processed_data['publication_dates'].append(temp)
+            # TODO in case no platform mentioned, use platforms
+        return processed_data
+
+
+    async def _add_return_new_game(self, db_connection_pool, new_game: Dict[str, str]) -> Game:
+        """Adds a new game into `game_db` and return it as Game.
+        
+        Args:
+            db_connection_pool: the pool of Connection to use to connect to DB.
+            new_game: a dictionary of a new game to be added into game_db.
+
+        Returns:
+            An instance of Game of the new game.
+        """
+
+        title = None
+        is_DLC = None
+        wikidata_code = None
+        aliases = None
+        genres = None
+        developers = None
+        publishers = None
+        dates_and_platforms = None
+        parent_id = 'N/A'
+
+        try:
+            title = new_game.get('title')
+            is_DLC = new_game.get('is_DLC')
+            wikidata_code = new_game.get('wikidata_link').rsplit('/', 1)[-1]
+
+            raw_metadata = self._get_metadata(wikidata_code, 'en')
+            processed_metadata = self._process_game_data_with_code(raw_metadata)
+            # TODO Implement features for the critics
+            # metascores = get_metacritic()
+            # openscores = get_opencritic()
+            aliases = processed_metadata.get('aliases', None)
+            genres = processed_metadata.get('genres', None)
+            developers = processed_metadata.get('developers', None)
+            publishers = processed_metadata.get('publishers', None)
+            dates_and_platforms = processed_metadata.get('publication_dates', None)
+
+            if is_DLC:
+                response = await self._search_game_db(title, db_connection_pool)
+                parent_cadiates_from_game_db = self._make_candiate_list_game_db(response)
+                selected_parent = self._display_game_candidates(parent_cadiates_from_game_db, 'game_db')
+                if not selected_parent:
+                    raise RuntimeError(f'The original game of {title} is not present in `game_db`')
+                parent_id = selected_parent.get('game_id')
+                aliases += selected_parent.get('aliases', '')
+                genres += selected_parent.get('genres', '')
+                developers += selected_parent.get('developers', '')
+                publishers += selected_parent.get('publishers', '')
+
+            # Sends query to `game_table` to add the new game.
+            query_insert_game = """
+            USE game_db;
+            INSERT INTO game_table 
+            (title, is_DLC, aliases, wikidata_code, genres, developers, publishers, parent_id)
+            VALUES(%s, %s, %s, %s, %s, %s, %s, %s);
+            """
+            value_insert_game = (title, is_DLC, aliases, wikidata_code, genres, developers, publishers, parent_id)
+            await query_db_with_pool(db_connection_pool, 'INSERT', query_insert_game, value_insert_game)
+
+            # Sends query to retrieve `game_id`
+            game_id_response = await query_db_with_pool(db_connection_pool, 'SELECT', 'SELECT LAST_INSERT_ID() AS game_id;')
+            game_id = game_id_response[0].get('game_id', None)
+
+            # Sends query to `release table` to add release data platforms and etc.
+            base_query = """
+            USE game_db;
+            INSERT INTO date_platform_table
+            (game_id, release_date, released, platforms)
+            """
+            complete_query = lambda base_query, length: base_query + "VALUE " + ", ".join(['(%s, %s, %s, %s)'] * length) + ';'
+            if dates_and_platforms:
+                query_insert_data = complete_query(base_query, len(dates_and_platforms))
+                value_insert_data = tuple()
+                for element in dates_and_platforms:
+                    release_date = element.get('publication_date', None)
+                    released = 0
+                    if release_date is not None:
+                        released = 1 if release_date and datetime.strptime(release_date, '%Y-%m-%d') <= datetime.today() else 0
+                    platforms = element.get('platforms', None)
+                    value_insert_data += (game_id, release_date, released, platforms)
+                await query_db_with_pool(db_connection_pool, 'INSERT', query_insert_data, value_insert_data)
+            else:
+                query_insert_data = complete_query(base_query, 1)
+                parent_platforms = await query_db_with_pool(db_connection_pool, 'SELECT', f'SELECT platforms FROM date_platform_table WHERE game_id = {parent_id} GROUP BY platforms')
+                platforms = ''
+                for element in parent_platforms:
+                    platforms = platforms+ ', ' + element['platforms'] if platforms else element['platforms']
+                value_insert_data = (game_id, '2100-12-31', 0, platforms)
+                await query_db_with_pool(db_connection_pool, 'INSERT', query_insert_data, value_insert_data)
+
+        except IntegrityError as e:
+            raise IntegrityError(f'IntegrityError has occurred. {title} is already present in the DB. Please check. | {e.__cause__}') from e
+        except Exception as e:
+            raise RuntimeError(f'Error occurred in `_add_return_new_game()` | {e}') from e
+
+
+    def _replace_code(self, property_name: str, codes: str) -> str:
+        """Finds and replcaes codes with actual values."""
+        values = []
+        for code in codes:
+            value = self.properties[property_name].get(code, 'N/A')
+            values.append(value)
+
+        return ', '.join(values)
+
+
+    def _process_release_date(self, release_date: Optional[str]) -> str:
+        """Hanldes release dates when it's yyyy-01-01 by modifying it to yyyy-12-31 to indicate the title comes out somewhere in the year.
+        
+        Args:
+            release_date: the release date to process.
+        Returns:
+            a processed release date.
+        """
+        if release_date is None:
+            return None
+        
+        release_date = release_date[1:11]
+        date_elements = release_date.split('-', 2)
+        year = date_elements[0]
+        month = date_elements[1]
+        day = date_elements[2]
+
+        if month == '00' and day == '00':
+            return f'{year}-12-31'
+        else:
+            return release_date
+
+
+    def _process_game_data_with_code(self, data_with_code: Dict) -> Dict:
+        """Replaces `Wikidata` code in the data with their equivalent values."""
+        game_data = {}
+        game_data['publication_dates'] = []
+        for key, value in data_with_code.items():
+            if key in ('genres', 'developers', 'publishers', 'platforms'):
+                game_data[key] = self._replace_code(key, value)
+            elif key == 'publication_dates':
+                for date_platform in value:
+                    temp = {}
+                    temp['publication_date'] = self._process_release_date(date_platform['publication_date'])
+                    temp['platforms'] = self._replace_code('platforms', date_platform['platforms'])
+                    game_data[key].append(temp)
+            elif key in ('title', 'wikidata_code', 'is_DLC'):
+                game_data[key] = value
+            elif key in ('aliases'):
+                game_data[key] = ', '.join(value)
+        return game_data
+
+
+    def _load_json_for_properties(self, json_path: str):
+        """Loads the property data from `wikidata_properties.json` file."""
+        with open(json_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        properties = {}
+
+        for property_name in data:
+            temp = {}
+            for element in data[property_name]:
+                temp[element['code']] = element['label']
+            properties[property_name] = temp
+
+        return properties
     
-    # it's expected to have one entry
-    simple_metadata = await query_wikidata(template_simple_metadata, {'wikidata_code':wikidata_code})
-    # there might be multiple entries
-    date_platform_metadata = await query_wikidata(template_date_platform, {'wikidata_code':wikidata_code})
 
-    aliases = simple_metadata['results']['bindings'][0].get('aliases', {}).get('value', None)
-    genres = simple_metadata['results']['bindings'][0].get('genres', {}).get('value', None)
-    developers = simple_metadata['results']['bindings'][0].get('developers', {}).get('value', None)
-    publishers = simple_metadata['results']['bindings'][0].get('publishers', {}).get('value', None)
+    def _display_game_candidates(self, game_candidates: List[Dict[str, str]], data_source: str) -> Optional[Dict[str, str]]:
+        # GTPS-49 for the client
+        """Displays found candidates to the user to choose.
+        
+        Args:
+            game_candiates: A list of dictionaries containing games found in the data_source
+            data_source: The indicator to tell where the data come from either `game_db` or `WikiData`.
+        Returns:
+            A dictionary of selected game if the user choose the target game from the candiates.
+        """
+        # Create a table to display
+        temp = []
+        for index, candidate in enumerate(game_candidates):
+            if data_source == 'game_db':
+                temp.append({'index': index + 1,
+                            'game_id': candidate.get('game_id'),
+                            'title': candidate.get('title'),
+                            'is_DLC': 'Yes' if candidate.get('is_DLC') == 1 else 'No',
+                            'genres': candidate.get('genres', 'N/A'),
+                            'developers': candidate.get('developers', 'N/A'),
+                            'publishers': candidate.get('publishers', 'N/A'),
+                            'wikidata': f"https://www.wikidata.org/wiki/{candidate.get('wikidata_code')}" if candidate.get('wikidata_code', None) != None else 'N/A'})
+            elif data_source == 'wikidata':
+                temp.append({'index': index + 1,
+                            'title': candidate.get('title'),
+                            'platforms': candidate.get('platforms'), 
+                            'is_DLC': 'Yes' if candidate.get('is_DLC') else 'No',
+                            'wikidata': candidate.get('wikidata_link')})
+        print('Choose the desired game or parent game from the list.')
+        print(tabulate(temp, headers='keys', tablefmt='rounded_outline'))
 
-    dates_and_platforms: List[Dict[str, str]] = []
-    for element in date_platform_metadata['results']['bindings']:
-        release_date = element.get('publicationDateLabel', {}).get('value', None)
-        platforms = element.get('platforms', {}).get('value', None)
-        regions = element.get('region', {}).get('value', None)
-
-        temp_entry = {
-            'release_date': release_date,
-            'platforms': platforms,
-            'regions': regions
-            }
-
-        dates_and_platforms.append(temp_entry)
-    
-    metadata = {
-        'aliases': aliases,
-        'genres': genres,
-        'developers': developers,
-        'publishers': publishers,
-        'dates_and_platforms': dates_and_platforms
-    }
-
-    return metadata
-
-
-def _process_release_date(release_date: Optional[str]) -> str:
-    """Hanldes release dates when it's yyyy-01-01 by modifying it to yyyy-12-31 to indicate the title comes out somewhere in the year.
-    
-    Args:
-        release_date: the release date to process.
-    Returns:
-        a processed release date.
-    """
-    if release_date is None:
-        return None
-    
-    release_date = release_date[:10]
-    date_elements = release_date.split('-', 2)
-    year = date_elements[0]
-    month = date_elements[1]
-    day = date_elements[2]
-
-    if month == '01' and day == '01':
-        return f'{year}-12-31'
-    else:
-        return release_date
+        while True:
+            while True:
+                try:
+                    choice = int(input('Enter the number of the game that you want.\nIf the desired game is not in the list, press 0.\n'))
+                except ValueError:
+                    print('Please enter a valid number.\nIf the desired is not present in the list, press 0.\n')
+                    continue
+                break
+            if choice == 0:
+                return None
+            elif 1 <= choice <= len(temp):
+                print(f'You selected {temp[choice-1]["title"]}')
+                return game_candidates[choice-1]

--- a/sparql_tools.py
+++ b/sparql_tools.py
@@ -1,0 +1,186 @@
+"""Scripts that holds methods using SPARQL for Wikidata"""
+from db_manager import query_wikidata
+from typing import Any, Dict, List
+
+async def search_wikidata(search_title, search_page_num, search_offset) -> Any:
+    """Searches Wikidata for a game"""
+    query_template = """
+    SELECT DISTINCT ?item ?titleLabel ?is_DLC (GROUP_CONCAT(DISTINCT ?platformLabel; separator=", ") AS ?platforms)
+    WHERE {{
+        ?item wdt:P31 ?type.
+        VALUES ?type {{wd:Q7889 wd:Q64170203 wd:Q1066707 wd:Q209163}}.
+        BIND(IF(?type = wd:Q1066707 || ?type = wd:Q209163, 1, 0) AS ?is_DLC).
+        
+        ?item rdfs:label ?titleLabel.
+        FILTER(LANG(?titleLabel)="en").
+    
+        OPTIONAL{{
+            ?item skos:altLabel ?search_alias. 
+            FILTER(LANG(?search_alias)="en").
+        }}
+    
+        FILTER(CONTAINS(LCASE(?titleLabel), LCASE("{search_title}")) || CONTAINS(LCASE(?search_alias), LCASE("{search_title}"))).
+    
+        OPTIONAL {{
+            ?item p:P400 ?platformNode.
+            ?platformNode ps:P400 ?platformCode.
+            ?platformCode rdfs:label ?platformLabel.
+            FILTER(LANG(?platformLabel) = "en")
+        }}
+    }}
+    GROUP BY ?item ?titleLabel ?is_DLC ?platforms
+    LIMIT {search_page_num}
+    OFFSET {search_offset}
+    """
+    values = {'search_title': f'{search_title}',
+              'search_page_num': f'{search_page_num}',
+              'search_offset': f'{search_offset}'}
+    response = await query_wikidata(query_template, values)
+    return response
+
+
+def make_cadidate_list_wikidata(sparql_response) -> List[Dict[str, str]]:
+    """Makes a list of found games as candidates from Wikidata for the user to choose as a target game.
+
+    Args:
+        sparql_response : The response of SPARQL query containing probably multiple pages of games.
+
+    Returns:
+        game_candiates : A list of dictionaries containing multiple games' metadata.
+    """
+    target_keys = ['item', 'titleLabel']
+
+    game_candiates: List[Dict[str, Any]] = []
+
+    for element in sparql_response['results']['bindings']:  # -> List of Dicts, `element` is a dict
+        if all(key in element for key in target_keys):  # Lower the level of detail here
+            wikidata_link = element.get('item', {}).get('value', None)
+            platforms = element.get('platforms', {}).get('value', 'not available')
+            title = element.get('titleLabel', {}).get('value', None)
+            is_dlc = element.get('is_DLC', {}).get('value', None)
+            
+            candidate = {
+                'wikidata_link': wikidata_link,
+                'platforms': platforms,
+                'title': title,
+                'is_DLC': is_dlc
+            }
+
+            game_candiates.append(candidate)
+
+    return game_candiates
+
+
+async def get_metadata_from_wikidata(wikidata_code: str) -> Dict[str, str]:
+    """ Retrieves the following metadata of the target game from `Wikidata`:
+        aliases, genres, developers, publishers, platforms and publication data.
+
+        Args:
+            wikidata_code: the entity code of the target game in `Wikidata`.
+ 
+    """
+    template_simple_metadata = """
+    SELECT DISTINCT
+        (GROUP_CONCAT(DISTINCT ?alias; separator=", ") AS ?aliases)
+        (GROUP_CONCAT(DISTINCT ?genreLabel; separator=", ") AS ?genres)
+        (GROUP_CONCAT(DISTINCT ?developerLabel; separator=", ") AS ?developers)
+        (GROUP_CONCAT(DISTINCT ?publisherLabel; separator=", ") AS ?publishers)
+
+    WHERE {{
+        BIND(wd:{wikidata_code} AS ?item)
+        OPTIONAL {{
+            ?item skos:altLabel ?alias.
+            FILTER(LANG(?alias)="en")
+        }}
+
+        OPTIONAL {{
+            ?item wdt:P136 ?genre.
+            ?genre rdfs:label ?genreLabel.
+            FILTER(LANG(?genreLabel)="en")
+        }}
+
+        OPTIONAL {{
+            ?item wdt:P178 ?developer.
+            ?developer rdfs:label ?developerLabel.
+            FILTER(LANG(?developerLabel)="en")
+        }}
+
+        OPTIONAL {{
+            ?item wdt:P123 ?publisher.
+            ?publisher rdfs:label ?publisherLabel.
+            FILTER(LANG(?publisherLabel)="en")
+        }}
+    }}
+    """
+
+    template_date_platform = """
+        SELECT DISTINCT
+        ?publicationDateLabel 
+        (GROUP_CONCAT(DISTINCT ?finalPlatformLabel; separator=", ") AS ?platforms)
+        ?region
+        WHERE {{
+            BIND(wd:{wikidata_code} AS ?item)
+            OPTIONAL {{
+                ?item p:P577 ?publicationDateNode.
+                FILTER NOT EXISTS {{
+                    ?publicationDateNode pq:P2241 ?deprecationReason
+                }}
+                ?publicationDateNode ps:P577 ?publicationDateLabel.
+                OPTIONAL {{
+                    ?publicationDateNode pq:P400 ?platformNodeFromDate.
+                    ?platformNodeFromDate rdfs:label ?platformLabelFromDate.
+                    FILTER(LANG(?platformLabelFromDate) = "en").
+                }}
+                OPTIONAL {{
+                    ?publicationDateNode pq:P291 ?placeOfDistribution.
+                    ?placeOfDistribution rdfs:label ?region.
+                    FILTER(LANG(?region) = "en")
+                }}
+            }}
+
+            OPTIONAL {{
+                ?item p:P400 ?platformNode.
+                ?platformNode ps:P400 ?platformCode.
+                ?platformCode rdfs:label ?platformLabel.
+                FILTER(LANG(?platformLabel) = "en").
+            }}
+
+            BIND(COALESCE(?platformLabelFromDate, ?platformLabel) AS ?finalPlatformLabel).
+        }}
+
+        GROUP BY ?publicationDateLabel ?platforms ?region
+    """
+    
+    # it's expected to have one entry
+    simple_metadata = await query_wikidata(template_simple_metadata, {'wikidata_code':wikidata_code})
+    # there might be multiple entries
+    date_platform_metadata = await query_wikidata(template_date_platform, {'wikidata_code':wikidata_code})
+
+    aliases = simple_metadata['results']['bindings'][0].get('aliases', {}).get('value', None)
+    genres = simple_metadata['results']['bindings'][0].get('genres', {}).get('value', None)
+    developers = simple_metadata['results']['bindings'][0].get('developers', {}).get('value', None)
+    publishers = simple_metadata['results']['bindings'][0].get('publishers', {}).get('value', None)
+
+    dates_and_platforms: List[Dict[str, str]] = []
+    for element in date_platform_metadata['results']['bindings']:
+        release_date = element.get('publicationDateLabel', {}).get('value', None)
+        platforms = element.get('platforms', {}).get('value', None)
+        regions = element.get('region', {}).get('value', None)
+
+        temp_entry = {
+            'release_date': release_date,
+            'platforms': platforms,
+            'regions': regions
+            }
+
+        dates_and_platforms.append(temp_entry)
+    
+    metadata = {
+        'aliases': aliases,
+        'genres': genres,
+        'developers': developers,
+        'publishers': publishers,
+        'dates_and_platforms': dates_and_platforms
+    }
+
+    return metadata


### PR DESCRIPTION
# Resolution Details

- while working on this story, the work flow over the server and client got more clear.
    - Searching `Wikidata` for games when the games are not found in `game_db` should be done on the side of the client.
- Along with this, an enhanced searching `Wikidata`  has been found and tested.
- The enhanced logic has been implemented and tested with multiple games
- Due to the fact that some data in `Wikidata` are incomplete, a subsequent story has been created([https://www.notion.so/Story-Check-invalid-data-19aaf22643888010be47d3d4a23c1b14?pvs=4](https://www.notion.so/Story-Check-invalid-data-19aaf22643888010be47d3d4a23c1b14?pvs=21))