### PR TITLE
Gtps 83 implement fallback search with wikidata

### DIFF
--- a/client/templates/index.html
+++ b/client/templates/index.html
@@ -225,6 +225,9 @@
           <th>Title</th>
           <th>Platforms</th>
           <th>Release Date</th>
+          <th>Genres</th>
+          <th>Developers</th>
+          <th>wikidata</th>
         </tr>
       </thead>
       <tbody></tbody>
@@ -260,6 +263,9 @@
               <td>${game.title}</td>
               <td>${game.platforms}</td>
               <td>${game.release_date}</td>
+              <td>${game.genres}</td>
+              <td>${game.developers}</td>
+              <td><a href="https://wikidata.org/wiki/${game.wikidata_code}">LINK</a></td>
             `;
 
             tableBody.appendChild(row);

--- a/server/schemas/wikidata_properties.json
+++ b/server/schemas/wikidata_properties.json
@@ -32511,6 +32511,10 @@
             "label": "Microsoft Windows"
         },
         {
+          "code": "Q21207",
+          "label": "Windows Mobile"
+        },
+        {
             "code": "Q14116",
             "label": "macOS"
         },
@@ -32525,6 +32529,10 @@
         {
           "code": "Q188642",
           "label": "Game Boy Advance"
+        },
+        {
+          "code": "Q8079",
+          "label": "Wii"
         },
         {
           "code": "Q56942",

--- a/server/views/blog.py
+++ b/server/views/blog.py
@@ -80,9 +80,6 @@ def search_for_games():
     search_keyword = request.args.get('search_keyword')
 
     candidates = None
-    candidates = game_manager.loop.run_until_complete(game_manager.search_game_db(search_keyword))
-    if not candidates:
-        candidates = game_manager.loop.run_until_complete(game_manager.search_wikidata(search_keyword))
+    candidates = game_manager.loop.run_until_complete(game_manager.find_candiates(search_keyword))
 
     return jsonify(candidates)
-


### PR DESCRIPTION
# Resolution Details

- The fallback search with Wikidata has been integrated.
    - The search result limit has been incremented to 50
    - A filtering for video games had been implemented in the past.
- Now, the blog displays the following properties of games:
    - title, platforms, release date, genres, developers, and wikidata links
- It’s tested with the first berserker Khazan and Clair obscur: Expedition 33