### PR TITLE
Gtps 77 implement add game feature

### DIFF
--- a/client/templates/index.html
+++ b/client/templates/index.html
@@ -203,35 +203,54 @@
 <div>
   <nav>
       <div class="container pb-md-5 text-center">
-        <div class="row gx-5">
-          <div class="col d-grid">
-            <button type="button" class="btn btn-secondary w-100" onclick="changeTab('search')">Search</button>
+        {% if user_email != null %} 
+          <div class="row gx-5">
+            <div class="col d-grid">
+              <button type="button" class="btn btn-secondary w-100" onclick="changeTab('search')">Search</button>
+            </div>
+            <div class="col d-grid">
+              <button type="button" class="btn btn-secondary w-100" onclick="changeTab('tracker')">Games of Interest</button>
+            </div>
           </div>
-          <div class="col d-grid">
-            <button type="button" class="btn btn-secondary w-100" onclick="changeTab('tracker')">Games of Interest</button>
+        {% else %}
+          <div class="row gx-5">
+            <div class="col d-grid">
+              <button type="button" class="btn btn-secondary w-100" disabled>Search</button>
+            </div>
+            <div class="col d-grid">
+              <button type="button" class="btn btn-secondary w-100" disabled>Games of Interest</button>
+            </div>
           </div>
-        </div>
+        {% endif %}
       </div>
     </nav>
 </div>
 
 <main class="container">
   <div id="tab-search">
-    <input type="text" class="form-control form-control-dark text-bg-dark" id="search_keyword" name="search_keyword" placeholder="Search..." aria-label="Search" required>
-    <button onclick="searchGame()" class="btn btn-outline-primary btn-lg">Search</button>
-    <table id="game-table" class="table">
-      <thead>
-        <tr>
-          <th>Title</th>
-          <th>Platforms</th>
-          <th>Release Date</th>
-          <th>Genres</th>
-          <th>Developers</th>
-          <th>wikidata</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+    {% if user_email != null %}
+      <form onsubmit="searchGame(event)">
+        <input type="text" class="form-control form-control-dark text-bg-dark" id="search_keyword" name="search_keyword" placeholder="Search..." aria-label="Search" required>
+        <button type="submit" class="btn btn-outline-primary btn-lg">Search</button>
+      </form>
+      <table id="game-table" class="table">
+        <thead>
+          <tr>
+            <th>Add</th>
+            <th>Title</th>
+            <th>Platforms</th>
+            <th>Release Date</th>
+            <th>Genres</th>
+            <th>Developers</th>
+            <th>wikidata</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    {% else %}
+      <input type="text" class="form-control form-control-dark text-bg-dark" id="search_keyword" name="search_keyword" placeholder="Please Log in" disabled>
+      <button type="submit" class="btn btn-outline-primary btn-lg" disabled>Search</button>
+    {% endif %}
   </div>
   <div id="tab-tracker" class="d-none">
     <div class="row mb-3 text-center">
@@ -246,7 +265,8 @@
       document.getElementById('tab-tracker').classList.toggle('d-none', name !== 'tracker');
     }
 
-    function searchGame() {
+    function searchGame(e) {
+      e.preventDefault();
       const searchKeyword = document.getElementById('search_keyword').value;
       const url = `/blog/search?search_keyword=${encodeURIComponent(searchKeyword)}`;
       
@@ -260,6 +280,7 @@
             const row = document.createElement('tr');
 
             row.innerHTML = `
+              <td><a href="/blog/add_game?game_id=${game.game_id}&release_id=${game.release_id}" class="btn btn-primary">ADD</td>
               <td>${game.title}</td>
               <td>${game.platforms}</td>
               <td>${game.release_date}</td>

--- a/client/templates/index.html
+++ b/client/templates/index.html
@@ -260,6 +260,8 @@
     </div>
   </div>
   <script>
+    //let searchResult = [];
+
     function changeTab(name) {
       document.getElementById('tab-search').classList.toggle('d-none', name !== 'search');
       document.getElementById('tab-tracker').classList.toggle('d-none', name !== 'tracker');
@@ -273,6 +275,8 @@
       fetch(url)
         .then(response => response.json())
         .then(data => {
+          //searchResult = data; // stores the search result in the global variable.
+
           const tableBody = document.querySelector('#game-table tbody');
           tableBody.innerHTML = '';
 

--- a/old_app.py
+++ b/old_app.py
@@ -13,7 +13,7 @@ async def main():
     await create_mysql_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
     db_connection_pool = await init_pool(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd)
     game_manager = GameManager(pool=db_connection_pool, loop=loop)
-    game = await game_manager.resolve_game_entry('Amplitude', db_connection_pool)
+    game = await game_manager.resolve_game_entry('khazan', db_connection_pool)
 
     # The last to step before closing the app
     db_connection_pool.close()

--- a/old_app.py
+++ b/old_app.py
@@ -1,7 +1,7 @@
 """ Entry point of the app """
 import asyncio
 import argparse
-from server.models.mysqldb import create_db, init_pool, local_db_host, local_db_passwd, local_db_port, local_db_user, game_db_schema_path, query_db_with_pool
+from server.models.mysqldb import create_mysql_db, init_pool, local_db_host, local_db_passwd, local_db_port, local_db_user, game_db_schema_path, query_db_with_pool
 import os
 from server.controllers.game_manager import GameManager
 
@@ -10,7 +10,7 @@ async def main():
     # Initialize `game_db`
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    await create_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
+    await create_mysql_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
     db_connection_pool = await init_pool(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd)
     game_manager = GameManager(pool=db_connection_pool, loop=loop)
     game = await game_manager.resolve_game_entry('Amplitude', db_connection_pool)

--- a/server/controllers/user_manager.py
+++ b/server/controllers/user_manager.py
@@ -3,6 +3,7 @@ from bson.objectid import ObjectId
 from flask_login import UserMixin
 from server.models.mongodb import connect_mongodb
 
+
 class User(UserMixin):
     def __init__(self, user_id, user_email, game_list):
         self.user_id = user_id # `_id` genearted by MongoDB automatcially
@@ -92,3 +93,19 @@ class User(UserMixin):
         salt = bcrypt.gensalt()
 
         return bcrypt.hashpw(bytes, salt)
+
+
+    def add_game(self, target_game):
+        """Adds the target game into the user's game list.
+        
+        Args:
+            target_game: the game to add into the user's game list.
+        """
+        user_db = connect_mongodb('users')
+        user_collection = user_db.users
+
+        user_collection.update_one(
+            {'_id': ObjectId(self.user_id)},
+            {'$push': {'game_list': target_game.__dict__}}
+        )
+        self.game_list.append(target_game)

--- a/server/controllers/user_manager.py
+++ b/server/controllers/user_manager.py
@@ -105,7 +105,7 @@ class User(UserMixin):
         user_collection = user_db.users
 
         user_collection.update_one(
-            {'_id': ObjectId(self.user_id)},
-            {'$push': {'game_list': target_game.__dict__}}
+            {'_id': self.user_id},
+            {'$addToSet': {'game_list': target_game.__dict__}}
         )
         self.game_list.append(target_game)

--- a/server/models/game.py
+++ b/server/models/game.py
@@ -41,43 +41,47 @@ class Goals(Enum):
 
 class Game:
     """A class to hold metadata on a game"""
-    def __init__(self, title:str, wikidata =Dict[str, str]):
+    def __init__(self, title:str, game_id:str, aliases: str, wikidata_code: str, is_DLC: int, parent_id: str,
+                 genres: str, developers: str, publishers: str, release_id: str, release_date: datetime,
+                 released: int, platforms: str, **kwargs):
         # Necessary data on the game
         self.title = title
+        self.game_id = game_id
+        self.aliases = aliases.split(', ')
+        self.wikidata_code = wikidata_code
+        self.is_dlc = True if is_DLC else False
+        self.parent_id = parent_id
+        self.genres = genres.split(', ')
+        self.developers = developers.split(', ')
+        self.publishers = publishers.split(', ')
+        self.release_id = release_id
+        self.release_date = release_date.strftime('%Y-%m-%d')
+        self.released = True if released else False
+        self.platforms = platforms.split(', ')
+        # self.regions
 
-        # Data from the user
-        self.purchase_date = None # this is not stored in game_db
+        #self.my_score = 0
 
-        # Data from `Wikidata`
-        self.wikidata_code = ''
-        self.genres = ''
-        self.developers = ''
-        self.publishers = ''
-        self.release_date = None
-        self.released = None
-        self.platforms = ''
-        self.my_score = 0
+        # Data to be filled after playing
+        # self.goals = {}
+        # self.note = ''
+        # self.logo = None
 
-        # Data to be filled after playing # TODO maybe with NoSQL implemented
-        self.goals = {}
-        self.note = ''
-        self.logo = None # but from `Wikidata``
-
-        ## Data from `Metacritics`
-        self.meta_critics_score = 0
-        self.meta_user_score = 0
-        ## Data from `Opencritics`
-        self.open_critics_score = 0
-        self.open_user_score = 0
-
-        # Data from `PSN API`
-        self.pro_enhanced: bool = False
+        ## Data from `PSN API`
+        # self.pro_enhanced = pro_enhanced
+        # ## Data from `Metacritics`
+        # self.meta_critics_score = 0
+        # self.meta_user_score = 0
+        # ## Data from `Opencritics`
+        # self.open_critics_score = 0
+        # self.open_user_score = 0
 
         # Attributes to be updated per user, stored in their DB, not stored in game_db
-        self.purchased = None
-        self.playing = None
-        self.played = None
-        self.status: Status = None
+        # self.purchase_date = None # this is not stored in game_db
+        # self.purchased = None
+        # self.playing = None
+        # self.played = None
+        # self.status: Status = None
 
 
     def update_status(self) -> None:
@@ -110,8 +114,6 @@ class Game:
             print(f'Error occurred while updating Game status : {e}')
     
 
-
-
     def set_game_active(self) ->  None:
         """Set the game currently playing."""
         if self.purchased:
@@ -127,6 +129,7 @@ class Game:
             self.update_status()
 
 
+    # TODO maybe not needed
     def _fill_metadata_from_wikidata(self, wikidata:Dict[str, str]):
         """Fills up the metadata from `Wikidata` """
         try:

--- a/server/models/mongodb.py
+++ b/server/models/mongodb.py
@@ -24,3 +24,4 @@ def connect_mongodb(db_name: Literal['users', 'sessions']):
         return MONGO_CONNECTION.users
     elif db_name == 'sessions':
         return MONGO_CONNECTION.sessions
+    

--- a/server/models/mysqldb.py
+++ b/server/models/mysqldb.py
@@ -17,7 +17,7 @@ game_db_schema_path = os.path.join(os.getcwd(), 'server', 'schemas', 'game_db_sc
 # for Wikidata
 WIKIDATA_SPARQL_URL = "https://query.wikidata.org/sparql"
 
-async def create_db(host: str, port: int, user: str, passwd: str, db_name: str, schema_path: str):
+async def create_mysql_db(host: str, port: int, user: str, passwd: str, db_name: str, schema_path: str):
     """Creates a database from a schema file.
     Args:
         schema_path: the path to .sql file containg the shcema.
@@ -38,11 +38,11 @@ async def create_db(host: str, port: int, user: str, passwd: str, db_name: str, 
         async with db_connection.cursor() as db_cursor:
             await db_cursor.execute(f'CREATE DATABASE {db_name}')
             await db_cursor.execute(f'USE {db_name}')
-            await create_db(local_db_host, local_db_port, local_db_user, local_db_passwd, 'game_db', game_db_schema_path)
+            await create_mysql_db(local_db_host, local_db_port, local_db_user, local_db_passwd, 'game_db', game_db_schema_path)
     except ProgrammingError as e:
         print(f'Error occurred while creating DB: {e}')
     except Exception as e:
-        raise Exception(f'Error occurred in `create_db()`: {e}') from e
+        raise Exception(f'Error occurred in `create_mysql_db()`: {e}') from e
 
 
 async def init_pool(host: str, port: int, user: str, passwd: str):
@@ -52,8 +52,8 @@ async def init_pool(host: str, port: int, user: str, passwd: str):
 
 
 async def init_db(host: str, port: int, user: str, passwd: str, db_name: str, schema_path: str):
-    """Calls `create_db` and `init_pool` in succession."""
-    await create_db(host, port, user, passwd, db_name, schema_path)
+    """Calls `create_mysql_db` and `init_pool` in succession."""
+    await create_mysql_db(host, port, user, passwd, db_name, schema_path)
     pool = await init_pool(host, port, user, passwd)
     return pool
 

--- a/server/schemas/wikidata_properties.json
+++ b/server/schemas/wikidata_properties.json
@@ -26421,6 +26421,10 @@
       ],
     "publishers": [
         {
+          "code": "Q562078",
+          "label": "Nexon"
+        },
+        {
           "code": "Q109342583",
           "label": "Game Science"
         },

--- a/server/views/blog.py
+++ b/server/views/blog.py
@@ -83,3 +83,26 @@ def search_for_games():
     candidates = game_manager.loop.run_until_complete(game_manager.find_candiates(search_keyword))
 
     return jsonify(candidates)
+
+
+@blog.route('/add_game')
+def add_game_into_game_list():
+    """Adds the given game into the user's game list while adding the game into game_db if it's not in game_db."""
+    # TODO Veirfy if the user is authenticated
+    if not current_user.is_authenticated:
+        return
+    
+    # TODO add the target game into the user's game list.
+    game_id = request.args.get('game_id')
+    release_id = request.args.get('release_id')
+    target_game = game_manager.loop.run_until_complete(game_manager.search_game_db_with_id(game_id, release_id))
+    # TODO add loop to the user?
+    current_user.add_game(target_game)
+
+    # TODO add the target game into game_db if it is not there.
+    # if game not in game_db:
+    # Use the wikidata code
+    #   game_manager.add_new_game()
+
+    # TODO what to show to the user after adding the game??
+    # return

--- a/server/views/blog.py
+++ b/server/views/blog.py
@@ -74,7 +74,7 @@ def delete_account():
 
 # Game Search
 
-@blog.route('/search', methods=['GET', 'POST'])
+@blog.route('/search', methods=['GET'])
 def search_for_games():
     """Searchs for the target game with the given keywords."""
     search_keyword = request.args.get('search_keyword')
@@ -88,21 +88,13 @@ def search_for_games():
 @blog.route('/add_game')
 def add_game_into_game_list():
     """Adds the given game into the user's game list while adding the game into game_db if it's not in game_db."""
-    # TODO Veirfy if the user is authenticated
     if not current_user.is_authenticated:
         return
     
-    # TODO add the target game into the user's game list.
     game_id = request.args.get('game_id')
     release_id = request.args.get('release_id')
+
     target_game = game_manager.loop.run_until_complete(game_manager.search_game_db_with_id(game_id, release_id))
-    # TODO add loop to the user?
     current_user.add_game(target_game)
 
-    # TODO add the target game into game_db if it is not there.
-    # if game not in game_db:
-    # Use the wikidata code
-    #   game_manager.add_new_game()
-
-    # TODO what to show to the user after adding the game??
-    # return
+    return redirect(url_for('.load_main_page'))

--- a/utils/admin_tools.py
+++ b/utils/admin_tools.py
@@ -1,5 +1,5 @@
 import asyncio
-from server.models.mysqldb import create_db, init_pool, local_db_host, local_db_passwd, local_db_port, local_db_user, game_db_schema_path, query_db_with_pool
+from server.models.mysqldb import create_mysql_db, init_pool, local_db_host, local_db_passwd, local_db_port, local_db_user, game_db_schema_path, query_db_with_pool
 from server.controllers.game_manager import GameManager
 import os
 import json
@@ -10,7 +10,7 @@ import re
 async def fill_up_game_db():
     """Fills up the game db from Wikidata using a given json file"""
     # Initialize `game_db`
-    await create_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
+    await create_mysql_db(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db', schema_path=game_db_schema_path)
     db_connection_pool = await init_pool(host=local_db_host, port=local_db_port, user=local_db_user, passwd=local_db_passwd, db_name='game_db')
 
     game_list_json_path = os.path.join(os.getcwd(), 'DB', 'All_PlayStation_Games.json')


### PR DESCRIPTION
- dd buttons are generated before each element in the list of the search result
- the search and list display buttons are only available when logged in.
- The old logic where the candidates were searched for separately from `game_db`  and `Wikidata`  separately has been refactored.
    - `game_db`  is checked with the provided keywords.
    - When the target game is not found in `game_db`, it falls into the fallback search with Wikidata, while adding the games found with the search keywords in Wikidata automatically and seamlessly into `game_db`.
    - After the new games are added, `game_db` is searched again with the same keywords.
    - When the add button is pressed, the target game is added into the user’s `game_list` in `MongoDB`.